### PR TITLE
fix(registry): regenerate index checksums

### DIFF
--- a/registry/index.json
+++ b/registry/index.json
@@ -6717,13 +6717,7 @@
           "StructuredData",
           "OpenGraphMeta"
         ],
-        "shared": [
-          "primitives",
-          "icons",
-          "content",
-          "utils",
-          "headless"
-        ],
+        "shared": ["primitives", "icons", "content", "utils", "headless"],
         "patterns": [],
         "components": [
           "Article",
@@ -6990,13 +6984,7 @@
           "RulesSidebar",
           "WikiPage"
         ],
-        "shared": [
-          "primitives",
-          "icons",
-          "content",
-          "utils",
-          "headless"
-        ],
+        "shared": ["primitives", "icons", "content", "utils", "headless"],
         "patterns": [],
         "components": [
           "Community",
@@ -7297,14 +7285,7 @@
           "PremiumBadge",
           "InstitutionalTools"
         ],
-        "shared": [
-          "primitives",
-          "headless",
-          "icons",
-          "tokens",
-          "adapters",
-          "utils"
-        ],
+        "shared": ["primitives", "headless", "icons", "tokens", "adapters", "utils"],
         "patterns": [],
         "components": [
           "Artwork",
@@ -8639,15 +8620,7 @@
       "name": "search",
       "version": "4.0.1",
       "description": "Search components for ActivityPub/Fediverse applications with federated search support",
-      "exports": [
-        "Root",
-        "Bar",
-        "Filters",
-        "Results",
-        "ActorResult",
-        "NoteResult",
-        "TagResult"
-      ],
+      "exports": ["Root", "Bar", "Filters", "Results", "ActorResult", "NoteResult", "TagResult"],
       "files": [
         {
           "path": "src/ActorResult.svelte",


### PR DESCRIPTION
Fixes `greater update --ref 8084acec6b6eaa856fc2fdf09f052b922721ae2f` failures like:
- Checksum mismatch for packages/tokens/src/palette-utils.d.ts
- Checksum mismatch for packages/primitives/src/components/Alert.svelte
- Checksum mismatch for packages/content/src/components/CodeBlock.svelte

Root cause: `registry/index.json` checksums were stale after #85 merge (`pnpm validate:registry` reported 119 mismatches).

Changes:
- Regenerates `registry/index.json` so checksums match the current source tree.
- Formats `registry/index.json` with Prettier.
- Makes `scripts/generate-registry-index.js` write Prettier-formatted JSON.
- Runs `pnpm validate:registry` unconditionally in CI so main stays release-ready.
- Documents release criteria in `docs/devops/github-releases.md`.
