### PR TITLE
ci: adopt premain/main release flow

### DIFF
--- a/.github/workflows/a11y.yml
+++ b/.github/workflows/a11y.yml
@@ -2,9 +2,9 @@ name: Accessibility Testing
 
 on:
   push:
-    branches: [main, develop]
+    branches: [premain, main]
   pull_request:
-    branches: [main, develop]
+    branches: [premain, main]
   schedule:
     # Run accessibility tests daily at 2 AM UTC
     - cron: '0 2 * * *'

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -13,9 +13,9 @@ name: 'CodeQL Advanced'
 
 on:
   push:
-    branches: ['main']
+    branches: ['premain', 'main']
   pull_request:
-    branches: ['main']
+    branches: ['premain', 'main']
   schedule:
     - cron: '44 21 * * 0'
 

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -2,9 +2,9 @@ name: Test Coverage
 
 on:
   push:
-    branches: [main, develop]
+    branches: [premain, main]
   pull_request:
-    branches: [main, develop]
+    branches: [premain, main]
 
 permissions:
   contents: write

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -2,9 +2,9 @@ name: Documentation
 
 on:
   push:
-    branches: [main]
+    branches: [premain, main]
   pull_request:
-    branches: [main]
+    branches: [premain, main]
 
 permissions:
   contents: write

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -2,9 +2,9 @@ name: E2E Tests
 
 on:
   push:
-    branches: [main, develop]
+    branches: [premain, main]
   pull_request:
-    branches: [main, develop]
+    branches: [premain, main]
 
 permissions:
   contents: read

--- a/.github/workflows/generate-registry.yml
+++ b/.github/workflows/generate-registry.yml
@@ -1,9 +1,8 @@
-name: Generate Registry Index
+name: Publish GitHub Release Artifacts
 
 on:
   push:
     tags:
-      - 'v*'
       - 'greater-v*'
   workflow_dispatch:
     inputs:
@@ -41,25 +40,37 @@ jobs:
       - name: Build packages
         run: pnpm build
 
-      - name: Generate registry index
-        run: node scripts/generate-registry-index.js
-
       - name: Validate registry index
         run: node scripts/validate-registry-index.js --strict
 
-      - name: Update latest.json
-        if: startsWith(github.ref, 'refs/tags/greater-v')
+      - name: Validate release metadata
         run: |
           TAG=${GITHUB_REF#refs/tags/}
-          VERSION=${TAG#greater-v}
-          cat > registry/latest.json << EOF
-          {
-            "ref": "$TAG",
-            "version": "$VERSION",
-            "updatedAt": "$(date -u +"%Y-%m-%dT%H:%M:%S.000Z")"
+          node - <<'NODE'
+          const fs = require('node:fs');
+
+          const tag = process.env.TAG;
+          const version = tag.replace(/^greater-v/, '');
+
+          const index = JSON.parse(fs.readFileSync('registry/index.json', 'utf8'));
+          const latest = JSON.parse(fs.readFileSync('registry/latest.json', 'utf8'));
+
+          const failures = [];
+          if (index.version !== version) failures.push(`registry/index.json.version must be ${version}`);
+          if (index.ref !== tag) failures.push(`registry/index.json.ref must be ${tag}`);
+          if (latest.version !== version) failures.push(`registry/latest.json.version must be ${version}`);
+          if (latest.ref !== tag) failures.push(`registry/latest.json.ref must be ${tag}`);
+
+          if (failures.length > 0) {
+            for (const msg of failures) console.error(`::error::${msg}`);
+            process.exit(1);
           }
-          EOF
-          echo "Updated latest.json to point to $TAG"
+          NODE
+        env:
+          TAG: ${{ github.ref_name }}
+
+      - name: Pack release artifacts
+        run: node scripts/pack-for-release.js
 
       - name: Upload registry artifacts
         uses: actions/upload-artifact@v4
@@ -85,15 +96,7 @@ jobs:
           files: |
             registry/index.json
             registry/latest.json
+            artifacts/*
           tag_name: ${{ steps.release.outputs.tag }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Commit registry files
-        if: startsWith(github.ref, 'refs/tags/') && github.event.inputs.dry_run != 'true'
-        run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-          git add registry/index.json registry/latest.json
-          git commit -m "chore: update registry for ${{ steps.release.outputs.tag }}" || echo "No changes to commit"
-          git push origin HEAD:main || echo "Could not push to main"

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -2,9 +2,9 @@ name: Lint
 
 on:
   push:
-    branches: [main, develop]
+    branches: [premain, main]
   pull_request:
-    branches: [main, develop]
+    branches: [premain, main]
 
 permissions:
   contents: read

--- a/.github/workflows/main-guard.yml
+++ b/.github/workflows/main-guard.yml
@@ -1,0 +1,60 @@
+name: Main Branch Guard
+
+on:
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  guard:
+    name: Enforce release-only main
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Require release PR from premain
+        run: |
+          echo "Base: ${{ github.base_ref }}"
+          echo "Head: ${{ github.head_ref }}"
+          if [ "${{ github.head_ref }}" != "premain" ]; then
+            echo "::error::PRs must target premain. main is release-only. Create this PR against premain instead."
+            exit 1
+          fi
+
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      - name: Validate release metadata
+        run: |
+          VERSION="$(node -p "require('./package.json').version")"
+          TAG="greater-v${VERSION}"
+
+          if ! [[ "$VERSION" =~ ^[0-9]+\\.[0-9]+\\.[0-9]+(-[0-9A-Za-z.-]+)?$ ]]; then
+            echo "::error::package.json version is not valid semver: $VERSION"
+            exit 1
+          fi
+
+          node - <<'NODE'
+          const fs = require('node:fs');
+
+          const pkg = JSON.parse(fs.readFileSync('package.json', 'utf8'));
+          const index = JSON.parse(fs.readFileSync('registry/index.json', 'utf8'));
+          const latest = JSON.parse(fs.readFileSync('registry/latest.json', 'utf8'));
+
+          const version = pkg.version;
+          const tag = `greater-v${version}`;
+
+          const failures = [];
+
+          if (latest.version !== version) failures.push(`registry/latest.json.version must match package.json (${version})`);
+          if (latest.ref !== tag) failures.push(`registry/latest.json.ref must be ${tag}`);
+
+          if (index.version !== version) failures.push(`registry/index.json.version must match package.json (${version})`);
+          if (index.ref !== tag) failures.push(`registry/index.json.ref must be ${tag}`);
+
+          if (failures.length > 0) {
+            for (const msg of failures) console.error(`::error::${msg}`);
+            process.exit(1);
+          }
+          NODE

--- a/.github/workflows/tag-release.yml
+++ b/.github/workflows/tag-release.yml
@@ -1,0 +1,55 @@
+name: Tag Release
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch: {}
+
+permissions:
+  contents: write
+
+jobs:
+  tag:
+    name: Create greater-v* tag
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+
+      - name: Resolve version + tag
+        id: meta
+        run: |
+          VERSION="$(node -p "require('./package.json').version")"
+          if ! [[ "$VERSION" =~ ^[0-9]+\\.[0-9]+\\.[0-9]+(-[0-9A-Za-z.-]+)?$ ]]; then
+            echo "::error::package.json version is not valid semver: $VERSION"
+            exit 1
+          fi
+
+          TAG="greater-v${VERSION}"
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "tag=$TAG" >> "$GITHUB_OUTPUT"
+
+      - name: Create annotated tag (if missing)
+        run: |
+          TAG="${{ steps.meta.outputs.tag }}"
+          VERSION="${{ steps.meta.outputs.version }}"
+
+          git fetch --tags --force
+
+          if git rev-parse "$TAG" >/dev/null 2>&1; then
+            TAG_COMMIT="$(git rev-list -n 1 "$TAG")"
+            HEAD_COMMIT="$(git rev-parse HEAD)"
+            if [ "$TAG_COMMIT" != "$HEAD_COMMIT" ]; then
+              echo "::error::Tag $TAG already exists but points to $TAG_COMMIT (expected $HEAD_COMMIT)"
+              exit 1
+            fi
+
+            echo "Tag already exists for this commit: $TAG"
+            exit 0
+          fi
+
+          git tag -a "$TAG" -m "Greater Components release $TAG"
+          git push origin "$TAG"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,9 +2,9 @@ name: Test
 
 on:
   push:
-    branches: [main, develop]
+    branches: [premain, main]
   pull_request:
-    branches: [main, develop]
+    branches: [premain, main]
 
 permissions:
   contents: read

--- a/docs/devops/github-releases.md
+++ b/docs/devops/github-releases.md
@@ -2,6 +2,11 @@
 
 Greater Components distributes the `greater` CLI via GitHub Releases (it is not published to the npm registry).
 
+## Branching Model
+
+- `premain` is the default integration branch; feature PRs should target `premain`.
+- `main` is release-only; the only PR allowed into `main` is `premain → main` for a release cut.
+
 ## Release Definition (Client-Facing)
 
 A **Greater Components release** is a single, immutable reference that clients can pin and upgrade to safely.
@@ -16,13 +21,13 @@ A **Greater Components release** is a single, immutable reference that clients c
 
 ## Creating a Release (Maintainers)
 
-1. Create a repo release tag:
-   - `pnpm release:tag:dry` (preview)
-   - `pnpm release:tag` (creates `greater-vX.Y.Z`)
-2. Build and pack release artifacts:
-   - `node scripts/pack-for-release.js`
-   - Output is written to `artifacts/` and includes `greater-components-cli.tgz`
-3. Create a GitHub Release for the new `greater-vX.Y.Z` tag and upload everything in `artifacts/`.
+1. Prepare the release commit on `premain` (bump version + update registry refs):
+   - `pnpm release:prepare 0.1.0`
+   - Commit and merge to `premain` via PR.
+2. Cut the release by merging `premain → main` via PR.
+3. Tag + artifacts are published automatically:
+   - `Tag Release` creates the `greater-vX.Y.Z` tag from `main`.
+   - `Publish GitHub Release Artifacts` attaches `greater-components-cli.tgz`, `registry/index.json`, and `registry/latest.json`.
 
 ## Installing the CLI (Consumers)
 

--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
     "typecheck": "NODE_OPTIONS='--max-old-space-size=16384' pnpm run sveltekit:sync && NODE_OPTIONS='--max-old-space-size=16384' tsc --noEmit",
     "version": "changeset version && pnpm install --no-frozen-lockfile",
     "analyze:bundles": "node scripts/analyze-bundles.js",
+    "release:prepare": "node scripts/prepare-github-release.js",
     "release:tag": "node scripts/release-tag.js",
     "release:tag:dry": "node scripts/release-tag.js --dry-run"
   },

--- a/scripts/generate-registry-index.js
+++ b/scripts/generate-registry-index.js
@@ -642,6 +642,24 @@ async function main() {
 	const dryRun = args.includes('--dry-run');
 	const validateOnly = args.includes('--validate');
 	const verbose = args.includes('--verbose');
+	const refOverride = (() => {
+		const direct = args.find((arg) => arg.startsWith('--ref='));
+		if (direct) {
+			const value = direct.slice('--ref='.length);
+			return value.length > 0 ? value : undefined;
+		}
+
+		const idx = args.indexOf('--ref');
+		if (idx === -1) return undefined;
+
+		const value = args[idx + 1];
+		if (!value || value.startsWith('--')) {
+			log('❌ Missing value for --ref', colors.red);
+			process.exit(1);
+		}
+
+		return value;
+	})();
 
 	log('\n' + '='.repeat(60), colors.bold);
 	log('📦 Greater Components Registry Index Generator', colors.bold);
@@ -671,7 +689,7 @@ async function main() {
 
 	// Get metadata
 	const version = getVersion();
-	const ref = getGitRef();
+	const ref = refOverride ?? getGitRef();
 	const generatedAt = new Date().toISOString();
 
 	// Get workspace versions

--- a/scripts/prepare-github-release.js
+++ b/scripts/prepare-github-release.js
@@ -1,0 +1,74 @@
+#!/usr/bin/env node
+/**
+ * Prepare a GitHub-only Greater Components release commit.
+ *
+ * - Sets root package.json version
+ * - Updates registry/latest.json to point at `greater-vX.Y.Z`
+ * - Regenerates registry/index.json with ref override (so index.ref is the tag)
+ *
+ * Usage:
+ *   node scripts/prepare-github-release.js 0.1.0
+ */
+
+import { execSync } from 'node:child_process';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const rootDir = path.join(__dirname, '..');
+
+const semverPattern = /^[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?$/;
+
+function die(message) {
+	console.error(message);
+	process.exit(1);
+}
+
+function readJson(filePath) {
+	return JSON.parse(fs.readFileSync(filePath, 'utf8'));
+}
+
+function writeJson(filePath, value) {
+	fs.writeFileSync(filePath, JSON.stringify(value, null, 2) + '\n');
+}
+
+function main() {
+	const args = process.argv.slice(2);
+	const version = args[0];
+
+	if (!version) {
+		die('Usage: node scripts/prepare-github-release.js <version>');
+	}
+
+	if (!semverPattern.test(version)) {
+		die(`Invalid semver version: ${version}`);
+	}
+
+	const tag = `greater-v${version}`;
+
+	const packageJsonPath = path.join(rootDir, 'package.json');
+	const latestPath = path.join(rootDir, 'registry', 'latest.json');
+
+	const pkg = readJson(packageJsonPath);
+	writeJson(packageJsonPath, { ...pkg, version });
+
+	writeJson(latestPath, {
+		ref: tag,
+		version,
+		updatedAt: new Date().toISOString(),
+	});
+
+	execSync(`node scripts/generate-registry-index.js --ref ${tag}`, {
+		cwd: rootDir,
+		stdio: 'inherit',
+	});
+
+	execSync('node scripts/validate-registry-index.js --strict', {
+		cwd: rootDir,
+		stdio: 'inherit',
+	});
+}
+
+main();

--- a/scripts/release-tag.js
+++ b/scripts/release-tag.js
@@ -149,10 +149,10 @@ async function main() {
 	log('\n3️⃣  Regenerating registry/index.json...', colors.blue);
 
 	if (dryRun) {
-		log('   Would run: node scripts/generate-registry-index.js', colors.yellow);
+		log(`   Would run: node scripts/generate-registry-index.js --ref ${tagName}`, colors.yellow);
 	} else {
 		try {
-			exec('node scripts/generate-registry-index.js');
+			exec(`node scripts/generate-registry-index.js --ref ${tagName}`);
 			log('✅ Registry index regenerated', colors.green);
 		} catch (error) {
 			log('❌ Registry index generation failed', colors.red);


### PR DESCRIPTION
Establishes the new GitHub-only SemVer release flow:

- Creates premain as the default integration branch (PRs land here).
- Keeps main as release-only (guarded by CI + branch protection).
- Adds automated tagging (greater-vX.Y.Z) on main pushes.
- Publishes GitHub Release artifacts on greater-v* tag pushes.

Includes:
- Workflow trigger updates for premain/main
- Main Branch Guard workflow
- Tag Release workflow
- Updated Publish GitHub Release Artifacts workflow
- pnpm release:prepare helper script
