### PR TITLE
fix(ci): release guard semver regex

### DIFF
--- a/.github/workflows/main-guard.yml
+++ b/.github/workflows/main-guard.yml
@@ -30,7 +30,7 @@ jobs:
           VERSION="$(node -p "require('./package.json').version")"
           TAG="greater-v${VERSION}"
 
-          if ! [[ "$VERSION" =~ ^[0-9]+\\.[0-9]+\\.[0-9]+(-[0-9A-Za-z.-]+)?$ ]]; then
+          if ! [[ "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?$ ]]; then
             echo "::error::package.json version is not valid semver: $VERSION"
             exit 1
           fi

--- a/.github/workflows/tag-release.yml
+++ b/.github/workflows/tag-release.yml
@@ -23,7 +23,7 @@ jobs:
         id: meta
         run: |
           VERSION="$(node -p "require('./package.json').version")"
-          if ! [[ "$VERSION" =~ ^[0-9]+\\.[0-9]+\\.[0-9]+(-[0-9A-Za-z.-]+)?$ ]]; then
+          if ! [[ "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?$ ]]; then
             echo "::error::package.json version is not valid semver: $VERSION"
             exit 1
           fi

--- a/registry/index.json
+++ b/registry/index.json
@@ -7017,14 +7017,7 @@
           "PremiumBadge",
           "InstitutionalTools"
         ],
-        "shared": [
-          "primitives",
-          "headless",
-          "icons",
-          "tokens",
-          "adapters",
-          "utils"
-        ],
+        "shared": ["primitives", "headless", "icons", "tokens", "adapters", "utils"],
         "patterns": [],
         "components": [
           "Artwork",
@@ -8266,15 +8259,7 @@
       "name": "search",
       "version": "4.0.1",
       "description": "Search components for ActivityPub/Fediverse applications with federated search support",
-      "exports": [
-        "Root",
-        "Bar",
-        "Filters",
-        "Results",
-        "ActorResult",
-        "NoteResult",
-        "TagResult"
-      ],
+      "exports": ["Root", "Bar", "Filters", "Results", "ActorResult", "NoteResult", "TagResult"],
       "files": [
         {
           "path": "src/ActorResult.svelte",


### PR DESCRIPTION
Fixes main-guard/tag-release semver regex (was over-escaped and rejected 0.1.0) and formats registry/index.json so lint/format passes.