### PR TITLE
fix(ci): git identity for tag release

### DIFF
--- a/.github/workflows/tag-release.yml
+++ b/.github/workflows/tag-release.yml
@@ -19,6 +19,11 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Configure Git identity
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
       - name: Resolve version + tag
         id: meta
         run: |


### PR DESCRIPTION
Fixes Tag Release workflow failing with "Committer identity unknown" when creating annotated tags (git user.name/email not configured on runners).