### PR TITLE
chore(release): greater-v0.1.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "greater-components",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "private": true,
   "description": "Fediverse UI components built with Svelte 5, TypeScript, and pnpm workspaces",
   "repository": {

--- a/registry/index.json
+++ b/registry/index.json
@@ -1,9 +1,9 @@
 {
   "$schema": "https://equalto.ai/schemas/registry-index.schema.json",
   "schemaVersion": "1.0.0",
-  "generatedAt": "2026-01-07T03:54:51.204Z",
-  "ref": "d8372fa974df",
-  "version": "0.1.0",
+  "generatedAt": "2026-01-09T16:02:31.950Z",
+  "ref": "greater-v0.1.1",
+  "version": "0.1.1",
   "checksums": {
     "packages/primitives/src/assets/greater-default-profile.png": "sha256-fiYnr2MUUA1ZEBJHvY1Ppn00rF9WSgA8IAxwb0umSeU=",
     "packages/primitives/src/assets.d.ts": "sha256-mcuvYSPf1CA84g8LB5UTkxkmJIqwt8oxWdhiebocyfI=",
@@ -7027,7 +7027,14 @@
           "PremiumBadge",
           "InstitutionalTools"
         ],
-        "shared": ["primitives", "headless", "icons", "tokens", "adapters", "utils"],
+        "shared": [
+          "primitives",
+          "headless",
+          "icons",
+          "tokens",
+          "adapters",
+          "utils"
+        ],
         "patterns": [],
         "components": [
           "Artwork",
@@ -8269,7 +8276,15 @@
       "name": "search",
       "version": "4.0.1",
       "description": "Search components for ActivityPub/Fediverse applications with federated search support",
-      "exports": ["Root", "Bar", "Filters", "Results", "ActorResult", "NoteResult", "TagResult"],
+      "exports": [
+        "Root",
+        "Bar",
+        "Filters",
+        "Results",
+        "ActorResult",
+        "NoteResult",
+        "TagResult"
+      ],
       "files": [
         {
           "path": "src/ActorResult.svelte",

--- a/registry/latest.json
+++ b/registry/latest.json
@@ -1,5 +1,5 @@
 {
-  "ref": "greater-v0.1.0",
-  "version": "0.1.0",
-  "updatedAt": "2026-01-06T23:05:30.000Z"
+  "ref": "greater-v0.1.1",
+  "version": "0.1.1",
+  "updatedAt": "2026-01-09T16:02:31.926Z"
 }


### PR DESCRIPTION
Prepares greater-v0.1.1 release metadata (GitHub-only).

This PR is safe to merge immediately. It updates:
- root version (package.json)
- registry/latest.json (ref/version)
- registry/index.json (ref/version/checksums)