### PR TITLE
ci(release): release-please should include chore commits

### DIFF
--- a/.changeset/release-please-include-chore.md
+++ b/.changeset/release-please-include-chore.md
@@ -1,0 +1,5 @@
+---
+'greater-components': patch
+---
+
+Ensure release-please opens RC/stable release PRs even when the changes are `chore:` commits (for example dependency updates).

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -4,6 +4,18 @@
   "include-component-in-tag": true,
   "include-v-in-tag": true,
   "tag-separator": "-",
+  "changelog-sections": [
+    { "type": "feat", "section": "Features" },
+    { "type": "fix", "section": "Bug Fixes" },
+    { "type": "perf", "section": "Performance" },
+    { "type": "refactor", "section": "Refactors" },
+    { "type": "revert", "section": "Reverts" },
+    { "type": "docs", "section": "Docs" },
+    { "type": "build", "section": "Build" },
+    { "type": "ci", "section": "CI" },
+    { "type": "test", "section": "Tests" },
+    { "type": "chore", "section": "Chores" }
+  ],
   "draft": true,
   "packages": {
     ".": {}

--- a/release-please-config.premain.json
+++ b/release-please-config.premain.json
@@ -4,6 +4,18 @@
   "include-component-in-tag": true,
   "include-v-in-tag": true,
   "tag-separator": "-",
+  "changelog-sections": [
+    { "type": "feat", "section": "Features" },
+    { "type": "fix", "section": "Bug Fixes" },
+    { "type": "perf", "section": "Performance" },
+    { "type": "refactor", "section": "Refactors" },
+    { "type": "revert", "section": "Reverts" },
+    { "type": "docs", "section": "Docs" },
+    { "type": "build", "section": "Build" },
+    { "type": "ci", "section": "CI" },
+    { "type": "test", "section": "Tests" },
+    { "type": "chore", "section": "Chores" }
+  ],
   "draft": true,
   "versioning": "prerelease",
   "prerelease-type": "rc",


### PR DESCRIPTION
Release candidates were not being created on `premain` because release-please skipped when only `chore:` commits were present.

Evidence: `Prerelease PR (premain)` run 21657239637 ended with “No user facing commits found … - skipping”.

This PR updates `release-please-config.json` + `release-please-config.premain.json` to include `chore` (and other non-`feat`/`fix` types) as visible changelog sections, so dependency updates and release tooling changes still produce RC/stable release PRs.

Includes required changeset for `staging`.

After merging this PR to `staging`, promote `staging → premain` again; the `Prerelease PR (premain)` workflow should then open a release-please PR for the current baseline (expected `0.1.2-rc.*`).}