### PR TITLE
chore: promote staging to premain (RC)

### DIFF
--- a/.changeset/release-please-include-chore.md
+++ b/.changeset/release-please-include-chore.md
@@ -1,0 +1,5 @@
+---
+'greater-components': patch
+---
+
+Ensure release-please opens RC/stable release PRs even when the changes are `chore:` commits (for example dependency updates).

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -4,6 +4,18 @@
   "include-component-in-tag": true,
   "include-v-in-tag": true,
   "tag-separator": "-",
+  "changelog-sections": [
+    { "type": "feat", "section": "Features" },
+    { "type": "fix", "section": "Bug Fixes" },
+    { "type": "perf", "section": "Performance" },
+    { "type": "refactor", "section": "Refactors" },
+    { "type": "revert", "section": "Reverts" },
+    { "type": "docs", "section": "Docs" },
+    { "type": "build", "section": "Build" },
+    { "type": "ci", "section": "CI" },
+    { "type": "test", "section": "Tests" },
+    { "type": "chore", "section": "Chores" }
+  ],
   "draft": true,
   "packages": {
     ".": {}

--- a/release-please-config.premain.json
+++ b/release-please-config.premain.json
@@ -4,6 +4,18 @@
   "include-component-in-tag": true,
   "include-v-in-tag": true,
   "tag-separator": "-",
+  "changelog-sections": [
+    { "type": "feat", "section": "Features" },
+    { "type": "fix", "section": "Bug Fixes" },
+    { "type": "perf", "section": "Performance" },
+    { "type": "refactor", "section": "Refactors" },
+    { "type": "revert", "section": "Reverts" },
+    { "type": "docs", "section": "Docs" },
+    { "type": "build", "section": "Build" },
+    { "type": "ci", "section": "CI" },
+    { "type": "test", "section": "Tests" },
+    { "type": "chore", "section": "Chores" }
+  ],
   "draft": true,
   "versioning": "prerelease",
   "prerelease-type": "rc",


### PR DESCRIPTION
Promote `staging` into `premain` to cut a new Release Candidate for integration testing.

After merge, GitHub Actions should open a prerelease PR into `premain` from `release-please--branches--premain--components--greater`.