### PR TITLE
chore(premain): prepare release metadata for 0.1.2-rc

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,21 +14,19 @@ Package/library changelogs live in `packages/*/CHANGELOG.md` (for example `packa
 
 ## [0.1.2-rc](https://github.com/equaltoai/greater-components/compare/greater-v0.1.1...greater-v0.1.2-rc) (2026-02-04)
 
-
 ### CI
 
-* **release:** release-please should include chore commits ([7d450f8](https://github.com/equaltoai/greater-components/commit/7d450f850c189a7da50099dbad7e558da265e9c4))
-* **release:** treat chore commits as user-facing ([5a3b5e0](https://github.com/equaltoai/greater-components/commit/5a3b5e0b9654be1960c0551a46b09f738afff1f1))
-
+- **release:** release-please should include chore commits ([7d450f8](https://github.com/equaltoai/greater-components/commit/7d450f850c189a7da50099dbad7e558da265e9c4))
+- **release:** treat chore commits as user-facing ([5a3b5e0](https://github.com/equaltoai/greater-components/commit/5a3b5e0b9654be1960c0551a46b09f738afff1f1))
 
 ### Chores
 
-* align versions and automate releases ([d0d449b](https://github.com/equaltoai/greater-components/commit/d0d449bb72358549815e8e42851267ace75a4a6a))
-* align versions and automate releases ([6c9496f](https://github.com/equaltoai/greater-components/commit/6c9496f3d7efa4902f604b9aacf5cf3b112c539f))
-* **deps:** Bump the dependencies group across 1 directory with 26 updates ([9092ec8](https://github.com/equaltoai/greater-components/commit/9092ec8c2a805d73a94d81d0e4eadeed59000a90))
-* **deps:** update to latest stable ([8accdbf](https://github.com/equaltoai/greater-components/commit/8accdbfde97c9473cb0454dcc42bc217db9ea484))
-* **deps:** update to latest stable ([863e1e2](https://github.com/equaltoai/greater-components/commit/863e1e277e5f0be1db7a9cf24850e33dc8e3ff42))
-* promote staging to premain (RC) ([e910da0](https://github.com/equaltoai/greater-components/commit/e910da0b5a9d72995574a7d9ddbcb694fa2cb8b8))
+- align versions and automate releases ([d0d449b](https://github.com/equaltoai/greater-components/commit/d0d449bb72358549815e8e42851267ace75a4a6a))
+- align versions and automate releases ([6c9496f](https://github.com/equaltoai/greater-components/commit/6c9496f3d7efa4902f604b9aacf5cf3b112c539f))
+- **deps:** Bump the dependencies group across 1 directory with 26 updates ([9092ec8](https://github.com/equaltoai/greater-components/commit/9092ec8c2a805d73a94d81d0e4eadeed59000a90))
+- **deps:** update to latest stable ([8accdbf](https://github.com/equaltoai/greater-components/commit/8accdbfde97c9473cb0454dcc42bc217db9ea484))
+- **deps:** update to latest stable ([863e1e2](https://github.com/equaltoai/greater-components/commit/863e1e277e5f0be1db7a9cf24850e33dc8e3ff42))
+- promote staging to premain (RC) ([e910da0](https://github.com/equaltoai/greater-components/commit/e910da0b5a9d72995574a7d9ddbcb694fa2cb8b8))
 
 ## [0.1.1] - 2026-01-09
 

--- a/packages/adapters/package.json
+++ b/packages/adapters/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@equaltoai/greater-components-adapters",
   "private": true,
-  "version": "0.1.1",
+  "version": "0.1.2-rc",
   "type": "module",
   "description": "Transport adapters and state management for Greater Components",
   "license": "AGPL-3.0-only",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@equaltoai/greater-components-cli",
   "private": true,
-  "version": "0.1.1",
+  "version": "0.1.2-rc",
   "description": "CLI for adding Greater Components to your project",
   "type": "module",
   "bin": {

--- a/packages/content/package.json
+++ b/packages/content/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@equaltoai/greater-components-content",
-  "version": "0.1.1",
+  "version": "0.1.2-rc",
   "type": "module",
   "description": "Content rendering components (CodeBlock, MarkdownRenderer) for Greater Components",
   "license": "AGPL-3.0-only",

--- a/packages/faces/artist/manifest.json
+++ b/packages/faces/artist/manifest.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../../../schemas/module-manifest.schema.json",
   "name": "@equaltoai/greater-components-artist",
-  "version": "0.1.1",
+  "version": "0.1.2-rc",
   "description": "Artist portfolio and gallery UI components for visual artists and creative professionals",
   "components": {
     "Artwork": {

--- a/packages/faces/artist/package.json
+++ b/packages/faces/artist/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@equaltoai/greater-components-artist",
   "private": true,
-  "version": "0.1.1",
+  "version": "0.1.2-rc",
   "type": "module",
   "description": "Artist portfolio and gallery UI components for Greater Components",
   "license": "AGPL-3.0-only",

--- a/packages/faces/blog/manifest.json
+++ b/packages/faces/blog/manifest.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../../../schemas/module-manifest.schema.json",
   "name": "@equaltoai/greater-components-blog",
-  "version": "0.1.1",
+  "version": "0.1.2-rc",
   "description": "Blog/Medium-style UI components for long-form publishing applications",
   "components": {
     "Article": {

--- a/packages/faces/blog/package.json
+++ b/packages/faces/blog/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@equaltoai/greater-components-blog",
   "private": true,
-  "version": "0.1.1",
+  "version": "0.1.2-rc",
   "type": "module",
   "description": "Blog/Medium-style UI components for Greater Components",
   "license": "AGPL-3.0-only",

--- a/packages/faces/community/manifest.json
+++ b/packages/faces/community/manifest.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../../../schemas/module-manifest.schema.json",
   "name": "@equaltoai/greater-components-community",
-  "version": "0.1.1",
+  "version": "0.1.2-rc",
   "description": "Community/Reddit-style UI components for forum-based discussion applications",
   "components": {
     "Community": {

--- a/packages/faces/community/package.json
+++ b/packages/faces/community/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@equaltoai/greater-components-community",
   "private": true,
-  "version": "0.1.1",
+  "version": "0.1.2-rc",
   "type": "module",
   "description": "Community/Reddit-style UI components for Greater Components",
   "license": "AGPL-3.0-only",

--- a/packages/faces/social/manifest.json
+++ b/packages/faces/social/manifest.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../../../schemas/module-manifest.schema.json",
   "name": "@equaltoai/greater-components-social",
-  "version": "0.1.1",
+  "version": "0.1.2-rc",
   "description": "Social/Twitter-style UI components for ActivityPub/Fediverse applications",
   "components": {
     "Status": {

--- a/packages/faces/social/package.json
+++ b/packages/faces/social/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@equaltoai/greater-components-social",
   "private": true,
-  "version": "0.1.1",
+  "version": "0.1.2-rc",
   "type": "module",
   "description": "Social/Twitter-style UI components for Greater Components (formerly fediverse)",
   "license": "AGPL-3.0-only",

--- a/packages/greater-components/package.json
+++ b/packages/greater-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@equaltoai/greater-components",
-  "version": "0.1.1",
+  "version": "0.1.2-rc",
   "type": "module",
   "description": "Aggregate Greater Components library for EqualToAI",
   "license": "AGPL-3.0-only",

--- a/packages/headless/package.json
+++ b/packages/headless/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@equaltoai/greater-components-headless",
   "private": true,
-  "version": "0.1.1",
+  "version": "0.1.2-rc",
   "type": "module",
   "description": "Headless UI primitives for Greater Components - behavior without styling",
   "license": "AGPL-3.0-only",

--- a/packages/icons/package.json
+++ b/packages/icons/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@equaltoai/greater-components-icons",
   "private": true,
-  "version": "0.1.1",
+  "version": "0.1.2-rc",
   "type": "module",
   "description": "Icon components for Greater Components",
   "license": "AGPL-3.0-only",

--- a/packages/primitives/package.json
+++ b/packages/primitives/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@equaltoai/greater-components-primitives",
-  "version": "0.1.1",
+  "version": "0.1.2-rc",
   "type": "module",
   "description": "Primitive UI components for Greater Components",
   "license": "AGPL-3.0-only",

--- a/packages/shared/admin/manifest.json
+++ b/packages/shared/admin/manifest.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../../../schemas/module-manifest.schema.json",
   "name": "@equaltoai/greater-components-admin",
-  "version": "0.1.1",
+  "version": "0.1.2-rc",
   "description": "Admin dashboard components for ActivityPub instance management",
   "components": {
     "Root": {

--- a/packages/shared/admin/package.json
+++ b/packages/shared/admin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@equaltoai/greater-components-admin",
-  "version": "0.1.1",
+  "version": "0.1.2-rc",
   "type": "module",
   "description": "Admin dashboard components for Greater Components",
   "license": "AGPL-3.0-only",

--- a/packages/shared/auth/manifest.json
+++ b/packages/shared/auth/manifest.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../../../schemas/module-manifest.schema.json",
   "name": "@equaltoai/greater-components-auth",
-  "version": "0.1.1",
+  "version": "0.1.2-rc",
   "description": "Authentication components for ActivityPub/Fediverse applications",
   "components": {
     "Root": {

--- a/packages/shared/auth/package.json
+++ b/packages/shared/auth/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@equaltoai/greater-components-auth",
-  "version": "0.1.1",
+  "version": "0.1.2-rc",
   "type": "module",
   "description": "Authentication components for Greater Components",
   "license": "AGPL-3.0-only",

--- a/packages/shared/chat/manifest.json
+++ b/packages/shared/chat/manifest.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../../../schemas/module-manifest.schema.json",
   "name": "@equaltoai/greater-components-chat",
-  "version": "0.1.1",
+  "version": "0.1.2-rc",
   "description": "AI chat interface components with streaming responses, tool calls, and settings",
   "components": {
     "Container": {

--- a/packages/shared/chat/package.json
+++ b/packages/shared/chat/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@equaltoai/greater-components-chat",
-  "version": "0.1.1",
+  "version": "0.1.2-rc",
   "type": "module",
   "description": "AI chat interface components for Greater Components",
   "license": "AGPL-3.0-only",

--- a/packages/shared/compose/manifest.json
+++ b/packages/shared/compose/manifest.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../../../schemas/module-manifest.schema.json",
   "name": "@equaltoai/greater-components-compose",
-  "version": "0.1.1",
+  "version": "0.1.2-rc",
   "description": "Post/content composer components for ActivityPub/Fediverse applications",
   "components": {
     "Root": {

--- a/packages/shared/compose/package.json
+++ b/packages/shared/compose/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@equaltoai/greater-components-compose",
-  "version": "0.1.1",
+  "version": "0.1.2-rc",
   "type": "module",
   "description": "Post/content composer components for Greater Components",
   "license": "AGPL-3.0-only",

--- a/packages/shared/messaging/manifest.json
+++ b/packages/shared/messaging/manifest.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../../../schemas/module-manifest.schema.json",
   "name": "@equaltoai/greater-components-messaging",
-  "version": "0.1.1",
+  "version": "0.1.2-rc",
   "description": "Direct messaging components for ActivityPub/Fediverse applications",
   "components": {
     "Root": {

--- a/packages/shared/messaging/package.json
+++ b/packages/shared/messaging/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@equaltoai/greater-components-messaging",
-  "version": "0.1.1",
+  "version": "0.1.2-rc",
   "type": "module",
   "description": "Direct messaging components for Greater Components",
   "license": "AGPL-3.0-only",

--- a/packages/shared/notifications/manifest.json
+++ b/packages/shared/notifications/manifest.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../../../schemas/module-manifest.schema.json",
   "name": "@equaltoai/greater-components-notifications",
-  "version": "0.1.1",
+  "version": "0.1.2-rc",
   "description": "Notification components for ActivityPub/Fediverse applications",
   "components": {
     "Root": {

--- a/packages/shared/notifications/package.json
+++ b/packages/shared/notifications/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@equaltoai/greater-components-notifications",
-  "version": "0.1.1",
+  "version": "0.1.2-rc",
   "type": "module",
   "description": "Notification components for Greater Components",
   "license": "AGPL-3.0-only",

--- a/packages/shared/search/manifest.json
+++ b/packages/shared/search/manifest.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../../../schemas/module-manifest.schema.json",
   "name": "@equaltoai/greater-components-search",
-  "version": "0.1.1",
+  "version": "0.1.2-rc",
   "description": "Search components for ActivityPub/Fediverse applications with federated search support",
   "components": {
     "Root": {

--- a/packages/shared/search/package.json
+++ b/packages/shared/search/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@equaltoai/greater-components-search",
-  "version": "0.1.1",
+  "version": "0.1.2-rc",
   "type": "module",
   "description": "Search components for Greater Components",
   "license": "AGPL-3.0-only",

--- a/packages/testing/package.json
+++ b/packages/testing/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@equaltoai/greater-components-testing",
   "private": true,
-  "version": "0.1.1",
+  "version": "0.1.2-rc",
   "type": "module",
   "description": "Shared testing utilities for accessibility, keyboard navigation, and visual regression testing",
   "license": "AGPL-3.0-only",

--- a/packages/tokens/package.json
+++ b/packages/tokens/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@equaltoai/greater-components-tokens",
   "private": true,
-  "version": "0.1.1",
+  "version": "0.1.2-rc",
   "type": "module",
   "description": "Design tokens for Greater Components",
   "license": "AGPL-3.0-only",

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@equaltoai/greater-components-utils",
   "private": true,
-  "version": "0.1.1",
+  "version": "0.1.2-rc",
   "type": "module",
   "description": "Utility functions for Greater Components",
   "license": "AGPL-3.0-only",

--- a/registry/index.json
+++ b/registry/index.json
@@ -1,9 +1,9 @@
 {
   "$schema": "https://equalto.ai/schemas/registry-index.schema.json",
   "schemaVersion": "1.0.0",
-  "generatedAt": "2026-02-04T01:25:46.674Z",
-  "ref": "greater-v0.1.1",
-  "version": "0.1.1",
+  "generatedAt": "2026-02-04T04:58:24.787Z",
+  "ref": "greater-v0.1.2-rc",
+  "version": "0.1.2-rc",
   "checksums": {
     "packages/primitives/src/assets/greater-default-profile.png": "sha256-fiYnr2MUUA1ZEBJHvY1Ppn00rF9WSgA8IAxwb0umSeU=",
     "packages/primitives/src/assets.d.ts": "sha256-mcuvYSPf1CA84g8LB5UTkxkmJIqwt8oxWdhiebocyfI=",
@@ -1334,7 +1334,7 @@
   "components": {
     "primitives": {
       "name": "primitives",
-      "version": "0.1.1",
+      "version": "0.1.2-rc",
       "description": "Primitive UI components for Greater Components",
       "type": "primitives",
       "files": [
@@ -1965,21 +1965,21 @@
         }
       ],
       "dependencies": [
-        { "name": "icons", "version": "0.1.1" },
-        { "name": "tokens", "version": "0.1.1" },
-        { "name": "utils", "version": "0.1.1" }
+        { "name": "icons", "version": "0.1.2-rc" },
+        { "name": "tokens", "version": "0.1.2-rc" },
+        { "name": "utils", "version": "0.1.2-rc" }
       ],
       "peerDependencies": [
-        { "name": "@equaltoai/greater-components-icons", "version": "0.1.1" },
-        { "name": "@equaltoai/greater-components-utils", "version": "0.1.1" },
-        { "name": "@equaltoai/greater-components-tokens", "version": "0.1.1" },
-        { "name": "svelte", "version": "^5.46.1" }
+        { "name": "@equaltoai/greater-components-icons", "version": "0.1.2-rc" },
+        { "name": "@equaltoai/greater-components-utils", "version": "0.1.2-rc" },
+        { "name": "@equaltoai/greater-components-tokens", "version": "0.1.2-rc" },
+        { "name": "svelte", "version": "^5.49.1" }
       ],
       "tags": []
     },
     "headless": {
       "name": "headless",
-      "version": "0.1.1",
+      "version": "0.1.2-rc",
       "description": "Headless UI primitives for Greater Components - behavior without styling",
       "type": "primitives",
       "files": [
@@ -2116,15 +2116,15 @@
       ],
       "dependencies": [],
       "peerDependencies": [
-        { "name": "focus-trap", "version": "^7.7.1" },
+        { "name": "focus-trap", "version": "^8.0.0" },
         { "name": "tabbable", "version": "^6.4.0" },
-        { "name": "svelte", "version": "^5.46.1" }
+        { "name": "svelte", "version": "^5.49.1" }
       ],
       "tags": []
     },
     "icons": {
       "name": "icons",
-      "version": "0.1.1",
+      "version": "0.1.2-rc",
       "description": "Icon components for Greater Components",
       "type": "primitives",
       "files": [
@@ -5180,12 +5180,12 @@
         }
       ],
       "dependencies": [],
-      "peerDependencies": [{ "name": "svelte", "version": "^5.46.1" }],
+      "peerDependencies": [{ "name": "svelte", "version": "^5.49.1" }],
       "tags": []
     },
     "tokens": {
       "name": "tokens",
-      "version": "0.1.1",
+      "version": "0.1.2-rc",
       "description": "Design tokens for Greater Components",
       "type": "utilities",
       "files": [
@@ -5256,7 +5256,7 @@
     },
     "utils": {
       "name": "utils",
-      "version": "0.1.1",
+      "version": "0.1.2-rc",
       "description": "Utility functions for Greater Components",
       "type": "utilities",
       "files": [
@@ -5447,7 +5447,7 @@
     },
     "adapters": {
       "name": "adapters",
-      "version": "0.1.1",
+      "version": "0.1.2-rc",
       "description": "Transport adapters and state management for Greater Components",
       "type": "adapters",
       "files": [
@@ -5799,18 +5799,18 @@
       ],
       "dependencies": [],
       "peerDependencies": [
-        { "name": "@apollo/client", "version": "^4.0.11" },
-        { "name": "@apollo/client-react-streaming", "version": "^0.14.3" },
+        { "name": "@apollo/client", "version": "^4.1.3" },
+        { "name": "@apollo/client-react-streaming", "version": "^0.14.4" },
         { "name": "@graphql-typed-document-node/core", "version": "^3.2.0" },
         { "name": "graphql", "version": "^16.12.0" },
-        { "name": "graphql-ws", "version": "^6.0.6" },
+        { "name": "graphql-ws", "version": "^6.0.7" },
         { "name": "svelte", "version": "^5.43.6" }
       ],
       "tags": []
     },
     "content": {
       "name": "content",
-      "version": "0.1.1",
+      "version": "0.1.2-rc",
       "description": "Content rendering components (CodeBlock, MarkdownRenderer) for Greater Components",
       "type": "utilities",
       "files": [
@@ -5830,7 +5830,7 @@
           "size": 1119
         }
       ],
-      "dependencies": [{ "name": "primitives", "version": "0.1.1" }],
+      "dependencies": [{ "name": "primitives", "version": "0.1.2-rc" }],
       "peerDependencies": [
         { "name": "hast-util-sanitize", "version": "^5.0.2" },
         { "name": "rehype-sanitize", "version": "^6.0.0" },
@@ -5838,11 +5838,11 @@
         { "name": "remark-gfm", "version": "^4.0.1" },
         { "name": "remark-parse", "version": "^11.0.0" },
         { "name": "remark-rehype", "version": "^11.1.2" },
-        { "name": "shiki", "version": "^3.20.0" },
+        { "name": "shiki", "version": "^3.22.0" },
         { "name": "unified", "version": "^11.0.5" },
-        { "name": "@equaltoai/greater-components-primitives", "version": "0.1.1" },
-        { "name": "@equaltoai/greater-components-tokens", "version": "0.1.1" },
-        { "name": "svelte", "version": "^5.46.1" }
+        { "name": "@equaltoai/greater-components-primitives", "version": "0.1.2-rc" },
+        { "name": "@equaltoai/greater-components-tokens", "version": "0.1.2-rc" },
+        { "name": "svelte", "version": "^5.49.1" }
       ],
       "tags": []
     }
@@ -5850,7 +5850,7 @@
   "faces": {
     "social": {
       "name": "social",
-      "version": "0.1.1",
+      "version": "0.1.2-rc",
       "description": "Social/Twitter-style UI components for ActivityPub/Fediverse applications",
       "includes": {
         "primitives": [
@@ -6472,40 +6472,40 @@
       },
       "dependencies": [
         { "name": "@equaltoai/greater-components", "version": "latest" },
-        { "name": "adapters", "version": "0.1.1" },
-        { "name": "admin", "version": "0.1.1" },
-        { "name": "auth", "version": "0.1.1" },
-        { "name": "compose", "version": "0.1.1" },
-        { "name": "headless", "version": "0.1.1" },
-        { "name": "icons", "version": "0.1.1" },
-        { "name": "messaging", "version": "0.1.1" },
-        { "name": "notifications", "version": "0.1.1" },
-        { "name": "primitives", "version": "0.1.1" },
-        { "name": "search", "version": "0.1.1" },
-        { "name": "tokens", "version": "0.1.1" },
-        { "name": "utils", "version": "0.1.1" }
+        { "name": "adapters", "version": "0.1.2-rc" },
+        { "name": "admin", "version": "0.1.2-rc" },
+        { "name": "auth", "version": "0.1.2-rc" },
+        { "name": "compose", "version": "0.1.2-rc" },
+        { "name": "headless", "version": "0.1.2-rc" },
+        { "name": "icons", "version": "0.1.2-rc" },
+        { "name": "messaging", "version": "0.1.2-rc" },
+        { "name": "notifications", "version": "0.1.2-rc" },
+        { "name": "primitives", "version": "0.1.2-rc" },
+        { "name": "search", "version": "0.1.2-rc" },
+        { "name": "tokens", "version": "0.1.2-rc" },
+        { "name": "utils", "version": "0.1.2-rc" }
       ],
       "peerDependencies": [
-        { "name": "@equaltoai/greater-components-adapters", "version": "0.1.1" },
-        { "name": "@equaltoai/greater-components-admin", "version": "0.1.1" },
-        { "name": "@equaltoai/greater-components-auth", "version": "0.1.1" },
-        { "name": "@equaltoai/greater-components-compose", "version": "0.1.1" },
-        { "name": "@equaltoai/greater-components-headless", "version": "0.1.1" },
-        { "name": "@equaltoai/greater-components-icons", "version": "0.1.1" },
-        { "name": "@equaltoai/greater-components-messaging", "version": "0.1.1" },
-        { "name": "@equaltoai/greater-components-notifications", "version": "0.1.1" },
-        { "name": "@equaltoai/greater-components-primitives", "version": "0.1.1" },
-        { "name": "@equaltoai/greater-components-search", "version": "0.1.1" },
-        { "name": "@equaltoai/greater-components-tokens", "version": "0.1.1" },
-        { "name": "@equaltoai/greater-components-utils", "version": "0.1.1" },
+        { "name": "@equaltoai/greater-components-adapters", "version": "0.1.2-rc" },
+        { "name": "@equaltoai/greater-components-admin", "version": "0.1.2-rc" },
+        { "name": "@equaltoai/greater-components-auth", "version": "0.1.2-rc" },
+        { "name": "@equaltoai/greater-components-compose", "version": "0.1.2-rc" },
+        { "name": "@equaltoai/greater-components-headless", "version": "0.1.2-rc" },
+        { "name": "@equaltoai/greater-components-icons", "version": "0.1.2-rc" },
+        { "name": "@equaltoai/greater-components-messaging", "version": "0.1.2-rc" },
+        { "name": "@equaltoai/greater-components-notifications", "version": "0.1.2-rc" },
+        { "name": "@equaltoai/greater-components-primitives", "version": "0.1.2-rc" },
+        { "name": "@equaltoai/greater-components-search", "version": "0.1.2-rc" },
+        { "name": "@equaltoai/greater-components-tokens", "version": "0.1.2-rc" },
+        { "name": "@equaltoai/greater-components-utils", "version": "0.1.2-rc" },
         { "name": "@graphql-typed-document-node/core", "version": "^3.2.0" },
-        { "name": "@tanstack/svelte-virtual", "version": "^3.13.17" },
-        { "name": "svelte", "version": "^5.46.1" }
+        { "name": "@tanstack/svelte-virtual", "version": "^3.13.18" },
+        { "name": "svelte", "version": "^5.49.1" }
       ]
     },
     "blog": {
       "name": "blog",
-      "version": "0.1.1",
+      "version": "0.1.2-rc",
       "description": "Blog/Medium-style UI components for long-form publishing applications",
       "includes": {
         "primitives": [
@@ -6706,27 +6706,27 @@
       },
       "dependencies": [
         { "name": "@equaltoai/greater-components", "version": "latest" },
-        { "name": "content", "version": "0.1.1" },
-        { "name": "headless", "version": "0.1.1" },
-        { "name": "icons", "version": "0.1.1" },
-        { "name": "primitives", "version": "0.1.1" },
-        { "name": "utils", "version": "0.1.1" }
+        { "name": "content", "version": "0.1.2-rc" },
+        { "name": "headless", "version": "0.1.2-rc" },
+        { "name": "icons", "version": "0.1.2-rc" },
+        { "name": "primitives", "version": "0.1.2-rc" },
+        { "name": "utils", "version": "0.1.2-rc" }
       ],
       "peerDependencies": [
-        { "name": "@equaltoai/greater-components-auth", "version": "0.1.1" },
-        { "name": "@equaltoai/greater-components-content", "version": "0.1.1" },
-        { "name": "@equaltoai/greater-components-headless", "version": "0.1.1" },
-        { "name": "@equaltoai/greater-components-icons", "version": "0.1.1" },
-        { "name": "@equaltoai/greater-components-primitives", "version": "0.1.1" },
-        { "name": "@equaltoai/greater-components-search", "version": "0.1.1" },
-        { "name": "@equaltoai/greater-components-tokens", "version": "0.1.1" },
-        { "name": "@equaltoai/greater-components-utils", "version": "0.1.1" },
-        { "name": "svelte", "version": "^5.46.1" }
+        { "name": "@equaltoai/greater-components-auth", "version": "0.1.2-rc" },
+        { "name": "@equaltoai/greater-components-content", "version": "0.1.2-rc" },
+        { "name": "@equaltoai/greater-components-headless", "version": "0.1.2-rc" },
+        { "name": "@equaltoai/greater-components-icons", "version": "0.1.2-rc" },
+        { "name": "@equaltoai/greater-components-primitives", "version": "0.1.2-rc" },
+        { "name": "@equaltoai/greater-components-search", "version": "0.1.2-rc" },
+        { "name": "@equaltoai/greater-components-tokens", "version": "0.1.2-rc" },
+        { "name": "@equaltoai/greater-components-utils", "version": "0.1.2-rc" },
+        { "name": "svelte", "version": "^5.49.1" }
       ]
     },
     "community": {
       "name": "community",
-      "version": "0.1.1",
+      "version": "0.1.2-rc",
       "description": "Community/Reddit-style UI components for forum-based discussion applications",
       "includes": {
         "primitives": [
@@ -6945,29 +6945,29 @@
         "tokens": "@equaltoai/greater-components/tokens/theme.css"
       },
       "dependencies": [
-        { "name": "content", "version": "0.1.1" },
-        { "name": "headless", "version": "0.1.1" },
-        { "name": "icons", "version": "0.1.1" },
-        { "name": "primitives", "version": "0.1.1" },
-        { "name": "utils", "version": "0.1.1" }
+        { "name": "content", "version": "0.1.2-rc" },
+        { "name": "headless", "version": "0.1.2-rc" },
+        { "name": "icons", "version": "0.1.2-rc" },
+        { "name": "primitives", "version": "0.1.2-rc" },
+        { "name": "utils", "version": "0.1.2-rc" }
       ],
       "peerDependencies": [
-        { "name": "@equaltoai/greater-components-admin", "version": "0.1.1" },
-        { "name": "@equaltoai/greater-components-auth", "version": "0.1.1" },
-        { "name": "@equaltoai/greater-components-content", "version": "0.1.1" },
-        { "name": "@equaltoai/greater-components-headless", "version": "0.1.1" },
-        { "name": "@equaltoai/greater-components-icons", "version": "0.1.1" },
-        { "name": "@equaltoai/greater-components-notifications", "version": "0.1.1" },
-        { "name": "@equaltoai/greater-components-primitives", "version": "0.1.1" },
-        { "name": "@equaltoai/greater-components-search", "version": "0.1.1" },
-        { "name": "@equaltoai/greater-components-tokens", "version": "0.1.1" },
-        { "name": "@equaltoai/greater-components-utils", "version": "0.1.1" },
-        { "name": "svelte", "version": "^5.46.1" }
+        { "name": "@equaltoai/greater-components-admin", "version": "0.1.2-rc" },
+        { "name": "@equaltoai/greater-components-auth", "version": "0.1.2-rc" },
+        { "name": "@equaltoai/greater-components-content", "version": "0.1.2-rc" },
+        { "name": "@equaltoai/greater-components-headless", "version": "0.1.2-rc" },
+        { "name": "@equaltoai/greater-components-icons", "version": "0.1.2-rc" },
+        { "name": "@equaltoai/greater-components-notifications", "version": "0.1.2-rc" },
+        { "name": "@equaltoai/greater-components-primitives", "version": "0.1.2-rc" },
+        { "name": "@equaltoai/greater-components-search", "version": "0.1.2-rc" },
+        { "name": "@equaltoai/greater-components-tokens", "version": "0.1.2-rc" },
+        { "name": "@equaltoai/greater-components-utils", "version": "0.1.2-rc" },
+        { "name": "svelte", "version": "^5.49.1" }
       ]
     },
     "artist": {
       "name": "artist",
-      "version": "0.1.1",
+      "version": "0.1.2-rc",
       "description": "Artist portfolio and gallery UI components for visual artists and creative professionals",
       "includes": {
         "primitives": [
@@ -7803,31 +7803,31 @@
       },
       "dependencies": [
         { "name": "@equaltoai/greater-components", "version": "latest" },
-        { "name": "adapters", "version": "0.1.1" },
-        { "name": "headless", "version": "0.1.1" },
-        { "name": "icons", "version": "0.1.1" },
-        { "name": "primitives", "version": "0.1.1" },
-        { "name": "tokens", "version": "0.1.1" },
-        { "name": "utils", "version": "0.1.1" }
+        { "name": "adapters", "version": "0.1.2-rc" },
+        { "name": "headless", "version": "0.1.2-rc" },
+        { "name": "icons", "version": "0.1.2-rc" },
+        { "name": "primitives", "version": "0.1.2-rc" },
+        { "name": "tokens", "version": "0.1.2-rc" },
+        { "name": "utils", "version": "0.1.2-rc" }
       ],
       "peerDependencies": [
-        { "name": "@apollo/client", "version": "^4.0.11" },
-        { "name": "@equaltoai/greater-components-adapters", "version": "0.1.1" },
-        { "name": "@equaltoai/greater-components-auth", "version": "0.1.1" },
-        { "name": "@equaltoai/greater-components-headless", "version": "0.1.1" },
-        { "name": "@equaltoai/greater-components-icons", "version": "0.1.1" },
-        { "name": "@equaltoai/greater-components-notifications", "version": "0.1.1" },
-        { "name": "@equaltoai/greater-components-primitives", "version": "0.1.1" },
-        { "name": "@equaltoai/greater-components-tokens", "version": "0.1.1" },
-        { "name": "@equaltoai/greater-components-utils", "version": "0.1.1" },
-        { "name": "svelte", "version": "^5.46.1" }
+        { "name": "@apollo/client", "version": "^4.1.3" },
+        { "name": "@equaltoai/greater-components-adapters", "version": "0.1.2-rc" },
+        { "name": "@equaltoai/greater-components-auth", "version": "0.1.2-rc" },
+        { "name": "@equaltoai/greater-components-headless", "version": "0.1.2-rc" },
+        { "name": "@equaltoai/greater-components-icons", "version": "0.1.2-rc" },
+        { "name": "@equaltoai/greater-components-notifications", "version": "0.1.2-rc" },
+        { "name": "@equaltoai/greater-components-primitives", "version": "0.1.2-rc" },
+        { "name": "@equaltoai/greater-components-tokens", "version": "0.1.2-rc" },
+        { "name": "@equaltoai/greater-components-utils", "version": "0.1.2-rc" },
+        { "name": "svelte", "version": "^5.49.1" }
       ]
     }
   },
   "shared": {
     "auth": {
       "name": "auth",
-      "version": "0.1.1",
+      "version": "0.1.2-rc",
       "description": "Authentication components for ActivityPub/Fediverse applications",
       "exports": [
         "Root",
@@ -7927,15 +7927,15 @@
         }
       ],
       "dependencies": [
-        { "name": "headless", "version": "0.1.1" },
-        { "name": "icons", "version": "0.1.1" },
-        { "name": "primitives", "version": "0.1.1" }
+        { "name": "headless", "version": "0.1.2-rc" },
+        { "name": "icons", "version": "0.1.2-rc" },
+        { "name": "primitives", "version": "0.1.2-rc" }
       ],
       "peerDependencies": [
-        { "name": "@equaltoai/greater-components-headless", "version": "0.1.1" },
-        { "name": "@equaltoai/greater-components-icons", "version": "0.1.1" },
-        { "name": "@equaltoai/greater-components-primitives", "version": "0.1.1" },
-        { "name": "svelte", "version": "^5.46.1" }
+        { "name": "@equaltoai/greater-components-headless", "version": "0.1.2-rc" },
+        { "name": "@equaltoai/greater-components-icons", "version": "0.1.2-rc" },
+        { "name": "@equaltoai/greater-components-primitives", "version": "0.1.2-rc" },
+        { "name": "svelte", "version": "^5.49.1" }
       ],
       "types": [
         "LoginCredentials",
@@ -7958,7 +7958,7 @@
     },
     "compose": {
       "name": "compose",
-      "version": "0.1.1",
+      "version": "0.1.2-rc",
       "description": "Post/content composer components for ActivityPub/Fediverse applications",
       "exports": [
         "Root",
@@ -8077,17 +8077,17 @@
       ],
       "dependencies": [
         { "name": "adapters", "version": "latest" },
-        { "name": "headless", "version": "0.1.1" },
-        { "name": "icons", "version": "0.1.1" },
-        { "name": "primitives", "version": "0.1.1" },
-        { "name": "utils", "version": "0.1.1" }
+        { "name": "headless", "version": "0.1.2-rc" },
+        { "name": "icons", "version": "0.1.2-rc" },
+        { "name": "primitives", "version": "0.1.2-rc" },
+        { "name": "utils", "version": "0.1.2-rc" }
       ],
       "peerDependencies": [
-        { "name": "@equaltoai/greater-components-headless", "version": "0.1.1" },
-        { "name": "@equaltoai/greater-components-icons", "version": "0.1.1" },
-        { "name": "@equaltoai/greater-components-primitives", "version": "0.1.1" },
-        { "name": "@equaltoai/greater-components-utils", "version": "0.1.1" },
-        { "name": "svelte", "version": "^5.46.1" }
+        { "name": "@equaltoai/greater-components-headless", "version": "0.1.2-rc" },
+        { "name": "@equaltoai/greater-components-icons", "version": "0.1.2-rc" },
+        { "name": "@equaltoai/greater-components-primitives", "version": "0.1.2-rc" },
+        { "name": "@equaltoai/greater-components-utils", "version": "0.1.2-rc" },
+        { "name": "svelte", "version": "^5.49.1" }
       ],
       "types": [
         "ComposeContext",
@@ -8103,7 +8103,7 @@
     },
     "notifications": {
       "name": "notifications",
-      "version": "0.1.1",
+      "version": "0.1.2-rc",
       "description": "Notification components for ActivityPub/Fediverse applications",
       "exports": [
         "Root",
@@ -8183,13 +8183,13 @@
       ],
       "dependencies": [
         { "name": "adapters", "version": "latest" },
-        { "name": "icons", "version": "0.1.1" },
-        { "name": "primitives", "version": "0.1.1" }
+        { "name": "icons", "version": "0.1.2-rc" },
+        { "name": "primitives", "version": "0.1.2-rc" }
       ],
       "peerDependencies": [
-        { "name": "@equaltoai/greater-components-icons", "version": "0.1.1" },
-        { "name": "@equaltoai/greater-components-primitives", "version": "0.1.1" },
-        { "name": "svelte", "version": "^5.46.1" }
+        { "name": "@equaltoai/greater-components-icons", "version": "0.1.2-rc" },
+        { "name": "@equaltoai/greater-components-primitives", "version": "0.1.2-rc" },
+        { "name": "svelte", "version": "^5.49.1" }
       ],
       "types": [
         "NotificationsContext",
@@ -8207,7 +8207,7 @@
     },
     "search": {
       "name": "search",
-      "version": "0.1.1",
+      "version": "0.1.2-rc",
       "description": "Search components for ActivityPub/Fediverse applications with federated search support",
       "exports": ["Root", "Bar", "Filters", "Results", "ActorResult", "NoteResult", "TagResult"],
       "files": [
@@ -8263,17 +8263,17 @@
         }
       ],
       "dependencies": [
-        { "name": "headless", "version": "0.1.1" },
-        { "name": "icons", "version": "0.1.1" },
-        { "name": "primitives", "version": "0.1.1" },
-        { "name": "utils", "version": "0.1.1" }
+        { "name": "headless", "version": "0.1.2-rc" },
+        { "name": "icons", "version": "0.1.2-rc" },
+        { "name": "primitives", "version": "0.1.2-rc" },
+        { "name": "utils", "version": "0.1.2-rc" }
       ],
       "peerDependencies": [
-        { "name": "@equaltoai/greater-components-headless", "version": "0.1.1" },
-        { "name": "@equaltoai/greater-components-icons", "version": "0.1.1" },
-        { "name": "@equaltoai/greater-components-primitives", "version": "0.1.1" },
-        { "name": "@equaltoai/greater-components-utils", "version": "0.1.1" },
-        { "name": "svelte", "version": "^5.46.1" }
+        { "name": "@equaltoai/greater-components-headless", "version": "0.1.2-rc" },
+        { "name": "@equaltoai/greater-components-icons", "version": "0.1.2-rc" },
+        { "name": "@equaltoai/greater-components-primitives", "version": "0.1.2-rc" },
+        { "name": "@equaltoai/greater-components-utils", "version": "0.1.2-rc" },
+        { "name": "svelte", "version": "^5.49.1" }
       ],
       "types": [
         "SearchResultType",
@@ -8289,7 +8289,7 @@
     },
     "admin": {
       "name": "admin",
-      "version": "0.1.1",
+      "version": "0.1.2-rc",
       "description": "Admin dashboard components for ActivityPub instance management",
       "exports": [
         "Root",
@@ -8470,15 +8470,15 @@
       ],
       "dependencies": [
         { "name": "adapters", "version": "latest" },
-        { "name": "headless", "version": "0.1.1" },
-        { "name": "icons", "version": "0.1.1" },
-        { "name": "primitives", "version": "0.1.1" }
+        { "name": "headless", "version": "0.1.2-rc" },
+        { "name": "icons", "version": "0.1.2-rc" },
+        { "name": "primitives", "version": "0.1.2-rc" }
       ],
       "peerDependencies": [
-        { "name": "@equaltoai/greater-components-headless", "version": "0.1.1" },
-        { "name": "@equaltoai/greater-components-icons", "version": "0.1.1" },
-        { "name": "@equaltoai/greater-components-primitives", "version": "0.1.1" },
-        { "name": "svelte", "version": "^5.46.1" }
+        { "name": "@equaltoai/greater-components-headless", "version": "0.1.2-rc" },
+        { "name": "@equaltoai/greater-components-icons", "version": "0.1.2-rc" },
+        { "name": "@equaltoai/greater-components-primitives", "version": "0.1.2-rc" },
+        { "name": "svelte", "version": "^5.49.1" }
       ],
       "types": [
         "AdminStats",
@@ -8495,7 +8495,7 @@
     },
     "chat": {
       "name": "chat",
-      "version": "0.1.1",
+      "version": "0.1.2-rc",
       "description": "AI chat interface components with streaming responses, tool calls, and settings",
       "exports": [
         "Container",
@@ -8576,16 +8576,16 @@
         }
       ],
       "dependencies": [
-        { "name": "content", "version": "0.1.1" },
-        { "name": "icons", "version": "0.1.1" },
-        { "name": "primitives", "version": "0.1.1" }
+        { "name": "content", "version": "0.1.2-rc" },
+        { "name": "icons", "version": "0.1.2-rc" },
+        { "name": "primitives", "version": "0.1.2-rc" }
       ],
       "peerDependencies": [
-        { "name": "@equaltoai/greater-components-content", "version": "0.1.1" },
-        { "name": "@equaltoai/greater-components-headless", "version": "0.1.1" },
-        { "name": "@equaltoai/greater-components-icons", "version": "0.1.1" },
-        { "name": "@equaltoai/greater-components-primitives", "version": "0.1.1" },
-        { "name": "svelte", "version": "^5.46.1" }
+        { "name": "@equaltoai/greater-components-content", "version": "0.1.2-rc" },
+        { "name": "@equaltoai/greater-components-headless", "version": "0.1.2-rc" },
+        { "name": "@equaltoai/greater-components-icons", "version": "0.1.2-rc" },
+        { "name": "@equaltoai/greater-components-primitives", "version": "0.1.2-rc" },
+        { "name": "svelte", "version": "^5.49.1" }
       ],
       "types": [
         "MessageRole",
@@ -8613,7 +8613,7 @@
     },
     "messaging": {
       "name": "messaging",
-      "version": "0.1.1",
+      "version": "0.1.2-rc",
       "description": "Direct messaging components for ActivityPub/Fediverse applications",
       "exports": [
         "Root",
@@ -8693,17 +8693,17 @@
         }
       ],
       "dependencies": [
-        { "name": "compose", "version": "0.1.1" },
-        { "name": "headless", "version": "0.1.1" },
-        { "name": "icons", "version": "0.1.1" },
-        { "name": "primitives", "version": "0.1.1" }
+        { "name": "compose", "version": "0.1.2-rc" },
+        { "name": "headless", "version": "0.1.2-rc" },
+        { "name": "icons", "version": "0.1.2-rc" },
+        { "name": "primitives", "version": "0.1.2-rc" }
       ],
       "peerDependencies": [
-        { "name": "@equaltoai/greater-components-compose", "version": "0.1.1" },
-        { "name": "@equaltoai/greater-components-headless", "version": "0.1.1" },
-        { "name": "@equaltoai/greater-components-icons", "version": "0.1.1" },
-        { "name": "@equaltoai/greater-components-primitives", "version": "0.1.1" },
-        { "name": "svelte", "version": "^5.46.1" }
+        { "name": "@equaltoai/greater-components-compose", "version": "0.1.2-rc" },
+        { "name": "@equaltoai/greater-components-headless", "version": "0.1.2-rc" },
+        { "name": "@equaltoai/greater-components-icons", "version": "0.1.2-rc" },
+        { "name": "@equaltoai/greater-components-primitives", "version": "0.1.2-rc" },
+        { "name": "svelte", "version": "^5.49.1" }
       ],
       "types": [
         "MessageParticipant",


### PR DESCRIPTION
Premain is currently inconsistent (root is 0.1.2-rc but workspace packages + registry index are still 0.1.1), which breaks all CI on premain promotions.\n\nThis PR runs the repo’s release metadata prep (equivalent to: `pnpm release:prepare 0.1.2-rc`) and formats CHANGELOG so CI passes.\n\nAfter merging, the staging→premain promotion PR should go green.