### PR TITLE
chore(ci): ensure release-please PRs run CI checks

### DIFF
--- a/.changeset/release-please-pr-checks.md
+++ b/.changeset/release-please-pr-checks.md
@@ -1,0 +1,6 @@
+---
+'greater-components': patch
+---
+
+Ensure release-please PRs get CI checks even when created with `GITHUB_TOKEN` (dispatch fallback for premain/main release automation).
+

--- a/.github/workflows/a11y.yml
+++ b/.github/workflows/a11y.yml
@@ -8,6 +8,7 @@ on:
   schedule:
     # Run accessibility tests daily at 2 AM UTC
     - cron: '0 2 * * *'
+  workflow_dispatch: {}
 
 permissions:
   contents: read

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -18,6 +18,7 @@ on:
     branches: ['staging', 'premain', 'main']
   schedule:
     - cron: '44 21 * * 0'
+  workflow_dispatch: {}
 
 jobs:
   analyze:

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -5,6 +5,7 @@ on:
     branches: [staging, premain, main]
   pull_request:
     branches: [staging, premain, main]
+  workflow_dispatch: {}
 
 permissions:
   contents: write

--- a/.github/workflows/dco.yml
+++ b/.github/workflows/dco.yml
@@ -3,6 +3,12 @@ name: DCO Check
 on:
   pull_request:
     types: [opened, synchronize, reopened]
+  workflow_dispatch:
+    inputs:
+      base_ref:
+        description: 'Base branch to compare against for signoffs (e.g., premain or main)'
+        required: true
+        type: string
 
 permissions:
   contents: read
@@ -15,11 +21,46 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
 
-      - name: DCO Check
+      - name: DCO Check (pull_request)
+        if: github.event_name == 'pull_request'
         uses: tim-actions/dco@v1.0
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: DCO Check (workflow_dispatch)
+        if: github.event_name == 'workflow_dispatch'
+        env:
+          BASE_REF: ${{ inputs.base_ref }}
+        run: |
+          set -euo pipefail
+
+          if [[ -z "${BASE_REF}" ]]; then
+            echo "::error::Missing required input: base_ref"
+            exit 1
+          fi
+
+          git fetch origin "${BASE_REF}:${BASE_REF}" --force
+
+          head_sha="$(git rev-parse HEAD)"
+          mapfile -t commits < <(git rev-list "${BASE_REF}..${head_sha}")
+
+          if [[ ${#commits[@]} -eq 0 ]]; then
+            echo "dco: no commits to check in ${BASE_REF}..${head_sha}"
+            exit 0
+          fi
+
+          missing=0
+          for sha in "${commits[@]}"; do
+            if ! git show -s --format=%B "${sha}" | grep -qi '^Signed-off-by:'; then
+              echo "::error::Commit ${sha} is missing Signed-off-by"
+              missing=1
+            fi
+          done
+
+          if [[ "${missing}" -ne 0 ]]; then
+            exit 1
+          fi

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -5,6 +5,7 @@ on:
     branches: [staging, premain, main]
   pull_request:
     branches: [staging, premain, main]
+  workflow_dispatch: {}
 
 permissions:
   contents: write

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -5,6 +5,7 @@ on:
     branches: [staging, premain, main]
   pull_request:
     branches: [staging, premain, main]
+  workflow_dispatch: {}
 
 permissions:
   contents: read

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -5,6 +5,7 @@ on:
     branches: [staging, premain, main]
   pull_request:
     branches: [staging, premain, main]
+  workflow_dispatch: {}
 
 permissions:
   contents: read

--- a/.github/workflows/prerelease-pr.yml
+++ b/.github/workflows/prerelease-pr.yml
@@ -17,6 +17,7 @@ permissions:
   contents: write
   issues: write
   pull-requests: write
+  actions: write
 
 jobs:
   release-please:
@@ -99,3 +100,49 @@ jobs:
 
           git commit -s -m "chore(release): prepare metadata"
           git push origin "${RELEASE_BRANCH}"
+
+      - name: Dispatch CI workflows for prerelease PR branch (GITHUB_TOKEN fallback)
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+          RELEASE_BRANCH: release-please--branches--premain--components--greater
+          BASE_BRANCH: premain
+          RELEASE_PLEASE_TOKEN: ${{ secrets.RELEASE_PLEASE_TOKEN }}
+        run: |
+          set -euo pipefail
+
+          if [[ -n "${RELEASE_PLEASE_TOKEN:-}" ]]; then
+            echo "dispatch-ci: RELEASE_PLEASE_TOKEN is set; PR checks should trigger normally; skipping."
+            exit 0
+          fi
+
+          if ! git ls-remote --exit-code --heads origin "${RELEASE_BRANCH}" >/dev/null; then
+            echo "dispatch-ci: no release branch; skipping"
+            exit 0
+          fi
+
+          pr_number="$(
+            gh pr list \
+              --head "${RELEASE_BRANCH}" \
+              --base "${BASE_BRANCH}" \
+              --state open \
+              --json number \
+              --jq '.[0].number' \
+            || true
+          )"
+
+          if [[ -z "${pr_number}" || "${pr_number}" == "null" ]]; then
+            echo "dispatch-ci: no open PR for ${RELEASE_BRANCH} -> ${BASE_BRANCH}; skipping"
+            exit 0
+          fi
+
+          echo "dispatch-ci: triggering CI for PR #${pr_number} on ${RELEASE_BRANCH}"
+
+          gh workflow run dco.yml --ref "${RELEASE_BRANCH}" --field base_ref="${BASE_BRANCH}"
+          gh workflow run lint.yml --ref "${RELEASE_BRANCH}"
+          gh workflow run test.yml --ref "${RELEASE_BRANCH}"
+          gh workflow run e2e.yml --ref "${RELEASE_BRANCH}"
+          gh workflow run a11y.yml --ref "${RELEASE_BRANCH}"
+          gh workflow run coverage.yml --ref "${RELEASE_BRANCH}"
+          gh workflow run docs.yml --ref "${RELEASE_BRANCH}"
+          gh workflow run codeql.yml --ref "${RELEASE_BRANCH}"

--- a/.github/workflows/release-pr.yml
+++ b/.github/workflows/release-pr.yml
@@ -17,6 +17,7 @@ permissions:
   contents: write
   issues: write
   pull-requests: write
+  actions: write
 
 jobs:
   release-please:
@@ -158,3 +159,49 @@ jobs:
 
           git commit -s -m "chore(release): prepare metadata"
           git push origin "${RELEASE_BRANCH}"
+
+      - name: Dispatch CI workflows for release PR branch (GITHUB_TOKEN fallback)
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+          RELEASE_BRANCH: release-please--branches--main--components--greater
+          BASE_BRANCH: main
+          RELEASE_PLEASE_TOKEN: ${{ secrets.RELEASE_PLEASE_TOKEN }}
+        run: |
+          set -euo pipefail
+
+          if [[ -n "${RELEASE_PLEASE_TOKEN:-}" ]]; then
+            echo "dispatch-ci: RELEASE_PLEASE_TOKEN is set; PR checks should trigger normally; skipping."
+            exit 0
+          fi
+
+          if ! git ls-remote --exit-code --heads origin "${RELEASE_BRANCH}" >/dev/null; then
+            echo "dispatch-ci: no release branch; skipping"
+            exit 0
+          fi
+
+          pr_number="$(
+            gh pr list \
+              --head "${RELEASE_BRANCH}" \
+              --base "${BASE_BRANCH}" \
+              --state open \
+              --json number \
+              --jq '.[0].number' \
+            || true
+          )"
+
+          if [[ -z "${pr_number}" || "${pr_number}" == "null" ]]; then
+            echo "dispatch-ci: no open PR for ${RELEASE_BRANCH} -> ${BASE_BRANCH}; skipping"
+            exit 0
+          fi
+
+          echo "dispatch-ci: triggering CI for PR #${pr_number} on ${RELEASE_BRANCH}"
+
+          gh workflow run dco.yml --ref "${RELEASE_BRANCH}" --field base_ref="${BASE_BRANCH}"
+          gh workflow run lint.yml --ref "${RELEASE_BRANCH}"
+          gh workflow run test.yml --ref "${RELEASE_BRANCH}"
+          gh workflow run e2e.yml --ref "${RELEASE_BRANCH}"
+          gh workflow run a11y.yml --ref "${RELEASE_BRANCH}"
+          gh workflow run coverage.yml --ref "${RELEASE_BRANCH}"
+          gh workflow run docs.yml --ref "${RELEASE_BRANCH}"
+          gh workflow run codeql.yml --ref "${RELEASE_BRANCH}"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,6 +5,7 @@ on:
     branches: [staging, premain, main]
   pull_request:
     branches: [staging, premain, main]
+  workflow_dispatch: {}
 
 permissions:
   contents: read


### PR DESCRIPTION
Release-please PRs created by GitHub Actions with the default GITHUB_TOKEN don’t trigger pull_request workflows, so they show up with no CI checks.

This PR:
- Adds workflow_dispatch support to our CI workflows.
- Updates prerelease/release PR automation to dispatch CI runs on the release-please branches when RELEASE_PLEASE_TOKEN isn’t configured.
- Adds a workflow_dispatch mode to DCO Check so signoff verification can also be dispatched.

No manual steps required beyond merging PRs; if RELEASE_PLEASE_TOKEN is configured, normal PR-triggered checks run and dispatch is skipped.