### PR TITLE
ci: dispatch main/premain guard checks

### DIFF
--- a/.changeset/main-guard-dispatch.md
+++ b/.changeset/main-guard-dispatch.md
@@ -1,0 +1,6 @@
+---
+'greater-components': patch
+---
+
+Ensure `main`/`premain` guard checks can be dispatched for release-please PRs (keeps branch protections compatible with `GITHUB_TOKEN`).
+

--- a/.github/workflows/main-guard.yml
+++ b/.github/workflows/main-guard.yml
@@ -3,6 +3,12 @@ name: Main Branch Guard
 on:
   pull_request:
     branches: [main]
+  workflow_dispatch:
+    inputs:
+      base_ref:
+        description: 'Base branch for policy evaluation (e.g., main)'
+        required: true
+        type: string
 
 permissions:
   contents: read
@@ -15,10 +21,20 @@ jobs:
     steps:
       - name: Require PR from premain or release PR branch
         run: |
-          echo "Base: ${{ github.base_ref }}"
-          echo "Head: ${{ github.head_ref }}"
+          base_ref="${{ github.base_ref }}"
+          if [[ -z "${base_ref}" ]]; then
+            base_ref="${{ github.event.inputs.base_ref }}"
+          fi
 
-          if [ "${{ github.head_ref }}" != "premain" ] && [ "${{ github.head_ref }}" != "release-please--branches--main--components--greater" ]; then
+          head_ref="${{ github.head_ref }}"
+          if [[ -z "${head_ref}" ]]; then
+            head_ref="${{ github.ref_name }}"
+          fi
+
+          echo "Base: ${base_ref}"
+          echo "Head: ${head_ref}"
+
+          if [ "${head_ref}" != "premain" ] && [ "${head_ref}" != "release-please--branches--main--components--greater" ]; then
             echo "::error::main is release-only. Allowed sources: premain (promotion), release-please--branches--main--components--greater (release PR)."
             exit 1
           fi

--- a/.github/workflows/premain-guard.yml
+++ b/.github/workflows/premain-guard.yml
@@ -3,6 +3,12 @@ name: Premain Branch Guard
 on:
   pull_request:
     branches: [premain]
+  workflow_dispatch:
+    inputs:
+      base_ref:
+        description: 'Base branch for policy evaluation (e.g., premain)'
+        required: true
+        type: string
 
 permissions:
   contents: read
@@ -15,10 +21,20 @@ jobs:
     steps:
       - name: Require PR from staging or prerelease PR branch
         run: |
-          echo "Base: ${{ github.base_ref }}"
-          echo "Head: ${{ github.head_ref }}"
+          base_ref="${{ github.base_ref }}"
+          if [[ -z "${base_ref}" ]]; then
+            base_ref="${{ github.event.inputs.base_ref }}"
+          fi
 
-          if [ "${{ github.head_ref }}" != "staging" ] && [ "${{ github.head_ref }}" != "release-please--branches--premain--components--greater" ]; then
+          head_ref="${{ github.head_ref }}"
+          if [[ -z "${head_ref}" ]]; then
+            head_ref="${{ github.ref_name }}"
+          fi
+
+          echo "Base: ${base_ref}"
+          echo "Head: ${head_ref}"
+
+          if [ "${head_ref}" != "staging" ] && [ "${head_ref}" != "release-please--branches--premain--components--greater" ]; then
             echo "::error::premain is release-candidate only. Allowed sources: staging (promotion), release-please--branches--premain--components--greater (prerelease PR)."
             exit 1
           fi

--- a/.github/workflows/prerelease-pr.yml
+++ b/.github/workflows/prerelease-pr.yml
@@ -138,6 +138,7 @@ jobs:
 
           echo "dispatch-ci: triggering CI for PR #${pr_number} on ${RELEASE_BRANCH}"
 
+          gh workflow run premain-guard.yml --ref "${RELEASE_BRANCH}" --field base_ref="${BASE_BRANCH}"
           gh workflow run dco.yml --ref "${RELEASE_BRANCH}" --field base_ref="${BASE_BRANCH}"
           gh workflow run lint.yml --ref "${RELEASE_BRANCH}"
           gh workflow run test.yml --ref "${RELEASE_BRANCH}"

--- a/.github/workflows/release-pr.yml
+++ b/.github/workflows/release-pr.yml
@@ -197,6 +197,7 @@ jobs:
 
           echo "dispatch-ci: triggering CI for PR #${pr_number} on ${RELEASE_BRANCH}"
 
+          gh workflow run main-guard.yml --ref "${RELEASE_BRANCH}" --field base_ref="${BASE_BRANCH}"
           gh workflow run dco.yml --ref "${RELEASE_BRANCH}" --field base_ref="${BASE_BRANCH}"
           gh workflow run lint.yml --ref "${RELEASE_BRANCH}"
           gh workflow run test.yml --ref "${RELEASE_BRANCH}"


### PR DESCRIPTION
Fixes main release PRs getting stuck on required check ‘Enforce release-only main’ when the PR is created by Actions with GITHUB_TOKEN.

- Adds workflow_dispatch support to main/premain guard workflows (with base_ref input)
- Release-PR workflows dispatch those guard checks in the GITHUB_TOKEN fallback path
- Includes a changeset (required for staging PRs)