### PR TITLE
chore: promote staging to premain

### DIFF
--- a/.changeset/coverage-codecov-optional.md
+++ b/.changeset/coverage-codecov-optional.md
@@ -1,0 +1,6 @@
+---
+'greater-components': patch
+---
+
+Skip Codecov uploads when `CODECOV_TOKEN` is not configured so coverage CI doesn’t fail in repos that don’t use Codecov.
+

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -55,7 +55,9 @@ jobs:
         continue-on-error: true
 
       - name: Upload coverage reports to Codecov
+        if: ${{ secrets.CODECOV_TOKEN != '' }}
         uses: codecov/codecov-action@v4
+        continue-on-error: true
         with:
           directory: ./packages/
           files: ./packages/*/coverage/lcov.info


### PR DESCRIPTION
Promote staging to premain (includes optional Codecov upload in coverage workflow).