### PR TITLE
chore(deps): patch undici and flatted

### DIFF
--- a/package.json
+++ b/package.json
@@ -103,7 +103,7 @@
     "pnpm": ">=9.0.0"
   },
   "dependencies": {
-    "undici": "^7.22.0"
+    "undici": "^7.24.3"
   },
   "pnpm": {
     "overrides": {
@@ -112,6 +112,7 @@
       "devalue": "^5.6.4",
       "dompurify@^3.0.0": "^3.3.2",
       "esbuild": "^0.25.8",
+      "flatted": "^3.4.1",
       "immutable": "^4.3.8",
       "@isaacs/brace-expansion": "^5.0.1",
       "lodash": "^4.17.23",
@@ -126,7 +127,7 @@
       "serialize-javascript@^6.0.0": "^7.0.3",
       "serialize-javascript@^7.0.0": "^7.0.3",
       "tmp": "^0.2.4",
-      "undici": "^7.5.0",
+      "undici": "^7.24.3",
       "workbox-build": "^7.4.0"
     }
   }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -10,6 +10,7 @@ overrides:
   devalue: ^5.6.4
   dompurify@^3.0.0: ^3.3.2
   esbuild: ^0.25.8
+  flatted: ^3.4.1
   immutable: ^4.3.8
   '@isaacs/brace-expansion': ^5.0.1
   lodash: ^4.17.23
@@ -24,7 +25,7 @@ overrides:
   serialize-javascript@^6.0.0: ^7.0.3
   serialize-javascript@^7.0.0: ^7.0.3
   tmp: ^0.2.4
-  undici: ^7.5.0
+  undici: ^7.24.3
   workbox-build: ^7.4.0
 
 importers:
@@ -32,8 +33,8 @@ importers:
   .:
     dependencies:
       undici:
-        specifier: ^7.5.0
-        version: 7.22.0
+        specifier: ^7.24.3
+        version: 7.24.3
     devDependencies:
       '@changesets/cli':
         specifier: ^2.30.0
@@ -4243,11 +4244,8 @@ packages:
     resolution: {integrity: sha512-f7ccFPK3SXFHpx15UIGyRJ/FJQctuKZ0zVuN3frBo4HnK3cay9VEW0R6yPYFHC0AgqhukPzKjq22t5DmAyqGyw==}
     engines: {node: '>=16'}
 
-  flatted@3.3.4:
-    resolution: {integrity: sha512-3+mMldrTAPdta5kjX2G2J7iX4zxtnwpdA8Tr2ZSjkyPSanvbZAcy6flmtnXbEybHrDcU9641lxrMfFuUxVz9vA==}
-
-  flatted@3.4.0:
-    resolution: {integrity: sha512-kC6Bb+ooptOIvWj5B63EQWkF0FEnNjV2ZNkLMLZRDDduIiWeFF4iKnslwhiWxjAdbg4NzTNo6h0qLuvFrcx+Sw==}
+  flatted@3.4.1:
+    resolution: {integrity: sha512-IxfVbRFVlV8V/yRaGzk0UVIcsKKHMSfYw66T/u4nTwlWteQePsxe//LjudR1AMX4tZW3WFCh3Zqa/sjlqpbURQ==}
 
   flexsearch@0.8.212:
     resolution: {integrity: sha512-wSyJr1GUWoOOIISRu+X2IXiOcVfg9qqBRyCPRUdLMIGJqPzMo+jMRlvE83t14v1j0dRMEaBbER/adQjp6Du2pw==}
@@ -6107,8 +6105,8 @@ packages:
   undici-types@7.18.2:
     resolution: {integrity: sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==}
 
-  undici@7.22.0:
-    resolution: {integrity: sha512-RqslV2Us5BrllB+JeiZnK4peryVTndy9Dnqq62S3yYRRTj0tFQCwEniUy2167skdGOy3vqRzEvl1Dm4sV2ReDg==}
+  undici@7.24.3:
+    resolution: {integrity: sha512-eJdUmK/Wrx2d+mnWWmwwLRyA7OQCkLap60sk3dOK4ViZR7DKwwptwuIvFBg2HaiP9ESaEdhtpSymQPvytpmkCA==}
     engines: {node: '>=20.18.1'}
 
   unicode-canonical-property-names-ecmascript@2.0.1:
@@ -8797,7 +8795,7 @@ snapshots:
     dependencies:
       '@vitest/utils': 4.0.18
       fflate: 0.8.2
-      flatted: 3.3.4
+      flatted: 3.4.1
       pathe: 2.0.3
       sirv: 3.0.2
       tinyglobby: 0.2.15
@@ -9713,12 +9711,10 @@ snapshots:
 
   flat-cache@4.0.1:
     dependencies:
-      flatted: 3.4.0
+      flatted: 3.4.1
       keyv: 4.5.4
 
-  flatted@3.3.4: {}
-
-  flatted@3.4.0: {}
+  flatted@3.4.1: {}
 
   flexsearch@0.8.212: {}
 
@@ -10391,7 +10387,7 @@ snapshots:
       saxes: 6.0.0
       symbol-tree: 3.2.4
       tough-cookie: 6.0.0
-      undici: 7.22.0
+      undici: 7.24.3
       w3c-xmlserializer: 5.0.0
       webidl-conversions: 8.0.1
       whatwg-mimetype: 5.0.0
@@ -11940,7 +11936,7 @@ snapshots:
 
   undici-types@7.18.2: {}
 
-  undici@7.22.0: {}
+  undici@7.24.3: {}
 
   unicode-canonical-property-names-ecmascript@2.0.1: {}
 


### PR DESCRIPTION
## Summary
- bump direct `undici` to the patched 7.x line
- pin transitive `flatted` via `pnpm.overrides` so Vitest UI cannot resolve to vulnerable 3.3.x
- refresh the lockfile to clear Dependabot alerts 61-67

## Verification
- `corepack pnpm audit --audit-level=low`
- `corepack pnpm format:check`
- `corepack pnpm lint`
- `corepack pnpm typecheck`

## Notes
- branched from synced `staging` after backmerging `main -> premain -> staging`
- rehearsed merges into both `premain` and `main` cleanly