### PR TITLE
chore(main): promote premain adapter sync

### DIFF
--- a/.github/workflows/a11y.yml
+++ b/.github/workflows/a11y.yml
@@ -243,7 +243,8 @@ jobs:
           retention-days: 90
 
       - name: Comment PR with accessibility results
-        if: github.event_name == 'pull_request'
+        if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
+        continue-on-error: true
         uses: actions/github-script@v8
         with:
           script: |

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -85,7 +85,8 @@ jobs:
           retention-days: 30
 
       - name: Comment PR with coverage results
-        if: github.event_name == 'pull_request'
+        if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
+        continue-on-error: true
         uses: actions/github-script@v8
         with:
           script: |

--- a/docs/lesser-host/contracts/LESSER_HOST_REF.txt
+++ b/docs/lesser-host/contracts/LESSER_HOST_REF.txt
@@ -1,2 +1,2 @@
-tag: v0.1.13
-commit: 5c1e72047c02b6498799854adbefe4ac9be96bdb
+tag: v0.1.15
+commit: 828265c52c6d9eced9ae80e82b588d628aa8cf03

--- a/docs/lesser/contracts/LESSER_REF.txt
+++ b/docs/lesser/contracts/LESSER_REF.txt
@@ -1,2 +1,2 @@
-tag: v1.1.49
-commit: b64ceed66ccfc70eb6cc52a55aa9b56dc8639f25
+tag: v1.1.50
+commit: 5fe4e1244f861a4b2b9e568f1abe49028492eea0

--- a/docs/lesser/contracts/graphql-schema.graphql
+++ b/docs/lesser/contracts/graphql-schema.graphql
@@ -4276,6 +4276,20 @@ type AgentAccessLeaseTokenPayload {
   expiresIn: Int!
 }
 
+type AgentRuntimeSession {
+  sessionID: ID!
+  clientID: String!
+  deviceLabel: String!
+  scope: String!
+  createdAt: Time!
+  lastUsedAt: Time!
+  idleExpiresAt: Time!
+  absoluteExpiresAt: Time!
+  revoked: Boolean!
+  revokedAt: Time
+  revokedReason: String
+}
+
 input AgentAccessLeaseChallengeInput {
   principalWallet: String!
   agentWallet: String!
@@ -4414,6 +4428,7 @@ extend type Query {
   myAgents: [Agent!]!
   agentActivity(username: String!, first: Int = 20, after: Cursor): AgentActivityConnection!
   agentAccessLeases(username: String!): [AgentAccessLease!]!
+  agentRuntimeSessions(username: String!): [AgentRuntimeSession!]!
   adminAgentPolicy: AdminAgentPolicy!
   agentMemorySearch(query: String!, tags: [String!], dateRange: DateRangeInput, first: Int = 20, after: Cursor): ObjectConnection!
   mySouls: [SoulInventoryItem!]!
@@ -4425,6 +4440,7 @@ extend type Mutation {
   deleteAgent(username: String!): Agent!
   delegateToAgent(input: DelegateToAgentInput!): DelegationPayload!
   revokeAgentToken(username: String!): Boolean!
+  revokeAgentRuntimeSession(username: String!, sessionID: ID!, reason: String): AgentRuntimeSession!
   createAgentAccessLeasePrincipalChallenge(username: String!, input: AgentAccessLeaseChallengeInput!): AgentAccessLeaseChallenge!
   createAgentAccessLeaseAgentChallenge(username: String!, input: AgentAccessLeaseChallengeInput!): AgentAccessLeaseChallenge!
   createAgentAccessLease(username: String!, input: CreateAgentAccessLeaseInput!): AgentAccessLease!

--- a/docs/lesser/contracts/openapi.yaml
+++ b/docs/lesser/contracts/openapi.yaml
@@ -1154,6 +1154,8 @@ components:
                     type: string
                 bio:
                     type: string
+                device_label:
+                    type: string
                 display_name:
                     type: string
                 expires_in:
@@ -1347,10 +1349,54 @@ components:
                 - public_key
                 - signature
             type: object
+        AgentRuntimeSession:
+            additionalProperties: false
+            properties:
+                absolute_expires_at:
+                    $ref: '#/components/schemas/RFC3339DateTime'
+                client_id:
+                    type: string
+                created_at:
+                    $ref: '#/components/schemas/RFC3339DateTime'
+                device_label:
+                    type: string
+                idle_expires_at:
+                    $ref: '#/components/schemas/RFC3339DateTime'
+                last_used_at:
+                    $ref: '#/components/schemas/RFC3339DateTime'
+                revoked:
+                    type: boolean
+                revoked_at:
+                    anyOf:
+                        - $ref: '#/components/schemas/RFC3339DateTime'
+                        - type: "null"
+                revoked_reason:
+                    type: string
+                scope:
+                    type: string
+                session_id:
+                    type: string
+            required:
+                - absolute_expires_at
+                - client_id
+                - created_at
+                - device_label
+                - idle_expires_at
+                - last_used_at
+                - revoked
+                - scope
+                - session_id
+            type: object
+        AgentRuntimeSessionList:
+            items:
+                $ref: '#/components/schemas/AgentRuntimeSession'
+            type: array
         AgentSelfAuthTokenRequest:
             additionalProperties: false
             properties:
                 challenge_id:
+                    type: string
+                device_label:
                     type: string
                 signature:
                     type: string
@@ -1368,6 +1414,8 @@ components:
                 bio:
                     type: string
                 challenge_id:
+                    type: string
+                device_label:
                     type: string
                 display_name:
                     type: string
@@ -4643,6 +4691,12 @@ components:
                 - severity
             type: object
         RevokeAgentAccessLeaseRequest:
+            additionalProperties: false
+            properties:
+                reason:
+                    type: string
+            type: object
+        RevokeAgentRuntimeSessionRequest:
             additionalProperties: false
             properties:
                 reason:
@@ -11262,6 +11316,74 @@ paths:
                 - cmd/api/routes.go
             x-oauth-scopes:
                 - read
+    /api/v1/agents/{username}/runtime-sessions:
+        get:
+            operationId: get_api_v1_agents_by_username_runtime_sessions
+            tags:
+                - agents
+            parameters:
+                - name: username
+                  in: path
+                  required: true
+                  schema:
+                    type: string
+            responses:
+                "200":
+                    description: OK
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/AgentRuntimeSessionList'
+                "400":
+                    $ref: '#/components/responses/BadRequest'
+                "404":
+                    $ref: '#/components/responses/NotFound'
+                "500":
+                    $ref: '#/components/responses/InternalServerError'
+            x-lesser-handler: HandleListAgentRuntimeSessionsLift
+            x-lesser-lambda: api
+            x-lesser-routeSources:
+                - cmd/api/routes.go
+    /api/v1/agents/{username}/runtime-sessions/{sessionID}/revoke:
+        post:
+            operationId: post_api_v1_agents_by_username_runtime_sessions_by_sessionID_revoke
+            tags:
+                - agents
+            parameters:
+                - name: sessionID
+                  in: path
+                  required: true
+                  schema:
+                    type: string
+                - name: username
+                  in: path
+                  required: true
+                  schema:
+                    type: string
+            requestBody:
+                content:
+                    application/json:
+                        schema:
+                            $ref: '#/components/schemas/RevokeAgentRuntimeSessionRequest'
+            responses:
+                "200":
+                    description: OK
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/AgentRuntimeSession'
+                "400":
+                    $ref: '#/components/responses/BadRequest'
+                "404":
+                    $ref: '#/components/responses/NotFound'
+                "422":
+                    $ref: '#/components/responses/UnprocessableEntity'
+                "500":
+                    $ref: '#/components/responses/InternalServerError'
+            x-lesser-handler: HandleRevokeAgentRuntimeSessionLift
+            x-lesser-lambda: api
+            x-lesser-routeSources:
+                - cmd/api/routes.go
     /api/v1/agents/{username}/suspend:
         post:
             operationId: post_api_v1_agents_by_username_suspend

--- a/packages/adapters/src/graphql/generated/types.ts
+++ b/packages/adapters/src/graphql/generated/types.ts
@@ -867,6 +867,21 @@ export type AgentPostAttributionInput = {
   readonly triggerType?: InputMaybe<Scalars['String']['input']>;
 };
 
+export type AgentRuntimeSession = {
+  readonly __typename: 'AgentRuntimeSession';
+  readonly absoluteExpiresAt: Scalars['Time']['output'];
+  readonly clientID: Scalars['String']['output'];
+  readonly createdAt: Scalars['Time']['output'];
+  readonly deviceLabel: Scalars['String']['output'];
+  readonly idleExpiresAt: Scalars['Time']['output'];
+  readonly lastUsedAt: Scalars['Time']['output'];
+  readonly revoked: Scalars['Boolean']['output'];
+  readonly revokedAt?: Maybe<Scalars['Time']['output']>;
+  readonly revokedReason?: Maybe<Scalars['String']['output']>;
+  readonly scope: Scalars['String']['output'];
+  readonly sessionID: Scalars['ID']['output'];
+};
+
 export type AgentType =
   | 'ASSISTANT'
   | 'BRIDGE'
@@ -2705,6 +2720,7 @@ export type Mutation = {
   readonly restoreRevision: Article;
   readonly resumeFederation: FederationManagementStatus;
   readonly revokeAgentAccessLease: AgentAccessLease;
+  readonly revokeAgentRuntimeSession: AgentRuntimeSession;
   readonly revokeAgentToken: Scalars['Boolean']['output'];
   readonly revokeVouch: Scalars['Boolean']['output'];
   readonly saveMarkers: MarkerSet;
@@ -3374,6 +3390,13 @@ export type MutationResumeFederationArgs = {
 export type MutationRevokeAgentAccessLeaseArgs = {
   input?: InputMaybe<RevokeAgentAccessLeaseInput>;
   leaseID: Scalars['ID']['input'];
+  username: Scalars['String']['input'];
+};
+
+
+export type MutationRevokeAgentRuntimeSessionArgs = {
+  reason?: InputMaybe<Scalars['String']['input']>;
+  sessionID: Scalars['ID']['input'];
   username: Scalars['String']['input'];
 };
 
@@ -4091,6 +4114,7 @@ export type Query = {
   readonly agentAccessLeases: ReadonlyArray<AgentAccessLease>;
   readonly agentActivity: AgentActivityConnection;
   readonly agentMemorySearch: ObjectConnection;
+  readonly agentRuntimeSessions: ReadonlyArray<AgentRuntimeSession>;
   readonly agents: AgentConnection;
   readonly aiAnalysis?: Maybe<AiAnalysis>;
   readonly aiCapabilities: AiCapabilities;
@@ -4341,6 +4365,11 @@ export type QueryAgentMemorySearchArgs = {
   first?: InputMaybe<Scalars['Int']['input']>;
   query: Scalars['String']['input'];
   tags?: InputMaybe<ReadonlyArray<Scalars['String']['input']>>;
+};
+
+
+export type QueryAgentRuntimeSessionsArgs = {
+  username: Scalars['String']['input'];
 };
 
 

--- a/packages/adapters/src/rest/generated/lesser-api.ts
+++ b/packages/adapters/src/rest/generated/lesser-api.ts
@@ -1316,6 +1316,38 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/v1/agents/{username}/runtime-sessions": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get: operations["get_api_v1_agents_by_username_runtime_sessions"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/v1/agents/{username}/runtime-sessions/{sessionID}/revoke": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post: operations["post_api_v1_agents_by_username_runtime_sessions_by_sessionID_revoke"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/v1/agents/{username}/suspend": {
         parameters: {
             query?: never;
@@ -4645,6 +4677,7 @@ export interface components {
             agent_info?: unknown;
             agent_username: string;
             bio?: string;
+            device_label?: string;
             display_name: string;
             expires_in?: number;
             scopes: string[];
@@ -4717,8 +4750,23 @@ export interface components {
             public_key: string;
             signature: string;
         };
+        AgentRuntimeSession: {
+            absolute_expires_at: components["schemas"]["RFC3339DateTime"];
+            client_id: string;
+            created_at: components["schemas"]["RFC3339DateTime"];
+            device_label: string;
+            idle_expires_at: components["schemas"]["RFC3339DateTime"];
+            last_used_at: components["schemas"]["RFC3339DateTime"];
+            revoked: boolean;
+            revoked_at?: components["schemas"]["RFC3339DateTime"] | null;
+            revoked_reason?: string;
+            scope: string;
+            session_id: string;
+        };
+        AgentRuntimeSessionList: components["schemas"]["AgentRuntimeSession"][];
         AgentSelfAuthTokenRequest: {
             challenge_id: string;
+            device_label?: string;
             signature: string;
             username: string;
         };
@@ -4726,6 +4774,7 @@ export interface components {
             agent_info?: unknown;
             bio?: string;
             challenge_id: string;
+            device_label?: string;
             display_name: string;
             key_type: string;
             public_key: string;
@@ -5892,6 +5941,9 @@ export interface components {
             severity: number;
         };
         RevokeAgentAccessLeaseRequest: {
+            reason?: string;
+        };
+        RevokeAgentRuntimeSessionRequest: {
             reason?: string;
         };
         Role: {
@@ -9786,6 +9838,62 @@ export interface operations {
             400: components["responses"]["BadRequest"];
             401: components["responses"]["Unauthorized"];
             403: components["responses"]["Forbidden"];
+            404: components["responses"]["NotFound"];
+            422: components["responses"]["UnprocessableEntity"];
+            500: components["responses"]["InternalServerError"];
+        };
+    };
+    get_api_v1_agents_by_username_runtime_sessions: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                username: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["AgentRuntimeSessionList"];
+                };
+            };
+            400: components["responses"]["BadRequest"];
+            404: components["responses"]["NotFound"];
+            500: components["responses"]["InternalServerError"];
+        };
+    };
+    post_api_v1_agents_by_username_runtime_sessions_by_sessionID_revoke: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                sessionID: string;
+                username: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: {
+            content: {
+                "application/json": components["schemas"]["RevokeAgentRuntimeSessionRequest"];
+            };
+        };
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["AgentRuntimeSession"];
+                };
+            };
+            400: components["responses"]["BadRequest"];
             404: components["responses"]["NotFound"];
             422: components["responses"]["UnprocessableEntity"];
             500: components["responses"]["InternalServerError"];

--- a/packages/faces/social/src/adapters/graphql/generated/introspection.json
+++ b/packages/faces/social/src/adapters/graphql/generated/introspection.json
@@ -8594,6 +8594,186 @@
         "possibleTypes": null
       },
       {
+        "kind": "OBJECT",
+        "name": "AgentRuntimeSession",
+        "description": null,
+        "isOneOf": null,
+        "fields": [
+          {
+            "name": "absoluteExpiresAt",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Time",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "clientID",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "createdAt",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Time",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "deviceLabel",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "idleExpiresAt",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Time",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "lastUsedAt",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Time",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "revoked",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Boolean",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "revokedAt",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "Time",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "revokedReason",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "scope",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "sessionID",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "ID",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
         "kind": "ENUM",
         "name": "AgentType",
         "description": null,
@@ -30679,6 +30859,67 @@
             "deprecationReason": null
           },
           {
+            "name": "revokeAgentRuntimeSession",
+            "description": null,
+            "args": [
+              {
+                "name": "reason",
+                "description": null,
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "sessionID",
+                "description": null,
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "ID",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "username",
+                "description": null,
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              }
+            ],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "AgentRuntimeSession",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "revokeAgentToken",
             "description": null,
             "args": [
@@ -37782,6 +38023,47 @@
                 "kind": "OBJECT",
                 "name": "ObjectConnection",
                 "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "agentRuntimeSessions",
+            "description": null,
+            "args": [
+              {
+                "name": "username",
+                "description": null,
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              }
+            ],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "AgentRuntimeSession",
+                    "ofType": null
+                  }
+                }
               }
             },
             "isDeprecated": false,

--- a/packages/faces/social/src/adapters/graphql/generated/types.ts
+++ b/packages/faces/social/src/adapters/graphql/generated/types.ts
@@ -867,6 +867,21 @@ export type AgentPostAttributionInput = {
   readonly triggerType?: InputMaybe<Scalars['String']['input']>;
 };
 
+export type AgentRuntimeSession = {
+  readonly __typename: 'AgentRuntimeSession';
+  readonly absoluteExpiresAt: Scalars['Time']['output'];
+  readonly clientID: Scalars['String']['output'];
+  readonly createdAt: Scalars['Time']['output'];
+  readonly deviceLabel: Scalars['String']['output'];
+  readonly idleExpiresAt: Scalars['Time']['output'];
+  readonly lastUsedAt: Scalars['Time']['output'];
+  readonly revoked: Scalars['Boolean']['output'];
+  readonly revokedAt?: Maybe<Scalars['Time']['output']>;
+  readonly revokedReason?: Maybe<Scalars['String']['output']>;
+  readonly scope: Scalars['String']['output'];
+  readonly sessionID: Scalars['ID']['output'];
+};
+
 export type AgentType =
   | 'ASSISTANT'
   | 'BRIDGE'
@@ -2705,6 +2720,7 @@ export type Mutation = {
   readonly restoreRevision: Article;
   readonly resumeFederation: FederationManagementStatus;
   readonly revokeAgentAccessLease: AgentAccessLease;
+  readonly revokeAgentRuntimeSession: AgentRuntimeSession;
   readonly revokeAgentToken: Scalars['Boolean']['output'];
   readonly revokeVouch: Scalars['Boolean']['output'];
   readonly saveMarkers: MarkerSet;
@@ -3374,6 +3390,13 @@ export type MutationResumeFederationArgs = {
 export type MutationRevokeAgentAccessLeaseArgs = {
   input?: InputMaybe<RevokeAgentAccessLeaseInput>;
   leaseID: Scalars['ID']['input'];
+  username: Scalars['String']['input'];
+};
+
+
+export type MutationRevokeAgentRuntimeSessionArgs = {
+  reason?: InputMaybe<Scalars['String']['input']>;
+  sessionID: Scalars['ID']['input'];
   username: Scalars['String']['input'];
 };
 
@@ -4091,6 +4114,7 @@ export type Query = {
   readonly agentAccessLeases: ReadonlyArray<AgentAccessLease>;
   readonly agentActivity: AgentActivityConnection;
   readonly agentMemorySearch: ObjectConnection;
+  readonly agentRuntimeSessions: ReadonlyArray<AgentRuntimeSession>;
   readonly agents: AgentConnection;
   readonly aiAnalysis?: Maybe<AiAnalysis>;
   readonly aiCapabilities: AiCapabilities;
@@ -4341,6 +4365,11 @@ export type QueryAgentMemorySearchArgs = {
   first?: InputMaybe<Scalars['Int']['input']>;
   query: Scalars['String']['input'];
   tags?: InputMaybe<ReadonlyArray<Scalars['String']['input']>>;
+};
+
+
+export type QueryAgentRuntimeSessionsArgs = {
+  username: Scalars['String']['input'];
 };
 
 

--- a/registry/index.json
+++ b/registry/index.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://equalto.ai/schemas/registry-index.schema.json",
   "schemaVersion": "1.0.0",
-  "generatedAt": "2026-03-16T13:22:22.917Z",
+  "generatedAt": "2026-03-17T14:46:23.537Z",
   "ref": "greater-v0.4.4",
   "version": "0.4.4",
   "checksums": {
@@ -823,7 +823,7 @@
     "packages/adapters/src/graphql/client.d.ts": "sha256-pJIC62N40bdFXhryg13X0HezmJFinzT2I9n/6qK1iJo=",
     "packages/adapters/src/graphql/client.ts": "sha256-M0UwWko7U1Cgv/EZv6CStGHfwidKao9BxgJRvKcF8N8=",
     "packages/adapters/src/graphql/generated/types.d.ts": "sha256-06CrbILnoClJ2Egs3gR2tZE271RgSroJXY7QxF46uLI=",
-    "packages/adapters/src/graphql/generated/types.ts": "sha256-o1PyIakGY8/mgANVKYbZb6+lWRwkE+hHmpJ0sqLVQcw=",
+    "packages/adapters/src/graphql/generated/types.ts": "sha256-G5NFTyVGkz/sL1N4NY485xUFeeJ4oZfM7uJCE6WHmg4=",
     "packages/adapters/src/graphql/index.d.ts": "sha256-orLx9yyDGxzzxd5wHeLg/XKql86ntzhZSG6iUj6Tjx8=",
     "packages/adapters/src/graphql/index.ts": "sha256-13y12ovgBLm5aZQ7K90w+XVxhUWIKB/eaPVEJ4kPeBI=",
     "packages/adapters/src/graphql/LesserGraphQLAdapter.d.ts": "sha256-IaAk0WgvAp2OkEzu4npQZMfWN2vd6MERvs54nLoVpOs=",
@@ -854,7 +854,7 @@
     "packages/adapters/src/messaging/index.ts": "sha256-2P3bCyR2sBhuV0GrrVnAaqGSq8dMVhA95dIJZ2s+eKw=",
     "packages/adapters/src/models/unified.d.ts": "sha256-8Z2SFddm7Cszpe6EoB85lJVH0xW16xjo68PhJGuvmeQ=",
     "packages/adapters/src/models/unified.ts": "sha256-ehDle02wDrnpb+OmdCcEZKSJ9q942CMqtvncdlM22bU=",
-    "packages/adapters/src/rest/generated/lesser-api.ts": "sha256-T3RJtcWAPrac4k286Px3DPdPaiTaozO/s6Ok8BkaUsI=",
+    "packages/adapters/src/rest/generated/lesser-api.ts": "sha256-+YYhqhMIfUxhW2tAQG2TJQqI4X4GKSaXSWDfII/ANzk=",
     "packages/adapters/src/rest/generated/lesser-host-api.ts": "sha256-bOx1N326rqTFi58N1/iXsb8f3kXIBqUxo4S+YE5tgk0=",
     "packages/adapters/src/soul/client.ts": "sha256-MOmAY/2PiJTu0FofU2jiOpcqc9nTnv4YOR09VEShWsE=",
     "packages/adapters/src/soul/ens.ts": "sha256-CI8WkwLMw8ZXNPrN+LpQdK81vud8ecgQc3xOXFMvK2o=",
@@ -899,7 +899,7 @@
     "packages/faces/social/src/adapters/cache.ts": "sha256-32jUHLAsYoK4U0JZ6hswGUlQOmwhJ5yquqhMqyfrc4I=",
     "packages/faces/social/src/adapters/graphql/client.ts": "sha256-yor+sP4J7hzK+igh2s4mujPOUZTRDN/e3nU1eccrSyo=",
     "packages/faces/social/src/adapters/graphql/generated/possible-types.ts": "sha256-jICUa0Jvj62nX0BdiBLTWoH2TII2SjAkM3ivA4dyuyA=",
-    "packages/faces/social/src/adapters/graphql/generated/types.ts": "sha256-o1PyIakGY8/mgANVKYbZb6+lWRwkE+hHmpJ0sqLVQcw=",
+    "packages/faces/social/src/adapters/graphql/generated/types.ts": "sha256-G5NFTyVGkz/sL1N4NY485xUFeeJ4oZfM7uJCE6WHmg4=",
     "packages/faces/social/src/adapters/graphql/index.ts": "sha256-SMi4iyLZqIOJKJyIpt2msJuQELlVAFJlnxBOdaL0ftY=",
     "packages/faces/social/src/adapters/graphql/queries.ts": "sha256-uiYJnwcQO+eaZUiTgyKJMxpeoluOuagazSLjQUdMR8M=",
     "packages/faces/social/src/adapters/graphql/types.ts": "sha256-0GgEc9AYxNSfWTVE9POQu0haMmO+PydpLzVw90hoDls=",
@@ -2008,15 +2008,36 @@
         }
       ],
       "dependencies": [
-        { "name": "icons", "version": "0.4.4" },
-        { "name": "tokens", "version": "0.4.4" },
-        { "name": "utils", "version": "0.4.4" }
+        {
+          "name": "icons",
+          "version": "0.4.4"
+        },
+        {
+          "name": "tokens",
+          "version": "0.4.4"
+        },
+        {
+          "name": "utils",
+          "version": "0.4.4"
+        }
       ],
       "peerDependencies": [
-        { "name": "@equaltoai/greater-components-icons", "version": "0.4.4" },
-        { "name": "@equaltoai/greater-components-utils", "version": "0.4.4" },
-        { "name": "@equaltoai/greater-components-tokens", "version": "0.4.4" },
-        { "name": "svelte", "version": "^5.53.12" }
+        {
+          "name": "@equaltoai/greater-components-icons",
+          "version": "0.4.4"
+        },
+        {
+          "name": "@equaltoai/greater-components-utils",
+          "version": "0.4.4"
+        },
+        {
+          "name": "@equaltoai/greater-components-tokens",
+          "version": "0.4.4"
+        },
+        {
+          "name": "svelte",
+          "version": "^5.53.12"
+        }
       ],
       "tags": []
     },
@@ -2164,9 +2185,18 @@
       ],
       "dependencies": [],
       "peerDependencies": [
-        { "name": "focus-trap", "version": "^8.0.0" },
-        { "name": "tabbable", "version": "^6.4.0" },
-        { "name": "svelte", "version": "^5.53.12" }
+        {
+          "name": "focus-trap",
+          "version": "^8.0.0"
+        },
+        {
+          "name": "tabbable",
+          "version": "^6.4.0"
+        },
+        {
+          "name": "svelte",
+          "version": "^5.53.12"
+        }
       ],
       "tags": []
     },
@@ -5228,7 +5258,12 @@
         }
       ],
       "dependencies": [],
-      "peerDependencies": [{ "name": "svelte", "version": "^5.53.12" }],
+      "peerDependencies": [
+        {
+          "name": "svelte",
+          "version": "^5.53.12"
+        }
+      ],
       "tags": []
     },
     "tokens": {
@@ -5481,15 +5516,42 @@
       ],
       "dependencies": [],
       "peerDependencies": [
-        { "name": "hast-util-to-mdast", "version": "^10.1.2" },
-        { "name": "mdast-util-gfm", "version": "^3.1.0" },
-        { "name": "mdast-util-to-markdown", "version": "^2.1.2" },
-        { "name": "rehype-parse", "version": "^9.0.1" },
-        { "name": "rehype-sanitize", "version": "^6.0.0" },
-        { "name": "rehype-stringify", "version": "^10.0.1" },
-        { "name": "unified", "version": "^11.0.5" },
-        { "name": "svelte", "version": "^5.53.12" },
-        { "name": "hast-util-sanitize", "version": "^5.0.2" }
+        {
+          "name": "hast-util-to-mdast",
+          "version": "^10.1.2"
+        },
+        {
+          "name": "mdast-util-gfm",
+          "version": "^3.1.0"
+        },
+        {
+          "name": "mdast-util-to-markdown",
+          "version": "^2.1.2"
+        },
+        {
+          "name": "rehype-parse",
+          "version": "^9.0.1"
+        },
+        {
+          "name": "rehype-sanitize",
+          "version": "^6.0.0"
+        },
+        {
+          "name": "rehype-stringify",
+          "version": "^10.0.1"
+        },
+        {
+          "name": "unified",
+          "version": "^11.0.5"
+        },
+        {
+          "name": "svelte",
+          "version": "^5.53.12"
+        },
+        {
+          "name": "hast-util-sanitize",
+          "version": "^5.0.2"
+        }
       ],
       "tags": []
     },
@@ -5541,8 +5603,8 @@
         },
         {
           "path": "src/graphql/generated/types.ts",
-          "checksum": "sha256-o1PyIakGY8/mgANVKYbZb6+lWRwkE+hHmpJ0sqLVQcw=",
-          "size": 1528919
+          "checksum": "sha256-G5NFTyVGkz/sL1N4NY485xUFeeJ4oZfM7uJCE6WHmg4=",
+          "size": 1529987
         },
         {
           "path": "src/graphql/index.d.ts",
@@ -5696,8 +5758,8 @@
         },
         {
           "path": "src/rest/generated/lesser-api.ts",
-          "checksum": "sha256-T3RJtcWAPrac4k286Px3DPdPaiTaozO/s6Ok8BkaUsI=",
-          "size": 508204
+          "checksum": "sha256-+YYhqhMIfUxhW2tAQG2TJQqI4X4GKSaXSWDfII/ANzk=",
+          "size": 511785
         },
         {
           "path": "src/rest/generated/lesser-host-api.ts",
@@ -5887,13 +5949,34 @@
       ],
       "dependencies": [],
       "peerDependencies": [
-        { "name": "@apollo/client", "version": "^4.1.6" },
-        { "name": "@apollo/client-react-streaming", "version": "^0.14.4" },
-        { "name": "@graphql-typed-document-node/core", "version": "^3.2.0" },
-        { "name": "graphql", "version": "^16.13.1" },
-        { "name": "graphql-ws", "version": "^6.0.7" },
-        { "name": "viem", "version": "^2.47.4" },
-        { "name": "svelte", "version": "^5.53.12" }
+        {
+          "name": "@apollo/client",
+          "version": "^4.1.6"
+        },
+        {
+          "name": "@apollo/client-react-streaming",
+          "version": "^0.14.4"
+        },
+        {
+          "name": "@graphql-typed-document-node/core",
+          "version": "^3.2.0"
+        },
+        {
+          "name": "graphql",
+          "version": "^16.13.1"
+        },
+        {
+          "name": "graphql-ws",
+          "version": "^6.0.7"
+        },
+        {
+          "name": "viem",
+          "version": "^2.47.4"
+        },
+        {
+          "name": "svelte",
+          "version": "^5.53.12"
+        }
       ],
       "tags": []
     },
@@ -5919,19 +6002,57 @@
           "size": 1119
         }
       ],
-      "dependencies": [{ "name": "primitives", "version": "0.4.4" }],
+      "dependencies": [
+        {
+          "name": "primitives",
+          "version": "0.4.4"
+        }
+      ],
       "peerDependencies": [
-        { "name": "hast-util-sanitize", "version": "^5.0.2" },
-        { "name": "rehype-sanitize", "version": "^6.0.0" },
-        { "name": "rehype-stringify", "version": "^10.0.1" },
-        { "name": "remark-gfm", "version": "^4.0.1" },
-        { "name": "remark-parse", "version": "^11.0.0" },
-        { "name": "remark-rehype", "version": "^11.1.2" },
-        { "name": "shiki", "version": "^4.0.2" },
-        { "name": "unified", "version": "^11.0.5" },
-        { "name": "@equaltoai/greater-components-primitives", "version": "0.4.4" },
-        { "name": "@equaltoai/greater-components-tokens", "version": "0.4.4" },
-        { "name": "svelte", "version": "^5.53.12" }
+        {
+          "name": "hast-util-sanitize",
+          "version": "^5.0.2"
+        },
+        {
+          "name": "rehype-sanitize",
+          "version": "^6.0.0"
+        },
+        {
+          "name": "rehype-stringify",
+          "version": "^10.0.1"
+        },
+        {
+          "name": "remark-gfm",
+          "version": "^4.0.1"
+        },
+        {
+          "name": "remark-parse",
+          "version": "^11.0.0"
+        },
+        {
+          "name": "remark-rehype",
+          "version": "^11.1.2"
+        },
+        {
+          "name": "shiki",
+          "version": "^4.0.2"
+        },
+        {
+          "name": "unified",
+          "version": "^11.0.5"
+        },
+        {
+          "name": "@equaltoai/greater-components-primitives",
+          "version": "0.4.4"
+        },
+        {
+          "name": "@equaltoai/greater-components-tokens",
+          "version": "0.4.4"
+        },
+        {
+          "name": "svelte",
+          "version": "^5.53.12"
+        }
       ],
       "tags": []
     }
@@ -6031,8 +6152,8 @@
         },
         {
           "path": "src/adapters/graphql/generated/types.ts",
-          "checksum": "sha256-o1PyIakGY8/mgANVKYbZb6+lWRwkE+hHmpJ0sqLVQcw=",
-          "size": 1528919
+          "checksum": "sha256-G5NFTyVGkz/sL1N4NY485xUFeeJ4oZfM7uJCE6WHmg4=",
+          "size": 1529987
         },
         {
           "path": "src/adapters/graphql/index.ts",
@@ -6600,36 +6721,120 @@
         "tokens": "@equaltoai/greater-components/tokens/theme.css"
       },
       "dependencies": [
-        { "name": "@equaltoai/greater-components", "version": "latest" },
-        { "name": "adapters", "version": "0.4.4" },
-        { "name": "admin", "version": "0.4.4" },
-        { "name": "auth", "version": "0.4.4" },
-        { "name": "compose", "version": "0.4.4" },
-        { "name": "headless", "version": "0.4.4" },
-        { "name": "icons", "version": "0.4.4" },
-        { "name": "messaging", "version": "0.4.4" },
-        { "name": "notifications", "version": "0.4.4" },
-        { "name": "primitives", "version": "0.4.4" },
-        { "name": "search", "version": "0.4.4" },
-        { "name": "tokens", "version": "0.4.4" },
-        { "name": "utils", "version": "0.4.4" }
+        {
+          "name": "@equaltoai/greater-components",
+          "version": "latest"
+        },
+        {
+          "name": "adapters",
+          "version": "0.4.4"
+        },
+        {
+          "name": "admin",
+          "version": "0.4.4"
+        },
+        {
+          "name": "auth",
+          "version": "0.4.4"
+        },
+        {
+          "name": "compose",
+          "version": "0.4.4"
+        },
+        {
+          "name": "headless",
+          "version": "0.4.4"
+        },
+        {
+          "name": "icons",
+          "version": "0.4.4"
+        },
+        {
+          "name": "messaging",
+          "version": "0.4.4"
+        },
+        {
+          "name": "notifications",
+          "version": "0.4.4"
+        },
+        {
+          "name": "primitives",
+          "version": "0.4.4"
+        },
+        {
+          "name": "search",
+          "version": "0.4.4"
+        },
+        {
+          "name": "tokens",
+          "version": "0.4.4"
+        },
+        {
+          "name": "utils",
+          "version": "0.4.4"
+        }
       ],
       "peerDependencies": [
-        { "name": "@equaltoai/greater-components-adapters", "version": "0.4.4" },
-        { "name": "@equaltoai/greater-components-admin", "version": "0.4.4" },
-        { "name": "@equaltoai/greater-components-auth", "version": "0.4.4" },
-        { "name": "@equaltoai/greater-components-compose", "version": "0.4.4" },
-        { "name": "@equaltoai/greater-components-headless", "version": "0.4.4" },
-        { "name": "@equaltoai/greater-components-icons", "version": "0.4.4" },
-        { "name": "@equaltoai/greater-components-messaging", "version": "0.4.4" },
-        { "name": "@equaltoai/greater-components-notifications", "version": "0.4.4" },
-        { "name": "@equaltoai/greater-components-primitives", "version": "0.4.4" },
-        { "name": "@equaltoai/greater-components-search", "version": "0.4.4" },
-        { "name": "@equaltoai/greater-components-tokens", "version": "0.4.4" },
-        { "name": "@equaltoai/greater-components-utils", "version": "0.4.4" },
-        { "name": "@graphql-typed-document-node/core", "version": "^3.2.0" },
-        { "name": "@tanstack/svelte-virtual", "version": "^3.13.23" },
-        { "name": "svelte", "version": "^5.53.12" }
+        {
+          "name": "@equaltoai/greater-components-adapters",
+          "version": "0.4.4"
+        },
+        {
+          "name": "@equaltoai/greater-components-admin",
+          "version": "0.4.4"
+        },
+        {
+          "name": "@equaltoai/greater-components-auth",
+          "version": "0.4.4"
+        },
+        {
+          "name": "@equaltoai/greater-components-compose",
+          "version": "0.4.4"
+        },
+        {
+          "name": "@equaltoai/greater-components-headless",
+          "version": "0.4.4"
+        },
+        {
+          "name": "@equaltoai/greater-components-icons",
+          "version": "0.4.4"
+        },
+        {
+          "name": "@equaltoai/greater-components-messaging",
+          "version": "0.4.4"
+        },
+        {
+          "name": "@equaltoai/greater-components-notifications",
+          "version": "0.4.4"
+        },
+        {
+          "name": "@equaltoai/greater-components-primitives",
+          "version": "0.4.4"
+        },
+        {
+          "name": "@equaltoai/greater-components-search",
+          "version": "0.4.4"
+        },
+        {
+          "name": "@equaltoai/greater-components-tokens",
+          "version": "0.4.4"
+        },
+        {
+          "name": "@equaltoai/greater-components-utils",
+          "version": "0.4.4"
+        },
+        {
+          "name": "@graphql-typed-document-node/core",
+          "version": "^3.2.0"
+        },
+        {
+          "name": "@tanstack/svelte-virtual",
+          "version": "^3.13.23"
+        },
+        {
+          "name": "svelte",
+          "version": "^5.53.12"
+        }
       ]
     },
     "blog": {
@@ -6834,23 +7039,68 @@
         "tokens": "@equaltoai/greater-components/tokens/theme.css"
       },
       "dependencies": [
-        { "name": "@equaltoai/greater-components", "version": "latest" },
-        { "name": "content", "version": "0.4.4" },
-        { "name": "headless", "version": "0.4.4" },
-        { "name": "icons", "version": "0.4.4" },
-        { "name": "primitives", "version": "0.4.4" },
-        { "name": "utils", "version": "0.4.4" }
+        {
+          "name": "@equaltoai/greater-components",
+          "version": "latest"
+        },
+        {
+          "name": "content",
+          "version": "0.4.4"
+        },
+        {
+          "name": "headless",
+          "version": "0.4.4"
+        },
+        {
+          "name": "icons",
+          "version": "0.4.4"
+        },
+        {
+          "name": "primitives",
+          "version": "0.4.4"
+        },
+        {
+          "name": "utils",
+          "version": "0.4.4"
+        }
       ],
       "peerDependencies": [
-        { "name": "@equaltoai/greater-components-auth", "version": "0.4.4" },
-        { "name": "@equaltoai/greater-components-content", "version": "0.4.4" },
-        { "name": "@equaltoai/greater-components-headless", "version": "0.4.4" },
-        { "name": "@equaltoai/greater-components-icons", "version": "0.4.4" },
-        { "name": "@equaltoai/greater-components-primitives", "version": "0.4.4" },
-        { "name": "@equaltoai/greater-components-search", "version": "0.4.4" },
-        { "name": "@equaltoai/greater-components-tokens", "version": "0.4.4" },
-        { "name": "@equaltoai/greater-components-utils", "version": "0.4.4" },
-        { "name": "svelte", "version": "^5.53.12" }
+        {
+          "name": "@equaltoai/greater-components-auth",
+          "version": "0.4.4"
+        },
+        {
+          "name": "@equaltoai/greater-components-content",
+          "version": "0.4.4"
+        },
+        {
+          "name": "@equaltoai/greater-components-headless",
+          "version": "0.4.4"
+        },
+        {
+          "name": "@equaltoai/greater-components-icons",
+          "version": "0.4.4"
+        },
+        {
+          "name": "@equaltoai/greater-components-primitives",
+          "version": "0.4.4"
+        },
+        {
+          "name": "@equaltoai/greater-components-search",
+          "version": "0.4.4"
+        },
+        {
+          "name": "@equaltoai/greater-components-tokens",
+          "version": "0.4.4"
+        },
+        {
+          "name": "@equaltoai/greater-components-utils",
+          "version": "0.4.4"
+        },
+        {
+          "name": "svelte",
+          "version": "^5.53.12"
+        }
       ]
     },
     "community": {
@@ -7074,24 +7324,72 @@
         "tokens": "@equaltoai/greater-components/tokens/theme.css"
       },
       "dependencies": [
-        { "name": "content", "version": "0.4.4" },
-        { "name": "headless", "version": "0.4.4" },
-        { "name": "icons", "version": "0.4.4" },
-        { "name": "primitives", "version": "0.4.4" },
-        { "name": "utils", "version": "0.4.4" }
+        {
+          "name": "content",
+          "version": "0.4.4"
+        },
+        {
+          "name": "headless",
+          "version": "0.4.4"
+        },
+        {
+          "name": "icons",
+          "version": "0.4.4"
+        },
+        {
+          "name": "primitives",
+          "version": "0.4.4"
+        },
+        {
+          "name": "utils",
+          "version": "0.4.4"
+        }
       ],
       "peerDependencies": [
-        { "name": "@equaltoai/greater-components-admin", "version": "0.4.4" },
-        { "name": "@equaltoai/greater-components-auth", "version": "0.4.4" },
-        { "name": "@equaltoai/greater-components-content", "version": "0.4.4" },
-        { "name": "@equaltoai/greater-components-headless", "version": "0.4.4" },
-        { "name": "@equaltoai/greater-components-icons", "version": "0.4.4" },
-        { "name": "@equaltoai/greater-components-notifications", "version": "0.4.4" },
-        { "name": "@equaltoai/greater-components-primitives", "version": "0.4.4" },
-        { "name": "@equaltoai/greater-components-search", "version": "0.4.4" },
-        { "name": "@equaltoai/greater-components-tokens", "version": "0.4.4" },
-        { "name": "@equaltoai/greater-components-utils", "version": "0.4.4" },
-        { "name": "svelte", "version": "^5.53.12" }
+        {
+          "name": "@equaltoai/greater-components-admin",
+          "version": "0.4.4"
+        },
+        {
+          "name": "@equaltoai/greater-components-auth",
+          "version": "0.4.4"
+        },
+        {
+          "name": "@equaltoai/greater-components-content",
+          "version": "0.4.4"
+        },
+        {
+          "name": "@equaltoai/greater-components-headless",
+          "version": "0.4.4"
+        },
+        {
+          "name": "@equaltoai/greater-components-icons",
+          "version": "0.4.4"
+        },
+        {
+          "name": "@equaltoai/greater-components-notifications",
+          "version": "0.4.4"
+        },
+        {
+          "name": "@equaltoai/greater-components-primitives",
+          "version": "0.4.4"
+        },
+        {
+          "name": "@equaltoai/greater-components-search",
+          "version": "0.4.4"
+        },
+        {
+          "name": "@equaltoai/greater-components-tokens",
+          "version": "0.4.4"
+        },
+        {
+          "name": "@equaltoai/greater-components-utils",
+          "version": "0.4.4"
+        },
+        {
+          "name": "svelte",
+          "version": "^5.53.12"
+        }
       ]
     },
     "artist": {
@@ -7936,25 +8234,76 @@
         "tokens": "@equaltoai/greater-components/tokens/theme.css"
       },
       "dependencies": [
-        { "name": "@equaltoai/greater-components", "version": "latest" },
-        { "name": "adapters", "version": "0.4.4" },
-        { "name": "headless", "version": "0.4.4" },
-        { "name": "icons", "version": "0.4.4" },
-        { "name": "primitives", "version": "0.4.4" },
-        { "name": "tokens", "version": "0.4.4" },
-        { "name": "utils", "version": "0.4.4" }
+        {
+          "name": "@equaltoai/greater-components",
+          "version": "latest"
+        },
+        {
+          "name": "adapters",
+          "version": "0.4.4"
+        },
+        {
+          "name": "headless",
+          "version": "0.4.4"
+        },
+        {
+          "name": "icons",
+          "version": "0.4.4"
+        },
+        {
+          "name": "primitives",
+          "version": "0.4.4"
+        },
+        {
+          "name": "tokens",
+          "version": "0.4.4"
+        },
+        {
+          "name": "utils",
+          "version": "0.4.4"
+        }
       ],
       "peerDependencies": [
-        { "name": "@apollo/client", "version": "^4.1.6" },
-        { "name": "@equaltoai/greater-components-adapters", "version": "0.4.4" },
-        { "name": "@equaltoai/greater-components-auth", "version": "0.4.4" },
-        { "name": "@equaltoai/greater-components-headless", "version": "0.4.4" },
-        { "name": "@equaltoai/greater-components-icons", "version": "0.4.4" },
-        { "name": "@equaltoai/greater-components-notifications", "version": "0.4.4" },
-        { "name": "@equaltoai/greater-components-primitives", "version": "0.4.4" },
-        { "name": "@equaltoai/greater-components-tokens", "version": "0.4.4" },
-        { "name": "@equaltoai/greater-components-utils", "version": "0.4.4" },
-        { "name": "svelte", "version": "^5.53.12" }
+        {
+          "name": "@apollo/client",
+          "version": "^4.1.6"
+        },
+        {
+          "name": "@equaltoai/greater-components-adapters",
+          "version": "0.4.4"
+        },
+        {
+          "name": "@equaltoai/greater-components-auth",
+          "version": "0.4.4"
+        },
+        {
+          "name": "@equaltoai/greater-components-headless",
+          "version": "0.4.4"
+        },
+        {
+          "name": "@equaltoai/greater-components-icons",
+          "version": "0.4.4"
+        },
+        {
+          "name": "@equaltoai/greater-components-notifications",
+          "version": "0.4.4"
+        },
+        {
+          "name": "@equaltoai/greater-components-primitives",
+          "version": "0.4.4"
+        },
+        {
+          "name": "@equaltoai/greater-components-tokens",
+          "version": "0.4.4"
+        },
+        {
+          "name": "@equaltoai/greater-components-utils",
+          "version": "0.4.4"
+        },
+        {
+          "name": "svelte",
+          "version": "^5.53.12"
+        }
       ]
     }
   },
@@ -8061,15 +8410,36 @@
         }
       ],
       "dependencies": [
-        { "name": "headless", "version": "0.4.4" },
-        { "name": "icons", "version": "0.4.4" },
-        { "name": "primitives", "version": "0.4.4" }
+        {
+          "name": "headless",
+          "version": "0.4.4"
+        },
+        {
+          "name": "icons",
+          "version": "0.4.4"
+        },
+        {
+          "name": "primitives",
+          "version": "0.4.4"
+        }
       ],
       "peerDependencies": [
-        { "name": "@equaltoai/greater-components-headless", "version": "0.4.4" },
-        { "name": "@equaltoai/greater-components-icons", "version": "0.4.4" },
-        { "name": "@equaltoai/greater-components-primitives", "version": "0.4.4" },
-        { "name": "svelte", "version": "^5.53.12" }
+        {
+          "name": "@equaltoai/greater-components-headless",
+          "version": "0.4.4"
+        },
+        {
+          "name": "@equaltoai/greater-components-icons",
+          "version": "0.4.4"
+        },
+        {
+          "name": "@equaltoai/greater-components-primitives",
+          "version": "0.4.4"
+        },
+        {
+          "name": "svelte",
+          "version": "^5.53.12"
+        }
       ],
       "types": [
         "LoginCredentials",
@@ -8210,18 +8580,48 @@
         }
       ],
       "dependencies": [
-        { "name": "adapters", "version": "latest" },
-        { "name": "headless", "version": "0.4.4" },
-        { "name": "icons", "version": "0.4.4" },
-        { "name": "primitives", "version": "0.4.4" },
-        { "name": "utils", "version": "0.4.4" }
+        {
+          "name": "adapters",
+          "version": "latest"
+        },
+        {
+          "name": "headless",
+          "version": "0.4.4"
+        },
+        {
+          "name": "icons",
+          "version": "0.4.4"
+        },
+        {
+          "name": "primitives",
+          "version": "0.4.4"
+        },
+        {
+          "name": "utils",
+          "version": "0.4.4"
+        }
       ],
       "peerDependencies": [
-        { "name": "@equaltoai/greater-components-headless", "version": "0.4.4" },
-        { "name": "@equaltoai/greater-components-icons", "version": "0.4.4" },
-        { "name": "@equaltoai/greater-components-primitives", "version": "0.4.4" },
-        { "name": "@equaltoai/greater-components-utils", "version": "0.4.4" },
-        { "name": "svelte", "version": "^5.53.12" }
+        {
+          "name": "@equaltoai/greater-components-headless",
+          "version": "0.4.4"
+        },
+        {
+          "name": "@equaltoai/greater-components-icons",
+          "version": "0.4.4"
+        },
+        {
+          "name": "@equaltoai/greater-components-primitives",
+          "version": "0.4.4"
+        },
+        {
+          "name": "@equaltoai/greater-components-utils",
+          "version": "0.4.4"
+        },
+        {
+          "name": "svelte",
+          "version": "^5.53.12"
+        }
       ],
       "types": [
         "ComposeContext",
@@ -8322,16 +8722,40 @@
         }
       ],
       "dependencies": [
-        { "name": "adapters", "version": "latest" },
-        { "name": "icons", "version": "0.4.4" },
-        { "name": "primitives", "version": "0.4.4" },
-        { "name": "utils", "version": "0.4.4" }
+        {
+          "name": "adapters",
+          "version": "latest"
+        },
+        {
+          "name": "icons",
+          "version": "0.4.4"
+        },
+        {
+          "name": "primitives",
+          "version": "0.4.4"
+        },
+        {
+          "name": "utils",
+          "version": "0.4.4"
+        }
       ],
       "peerDependencies": [
-        { "name": "@equaltoai/greater-components-icons", "version": "0.4.4" },
-        { "name": "@equaltoai/greater-components-primitives", "version": "0.4.4" },
-        { "name": "@equaltoai/greater-components-utils", "version": "0.4.4" },
-        { "name": "svelte", "version": "^5.53.12" }
+        {
+          "name": "@equaltoai/greater-components-icons",
+          "version": "0.4.4"
+        },
+        {
+          "name": "@equaltoai/greater-components-primitives",
+          "version": "0.4.4"
+        },
+        {
+          "name": "@equaltoai/greater-components-utils",
+          "version": "0.4.4"
+        },
+        {
+          "name": "svelte",
+          "version": "^5.53.12"
+        }
       ],
       "types": [
         "NotificationsContext",
@@ -8405,17 +8829,44 @@
         }
       ],
       "dependencies": [
-        { "name": "headless", "version": "0.4.4" },
-        { "name": "icons", "version": "0.4.4" },
-        { "name": "primitives", "version": "0.4.4" },
-        { "name": "utils", "version": "0.4.4" }
+        {
+          "name": "headless",
+          "version": "0.4.4"
+        },
+        {
+          "name": "icons",
+          "version": "0.4.4"
+        },
+        {
+          "name": "primitives",
+          "version": "0.4.4"
+        },
+        {
+          "name": "utils",
+          "version": "0.4.4"
+        }
       ],
       "peerDependencies": [
-        { "name": "@equaltoai/greater-components-headless", "version": "0.4.4" },
-        { "name": "@equaltoai/greater-components-icons", "version": "0.4.4" },
-        { "name": "@equaltoai/greater-components-primitives", "version": "0.4.4" },
-        { "name": "@equaltoai/greater-components-utils", "version": "0.4.4" },
-        { "name": "svelte", "version": "^5.53.12" }
+        {
+          "name": "@equaltoai/greater-components-headless",
+          "version": "0.4.4"
+        },
+        {
+          "name": "@equaltoai/greater-components-icons",
+          "version": "0.4.4"
+        },
+        {
+          "name": "@equaltoai/greater-components-primitives",
+          "version": "0.4.4"
+        },
+        {
+          "name": "@equaltoai/greater-components-utils",
+          "version": "0.4.4"
+        },
+        {
+          "name": "svelte",
+          "version": "^5.53.12"
+        }
       ],
       "types": [
         "SearchResultType",
@@ -8639,16 +9090,40 @@
         }
       ],
       "dependencies": [
-        { "name": "adapters", "version": "latest" },
-        { "name": "headless", "version": "0.4.4" },
-        { "name": "icons", "version": "0.4.4" },
-        { "name": "primitives", "version": "0.4.4" }
+        {
+          "name": "adapters",
+          "version": "latest"
+        },
+        {
+          "name": "headless",
+          "version": "0.4.4"
+        },
+        {
+          "name": "icons",
+          "version": "0.4.4"
+        },
+        {
+          "name": "primitives",
+          "version": "0.4.4"
+        }
       ],
       "peerDependencies": [
-        { "name": "@equaltoai/greater-components-headless", "version": "0.4.4" },
-        { "name": "@equaltoai/greater-components-icons", "version": "0.4.4" },
-        { "name": "@equaltoai/greater-components-primitives", "version": "0.4.4" },
-        { "name": "svelte", "version": "^5.53.12" }
+        {
+          "name": "@equaltoai/greater-components-headless",
+          "version": "0.4.4"
+        },
+        {
+          "name": "@equaltoai/greater-components-icons",
+          "version": "0.4.4"
+        },
+        {
+          "name": "@equaltoai/greater-components-primitives",
+          "version": "0.4.4"
+        },
+        {
+          "name": "svelte",
+          "version": "^5.53.12"
+        }
       ],
       "types": [
         "AdminStats",
@@ -8746,16 +9221,40 @@
         }
       ],
       "dependencies": [
-        { "name": "content", "version": "0.4.4" },
-        { "name": "icons", "version": "0.4.4" },
-        { "name": "primitives", "version": "0.4.4" }
+        {
+          "name": "content",
+          "version": "0.4.4"
+        },
+        {
+          "name": "icons",
+          "version": "0.4.4"
+        },
+        {
+          "name": "primitives",
+          "version": "0.4.4"
+        }
       ],
       "peerDependencies": [
-        { "name": "@equaltoai/greater-components-content", "version": "0.4.4" },
-        { "name": "@equaltoai/greater-components-headless", "version": "0.4.4" },
-        { "name": "@equaltoai/greater-components-icons", "version": "0.4.4" },
-        { "name": "@equaltoai/greater-components-primitives", "version": "0.4.4" },
-        { "name": "svelte", "version": "^5.53.12" }
+        {
+          "name": "@equaltoai/greater-components-content",
+          "version": "0.4.4"
+        },
+        {
+          "name": "@equaltoai/greater-components-headless",
+          "version": "0.4.4"
+        },
+        {
+          "name": "@equaltoai/greater-components-icons",
+          "version": "0.4.4"
+        },
+        {
+          "name": "@equaltoai/greater-components-primitives",
+          "version": "0.4.4"
+        },
+        {
+          "name": "svelte",
+          "version": "^5.53.12"
+        }
       ],
       "types": [
         "MessageRole",
@@ -8863,17 +9362,44 @@
         }
       ],
       "dependencies": [
-        { "name": "compose", "version": "0.4.4" },
-        { "name": "headless", "version": "0.4.4" },
-        { "name": "icons", "version": "0.4.4" },
-        { "name": "primitives", "version": "0.4.4" }
+        {
+          "name": "compose",
+          "version": "0.4.4"
+        },
+        {
+          "name": "headless",
+          "version": "0.4.4"
+        },
+        {
+          "name": "icons",
+          "version": "0.4.4"
+        },
+        {
+          "name": "primitives",
+          "version": "0.4.4"
+        }
       ],
       "peerDependencies": [
-        { "name": "@equaltoai/greater-components-compose", "version": "0.4.4" },
-        { "name": "@equaltoai/greater-components-headless", "version": "0.4.4" },
-        { "name": "@equaltoai/greater-components-icons", "version": "0.4.4" },
-        { "name": "@equaltoai/greater-components-primitives", "version": "0.4.4" },
-        { "name": "svelte", "version": "^5.53.12" }
+        {
+          "name": "@equaltoai/greater-components-compose",
+          "version": "0.4.4"
+        },
+        {
+          "name": "@equaltoai/greater-components-headless",
+          "version": "0.4.4"
+        },
+        {
+          "name": "@equaltoai/greater-components-icons",
+          "version": "0.4.4"
+        },
+        {
+          "name": "@equaltoai/greater-components-primitives",
+          "version": "0.4.4"
+        },
+        {
+          "name": "svelte",
+          "version": "^5.53.12"
+        }
       ],
       "types": [
         "MessageParticipant",
@@ -8936,15 +9462,36 @@
         }
       ],
       "dependencies": [
-        { "name": "adapters", "version": "0.4.4" },
-        { "name": "primitives", "version": "0.4.4" },
-        { "name": "utils", "version": "0.4.4" }
+        {
+          "name": "adapters",
+          "version": "0.4.4"
+        },
+        {
+          "name": "primitives",
+          "version": "0.4.4"
+        },
+        {
+          "name": "utils",
+          "version": "0.4.4"
+        }
       ],
       "peerDependencies": [
-        { "name": "@equaltoai/greater-components-adapters", "version": "0.4.4" },
-        { "name": "@equaltoai/greater-components-primitives", "version": "0.4.4" },
-        { "name": "@equaltoai/greater-components-utils", "version": "0.4.4" },
-        { "name": "svelte", "version": "^5.53.12" }
+        {
+          "name": "@equaltoai/greater-components-adapters",
+          "version": "0.4.4"
+        },
+        {
+          "name": "@equaltoai/greater-components-primitives",
+          "version": "0.4.4"
+        },
+        {
+          "name": "@equaltoai/greater-components-utils",
+          "version": "0.4.4"
+        },
+        {
+          "name": "svelte",
+          "version": "^5.53.12"
+        }
       ],
       "types": [
         "ContactRecommendation",


### PR DESCRIPTION
## Summary
- promote the premain adapter sync into main
- carry forward the Lesser and lesser-host contract updates and regenerated adapters
- regenerate `registry/index.json` on the main release line so the promotion merge stays release-consistent