### PR TITLE
fix: exclude umbrella package from registry deps

### DIFF
--- a/packages/cli/tests/face-installer.integration.test.ts
+++ b/packages/cli/tests/face-installer.integration.test.ts
@@ -1,6 +1,12 @@
+import fs from 'node:fs';
 import { describe, expect, it } from 'vitest';
 import { getFaceManifest, getFaceExports, getFaceSurfaces } from '../src/registry/faces.js';
 import { resolveFaceDependencies } from '../src/utils/face-installer.js';
+import type { RegistryIndex } from '../src/utils/registry-index.js';
+
+const registryIndex = JSON.parse(
+	fs.readFileSync(new URL('../../../registry/index.json', import.meta.url), 'utf8')
+) as RegistryIndex;
 
 describe('agent face dependency resolution', () => {
 	it('keeps exported agent compositions as face surfaces instead of installable components', () => {
@@ -50,4 +56,22 @@ describe('agent face dependency resolution', () => {
 			])
 		);
 	});
+
+	it.each(['social', 'blog', 'artist'] as const)(
+		'keeps %s registry dependencies limited to vendorable workspace packages',
+		(faceName) => {
+			const faceEntry = registryIndex.faces[faceName];
+
+			expect(faceEntry).toBeDefined();
+			expect(faceEntry?.dependencies.map((dependency) => dependency.name)).not.toContain(
+				'@equaltoai/greater-components'
+			);
+
+			const resolution = resolveFaceDependencies(faceName, { registryIndex });
+
+			expect(resolution).not.toBeNull();
+			expect(resolution?.success).toBe(true);
+			expect(resolution?.missing).toEqual([]);
+		}
+	);
 });

--- a/registry/index.json
+++ b/registry/index.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://equalto.ai/schemas/registry-index.schema.json",
   "schemaVersion": "1.0.0",
-  "generatedAt": "2026-03-28T20:31:22.685Z",
+  "generatedAt": "2026-03-28T21:27:55.042Z",
   "ref": "greater-v0.5.8-rc.1",
   "version": "0.5.8-rc.1",
   "checksums": {
@@ -6637,7 +6637,6 @@
         "tokens": "@equaltoai/greater-components/tokens/theme.css"
       },
       "dependencies": [
-        { "name": "@equaltoai/greater-components", "version": "latest" },
         { "name": "adapters", "version": "0.5.8-rc.1" },
         { "name": "admin", "version": "0.5.8-rc.1" },
         { "name": "auth", "version": "0.5.8-rc.1" },
@@ -6946,7 +6945,6 @@
         "tokens": "@equaltoai/greater-components/tokens/theme.css"
       },
       "dependencies": [
-        { "name": "@equaltoai/greater-components", "version": "latest" },
         { "name": "content", "version": "0.5.8-rc.1" },
         { "name": "headless", "version": "0.5.8-rc.1" },
         { "name": "icons", "version": "0.5.8-rc.1" },
@@ -8115,7 +8113,6 @@
         "tokens": "@equaltoai/greater-components/tokens/theme.css"
       },
       "dependencies": [
-        { "name": "@equaltoai/greater-components", "version": "latest" },
         { "name": "adapters", "version": "0.5.8-rc.1" },
         { "name": "headless", "version": "0.5.8-rc.1" },
         { "name": "icons", "version": "0.5.8-rc.1" },
@@ -8189,18 +8186,7 @@
       ],
       "includes": {
         "primitives": [],
-        "shared": [
-          "shared/agent",
-          "shared/chat",
-          "shared/messaging",
-          "shared/notifications",
-          "shared/soul",
-          "agent",
-          "chat",
-          "messaging",
-          "notifications",
-          "soul"
-        ],
+        "shared": ["agent", "chat", "messaging", "notifications", "soul"],
         "patterns": [],
         "components": []
       },
@@ -8265,12 +8251,7 @@
         { "name": "chat", "version": "0.5.8-rc.1" },
         { "name": "messaging", "version": "0.5.8-rc.1" },
         { "name": "notifications", "version": "0.5.8-rc.1" },
-        { "name": "soul", "version": "0.5.8-rc.1" },
-        { "name": "shared/agent", "version": "latest" },
-        { "name": "shared/chat", "version": "latest" },
-        { "name": "shared/messaging", "version": "latest" },
-        { "name": "shared/notifications", "version": "latest" },
-        { "name": "shared/soul", "version": "latest" }
+        { "name": "soul", "version": "0.5.8-rc.1" }
       ],
       "peerDependencies": [
         { "name": "@equaltoai/greater-components-agent", "version": "0.5.8-rc.1" },

--- a/scripts/generate-registry-index.js
+++ b/scripts/generate-registry-index.js
@@ -525,6 +525,13 @@ function mapDependencies(depNames, packageJson, workspaceVersions) {
 	}));
 }
 
+function getWorkspaceInternalDependencies(depNames, packageJson, workspaceVersions) {
+	return Array.from(new Set(depNames))
+		.filter((dep) => dep.startsWith('@equaltoai/greater-components'))
+		.filter((dep) => dep !== packageJson.name)
+		.filter((dep) => Boolean(workspaceVersions?.[dep]));
+}
+
 /**
  * Process a package and extract component metadata
  */
@@ -544,8 +551,10 @@ function processPackage(packageName, config, verbose, workspaceVersions) {
 	const detectedDeps = analyzeDependencies(path.join(packageDir, config.srcDir), config.extensions);
 
 	// Filter for internal dependencies (Greater components)
-	const internalDeps = detectedDeps.filter(
-		(dep) => dep.startsWith('@equaltoai/greater-components') && dep !== packageJson.name
+	const internalDeps = getWorkspaceInternalDependencies(
+		detectedDeps,
+		packageJson,
+		workspaceVersions
 	);
 
 	// Filter for external dependencies (everything else)
@@ -617,13 +626,17 @@ function processFace(faceName, verbose, workspaceVersions) {
 	]);
 
 	// Internal dependencies often come from manifest, but we can verify with detected ones
-	const internalDeps = new Set([
-		...(manifest.dependencies?.internal || []),
-		...detectedDeps.filter((dep) => dep.startsWith('@equaltoai/greater-components')),
-	]);
+	const internalDeps = getWorkspaceInternalDependencies(
+		[
+			...(manifest.dependencies?.internal || []),
+			...detectedDeps.filter((dep) => dep.startsWith('@equaltoai/greater-components')),
+		],
+		packageJson,
+		workspaceVersions
+	);
 
 	// Filter self-dependency if packageJson has name
-	const filteredInternalDeps = Array.from(internalDeps).filter((dep) => dep !== packageJson.name);
+	const filteredInternalDeps = Array.from(internalDeps);
 	const exportedMembers = getManifestExports(manifest);
 
 	return {
@@ -694,13 +707,17 @@ function processSharedModule(moduleName, verbose, workspaceVersions) {
 		...detectedDeps.filter((dep) => !dep.startsWith('@equaltoai/greater-components')),
 	]);
 
-	const internalDeps = new Set([
-		...(manifest.dependencies?.internal || []),
-		...detectedDeps.filter((dep) => dep.startsWith('@equaltoai/greater-components')),
-	]);
+	const internalDeps = getWorkspaceInternalDependencies(
+		[
+			...(manifest.dependencies?.internal || []),
+			...detectedDeps.filter((dep) => dep.startsWith('@equaltoai/greater-components')),
+		],
+		packageJson,
+		workspaceVersions
+	);
 
 	// Filter self-dependency
-	const filteredInternalDeps = Array.from(internalDeps).filter((dep) => dep !== packageJson.name);
+	const filteredInternalDeps = Array.from(internalDeps);
 
 	return {
 		name: moduleName,


### PR DESCRIPTION
## Summary
- harden registry generation so only real vendorable workspace packages become internal registry dependencies
- remove leaked `@equaltoai/greater-components` face dependencies from the generated registry
- add a regression test that exercises `resolveFaceDependencies(..., { registryIndex })` for the affected faces

## Verification
- `corepack pnpm generate-registry`
- `corepack pnpm --filter @equaltoai/greater-components-cli exec vitest run tests/face-installer.integration.test.ts`
- `corepack pnpm --filter @equaltoai/greater-components-cli exec vitest run tests/e2e/smoke.test.ts`
- `corepack pnpm --filter @equaltoai/greater-components-cli typecheck`
- `corepack pnpm validate:registry`
- `corepack pnpm format:check`
- `corepack pnpm lint`
- promotion rehearsal stayed clean for `candidate -> staging -> premain -> main`

## Context
This fixes the prerelease failure seen in GitHub Actions run `23694565702`, where `greater add faces/social|blog|artist` failed because the generated registry incorrectly emitted `@equaltoai/greater-components` as a vendorable internal dependency.