### PR TITLE
fix: preserve binary assets during greater update

### DIFF
--- a/packages/cli/src/commands/update.ts
+++ b/packages/cli/src/commands/update.ts
@@ -22,7 +22,7 @@ import {
 import { resolveRef } from '../utils/registry-index.js';
 import { getComponent } from '../registry/index.js';
 import { fetchComponentFiles, type FetchOptions } from '../utils/fetch.js';
-import { readFile, writeFile, fileExists } from '../utils/files.js';
+import { readFile, readFileBuffer, writeFile, fileExists } from '../utils/files.js';
 import { computeDiff, formatDiffStats, type DiffResult } from '../utils/diff.js';
 
 import { transformImports } from '../utils/transform.js';
@@ -136,6 +136,22 @@ function displayConflictDiff(diff: DiffResult): void {
 	logger.info('\n' + coloredLines.join('\n') + '\n');
 }
 
+function createBinaryDiffResult(filePath: string, identical: boolean): DiffResult {
+	return {
+		identical,
+		isBinary: true,
+		hunks: [],
+		stats: identical
+			? { additions: 0, deletions: 0, unchanged: 1, totalLines: 1 }
+			: { additions: 1, deletions: 1, unchanged: 0, totalLines: 2 },
+		unifiedDiff: identical
+			? ''
+			: filePath
+				? `Binary files a/${filePath} and b/${filePath} differ`
+				: 'Binary files differ',
+	};
+}
+
 /**
  * Update a single component
  */
@@ -195,6 +211,9 @@ async function updateComponent(
 	for (const file of remoteFiles) {
 		const localPath = getInstalledFilePath(file.path, config, cwd);
 		const remoteContent = file.content;
+		const remoteRaw = file.raw;
+		const isBinaryFile = !!remoteRaw;
+		const shouldBypassTransform = file.transform === false;
 
 		const status: FileUpdateStatus = {
 			filePath: file.path,
@@ -207,11 +226,12 @@ async function updateComponent(
 
 		if (localExists) {
 			try {
-				const localContent = await readFile(localPath);
-				const diff = computeDiff(localContent, remoteContent, {
-					filePath: file.path,
-					contextLines: 3,
-				});
+				const diff = isBinaryFile
+					? createBinaryDiffResult(file.path, (await readFileBuffer(localPath)).equals(remoteRaw))
+					: computeDiff(await readFile(localPath), remoteContent, {
+							filePath: file.path,
+							contextLines: 3,
+						});
 
 				status.diff = diff;
 
@@ -266,8 +286,14 @@ async function updateComponent(
 
 				// Apply transformation and write file
 				if (!options.dryRun) {
-					const transformed = transformImports(remoteContent, config, file.path);
-					await writeFile(localPath, transformed.content);
+					if (isBinaryFile) {
+						await writeFile(localPath, remoteRaw);
+					} else if (shouldBypassTransform) {
+						await writeFile(localPath, remoteContent);
+					} else {
+						const transformed = transformImports(remoteContent, config, file.path);
+						await writeFile(localPath, transformed.content);
+					}
 				}
 
 				status.status = 'updated';
@@ -281,8 +307,14 @@ async function updateComponent(
 
 			if (!options.dryRun) {
 				try {
-					const transformed = transformImports(remoteContent, config, file.path);
-					await writeFile(localPath, transformed.content);
+					if (isBinaryFile) {
+						await writeFile(localPath, remoteRaw);
+					} else if (shouldBypassTransform) {
+						await writeFile(localPath, remoteContent);
+					} else {
+						const transformed = transformImports(remoteContent, config, file.path);
+						await writeFile(localPath, transformed.content);
+					}
 				} catch (error) {
 					status.status = 'error';
 					status.error = error instanceof Error ? error.message : String(error);

--- a/packages/cli/src/utils/files.ts
+++ b/packages/cli/src/utils/files.ts
@@ -38,6 +38,13 @@ export async function readFile(filePath: string): Promise<string> {
 }
 
 /**
+ * Read file as raw bytes
+ */
+export async function readFileBuffer(filePath: string): Promise<Buffer> {
+	return fs.readFile(filePath);
+}
+
+/**
  * Check if file exists
  */
 export async function fileExists(filePath: string): Promise<boolean> {

--- a/packages/cli/tests/update.unit.test.ts
+++ b/packages/cli/tests/update.unit.test.ts
@@ -102,6 +102,10 @@ vi.mock('../src/utils/install-path.js', () => ({
 // We mock files.js to verify calls and simulate errors
 vi.mock('../src/utils/files.js', () => ({
 	readFile: vi.fn(async (p) => mockFs.createFsMock().readFile(p)),
+	readFileBuffer: vi.fn(async (p) => {
+		const content = await mockFs.createFsMock().readFile(p);
+		return Buffer.isBuffer(content) ? content : Buffer.from(content, 'utf-8');
+	}),
 	writeFile: vi.fn(async (p, c) => mockFs.createFsMock().writeFile(p, c)),
 	fileExists: vi.fn(async (p) => mockFs.createFsMock().pathExists(p)),
 }));
@@ -218,6 +222,55 @@ describe('Update Command', () => {
 			);
 			expect(mockFs.get('/src/lib/greater/adapters/soul/index.ts')).toContain(
 				'SoulAgentChannelPreferencesRequest'
+			);
+		});
+
+		it('preserves binary assets when updating core packages', async () => {
+			const config = createTestConfig({
+				installed: [createInstalledComponent('primitives')],
+			});
+			mockFs.set('/components.json', JSON.stringify(config));
+			mockFs.set('/src/lib/greater/primitives/assets/greater-default-profile.png', 'old-bytes');
+
+			const avatarBytes = Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]);
+
+			const { getComponent } = await import('../src/registry/index.js');
+			vi.mocked(getComponent).mockReturnValueOnce(
+				createTestComponentMetadata('primitives', {
+					type: 'shared',
+					files: [
+						{
+							path: 'greater/primitives/assets/greater-default-profile.png',
+							content: '',
+							type: 'styles',
+							transform: false,
+						},
+					],
+					tags: ['core', 'primitives'],
+				})
+			);
+
+			const { fetchComponentFiles } = await import('../src/utils/fetch.js');
+			vi.mocked(fetchComponentFiles).mockResolvedValueOnce({
+				files: [
+					{
+						path: 'greater/primitives/assets/greater-default-profile.png',
+						content: '',
+						raw: avatarBytes,
+						type: 'styles',
+						transform: false,
+					},
+				],
+				ref: 'greater-v0.6.0',
+			});
+
+			const { updateAction } = await import('../src/commands/update.js');
+			await updateAction(['primitives'], { cwd: '/', yes: true, force: true });
+
+			const { writeFile } = await import('../src/utils/files.js');
+			expect(writeFile).toHaveBeenCalledWith(
+				expect.stringContaining('greater-default-profile.png'),
+				avatarBytes
 			);
 		});
 


### PR DESCRIPTION
## Summary
- preserve binary asset bytes during `greater update` instead of rewriting the empty text placeholder for raw files
- add a raw-byte file reader and binary update handling for non-transforming assets
- cover the default avatar PNG regression in the CLI update tests

## Verification
- `corepack pnpm --filter @equaltoai/greater-components-cli exec vitest run tests/update.unit.test.ts tests/update.integration.test.ts`
- `corepack pnpm --filter @equaltoai/greater-components-cli typecheck`
- `corepack pnpm --filter @equaltoai/greater-components-cli build`
- `corepack pnpm lint`
- real repro: temp vendored project + `greater update primitives --force` kept `greater-default-profile.png` at `1539338` bytes with a valid PNG header
- merge rehearsal: `HEAD -> staging`, `HEAD -> premain`, `HEAD -> main`, `staging -> premain`, and `premain -> main` all clean
