### PR TITLE
fix: harden vendored face export transforms

### DIFF
--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -53,7 +53,20 @@ const AVAILABLE_FACES = [
 		value: 'artist',
 		description: 'Visual artist portfolios and gallery platforms',
 	},
+	{
+		title: 'Agent',
+		value: 'agent',
+		description: 'Agent workflow shells and lifecycle-driven workspace UI',
+	},
 ] as const;
+
+const AVAILABLE_FACE_VALUES = AVAILABLE_FACES.map((face) => face.value).filter(
+	(face): face is Exclude<(typeof AVAILABLE_FACES)[number]['value'], null> => face !== null
+);
+
+function isAvailableFace(face: string): face is (typeof AVAILABLE_FACE_VALUES)[number] {
+	return AVAILABLE_FACE_VALUES.includes(face as (typeof AVAILABLE_FACE_VALUES)[number]);
+}
 
 /**
  * Format project type for display
@@ -260,9 +273,9 @@ export const initAction = async (options: {
 
 	// Validate face option if provided
 	let selectedFace: string | null = options.face || null;
-	if (selectedFace && !['social', 'blog', 'community', 'artist'].includes(selectedFace)) {
+	if (selectedFace && !isAvailableFace(selectedFace)) {
 		logger.error(chalk.red(`\n✖ Invalid face: ${selectedFace}`));
-		logger.note(chalk.dim('  Available faces: social, blog, community, artist\n'));
+		logger.note(chalk.dim(`  Available faces: ${AVAILABLE_FACE_VALUES.join(', ')}\n`));
 		process.exit(1);
 	}
 
@@ -548,5 +561,5 @@ export const initCommand = new Command()
 	.option('--cwd <path>', 'Working directory (default: current directory)')
 	.option('--ref <tag>', 'Pin to a specific version tag (default: latest stable)')
 	.option('--skip-css', 'Skip automatic CSS injection')
-	.option('--face <name>', 'Pre-select a face (social, blog, community, artist)')
+	.option('--face <name>', `Pre-select a face (${AVAILABLE_FACE_VALUES.join(', ')})`)
 	.action(initAction);

--- a/packages/cli/src/utils/transform.ts
+++ b/packages/cli/src/utils/transform.ts
@@ -57,6 +57,7 @@ const LEGACY_PACKAGE_REWRITES: Record<string, string> = {
 const SHARED_MODULES = [
 	'auth',
 	'admin',
+	'agent',
 	'compose',
 	'messaging',
 	'search',
@@ -430,7 +431,7 @@ export function transformImports(
 	// Detect file type from extension or content
 	const ext = filePath?.split('.').pop()?.toLowerCase();
 
-	if (ext === 'svelte' || content.includes('<script')) {
+	if (ext === 'svelte') {
 		return transformSvelteImports(content, config);
 	}
 
@@ -438,7 +439,17 @@ export function transformImports(
 		return transformCssFileImports(content, config);
 	}
 
-	// Default to TypeScript/JavaScript handling
+	// Trust explicit file extensions before content sniffing so JSDoc examples like
+	// `<script>` inside .ts files do not get misclassified as Svelte.
+	if (ext) {
+		return transformTypeScriptImports(content, config);
+	}
+
+	if (content.includes('<script')) {
+		return transformSvelteImports(content, config);
+	}
+
+	// Default to TypeScript/JavaScript handling for extensionless text files.
 	return transformTypeScriptImports(content, config);
 }
 

--- a/packages/cli/tests/e2e/smoke.test.ts
+++ b/packages/cli/tests/e2e/smoke.test.ts
@@ -29,8 +29,8 @@ const FACE_CASES = [
 	{
 		face: 'social',
 		componentFile: 'src/lib/components/Status/Root.svelte',
-		componentImport: '$lib/components/Status/Root.svelte',
 		componentName: 'StatusRoot',
+		componentImportLine: `import StatusRoot from '$lib/components/Status/Root.svelte';`,
 		extraChecks: async (fixtureRoot: string) => {
 			expect(await fs.pathExists(path.join(fixtureRoot, 'src/lib/generics/index.ts'))).toBe(true);
 		},
@@ -38,22 +38,29 @@ const FACE_CASES = [
 	{
 		face: 'blog',
 		componentFile: 'src/lib/components/Article/Root.svelte',
-		componentImport: '$lib/components/Article/Root.svelte',
 		componentName: 'ArticleRoot',
+		componentImportLine: `import ArticleRoot from '$lib/components/Article/Root.svelte';`,
 		extraChecks: async () => {},
 	},
 	{
 		face: 'community',
 		componentFile: 'src/lib/components/Thread/Root.svelte',
-		componentImport: '$lib/components/Thread/Root.svelte',
 		componentName: 'ThreadRoot',
+		componentImportLine: `import ThreadRoot from '$lib/components/Thread/Root.svelte';`,
 		extraChecks: async () => {},
 	},
 	{
 		face: 'artist',
 		componentFile: 'src/lib/components/Artwork/Root.svelte',
-		componentImport: '$lib/components/Artwork/Root.svelte',
 		componentName: 'ArtworkRoot',
+		componentImportLine: `import ArtworkRoot from '$lib/components/Artwork/Root.svelte';`,
+		extraChecks: async () => {},
+	},
+	{
+		face: 'agent',
+		componentFile: 'src/lib/greater/faces/agent/AgentGenesisWorkspace.svelte',
+		componentName: 'AgentGenesisWorkspace',
+		componentImportLine: `import { AgentGenesisWorkspace } from '$lib/greater/faces/agent';`,
 		extraChecks: async () => {},
 	},
 ] as const;
@@ -66,7 +73,7 @@ beforeAll(async () => {
 
 test.each(FACE_CASES)(
 	'CLI Smoke Test: Init, Add, Build ($face face)',
-	async ({ face, componentFile, componentImport, componentName, extraChecks }) => {
+	async ({ face, componentFile, componentImportLine, componentName, extraChecks }) => {
 		await fs.ensureDir(TMP_ROOT);
 		const fixtureRoot = await fs.mkdtemp(path.join(TMP_ROOT, 'cli-fixture-'));
 
@@ -119,7 +126,7 @@ test.each(FACE_CASES)(
 			await fs.writeFile(
 				path.join(fixtureRoot, 'src/routes/+page.svelte'),
 				`<script lang="ts">
-\timport ${componentName} from '${componentImport}';
+\t${componentImportLine}
 \timport { createButton } from '$lib/greater/headless/button';
 
 \tconst button = createButton();

--- a/packages/cli/tests/transform.test.ts
+++ b/packages/cli/tests/transform.test.ts
@@ -99,6 +99,9 @@ describe('transformPath (vendored mode)', () => {
 		expect(transformPath('@equaltoai/greater-components-auth', mappings)).toBe(
 			'$lib/components/auth'
 		);
+		expect(transformPath('@equaltoai/greater-components-agent', mappings)).toBe(
+			'$lib/components/agent'
+		);
 	});
 
 	it('rewrites core package imports to greater alias', () => {
@@ -344,6 +347,24 @@ describe('transformImports (auto-detection)', () => {
 		const result = transformImports(content, config);
 
 		expect(result.hasChanges).toBe(true);
+	});
+
+	it('trusts TypeScript extensions even when comments include <script> examples', () => {
+		const content = `/**
+ * @example
+ * \`\`\`svelte
+ * <script>
+ *   import { createGalleryStore } from '@equaltoai/greater-components-artist/subscriptions';
+ * </script>
+ * \`\`\`
+ */
+import type { LesserGraphQLAdapter } from '@equaltoai/greater-components-adapters';
+`;
+
+		const result = transformImports(content, config, 'subscriptions/index.ts');
+
+		expect(result.transformedCount).toBe(1);
+		expect(result.content).toContain("from '$lib/greater/adapters'");
 	});
 });
 


### PR DESCRIPTION
## Summary
- fix vendored import rewriting for text files that contain JSDoc `<script>` examples
- add missing `shared/agent` vendored rewrite coverage and sync `init --face` with the real face catalog
- extend the CLI smoke matrix so social, blog, community, artist, and agent faces all go through init/add/build verification

## Verification
- corepack pnpm --filter @equaltoai/greater-components-cli exec vitest run tests/e2e/smoke.test.ts
- corepack pnpm --filter @equaltoai/greater-components-cli test
- corepack pnpm --filter @equaltoai/greater-components-cli typecheck
- corepack pnpm lint
- corepack pnpm format:check

## Promotion
- rehearsed clean merge path from this branch to `premain` with no merge-tree conflicts detected