### PR TITLE
fix: remediate Greater security project 28 findings

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -51,7 +51,11 @@ jobs:
             exit 1
           fi
 
+          pnpm audit:tarball-integrity
           pnpm install --frozen-lockfile
+
+          VERSION="$(node -p "require('./package.json').version")"
+          node scripts/prepare-github-release.js "${VERSION}"
 
           # Immutable releases block asset/notes changes after publication.
           # We only support mutating draft releases (or creating a draft release) here.
@@ -130,11 +134,19 @@ jobs:
 
       - name: Install dependencies
         if: steps.release.outputs.release_created == 'true'
-        run: pnpm install --frozen-lockfile
+        run: |
+          pnpm audit:tarball-integrity
+          pnpm install --frozen-lockfile
 
       - name: Fetch main + premain (release branch verification)
         if: steps.release.outputs.release_created == 'true'
         run: git fetch origin main premain --force
+
+      - name: Prepare immutable registry metadata
+        if: steps.release.outputs.release_created == 'true'
+        run: |
+          VERSION="$(node -p "require('./package.json').version")"
+          node scripts/prepare-github-release.js "${VERSION}"
 
       - name: Verify tag was cut from the correct branch
         if: steps.release.outputs.release_created == 'true'

--- a/docs/lesser/contracts/README.md
+++ b/docs/lesser/contracts/README.md
@@ -30,6 +30,12 @@ Client generation guidance:
 
 - `docs/specs/openapi-client-generation.md`
 
+Security/auth metadata guidance:
+
+- Treat missing or incorrect auth/security metadata in these snapshots as an upstream Lesser contract issue.
+- Do not hand-edit `openapi.yaml` in Greater to add auth requirements; fix the Lesser route contract, publish a Lesser
+  release tag, then resync this directory from that tag so the pinned snapshot remains auditable.
+
 ## GraphQL (Published schema)
 
 - Published contract: `docs/contracts/graphql-schema.graphql`

--- a/package.json
+++ b/package.json
@@ -68,7 +68,8 @@
     "release:cut": "node scripts/cut-github-release.js",
     "release:tag": "node scripts/release-tag.js",
     "release:artifacts": "bash scripts/build-release-artifacts.sh",
-    "release:tag:dry": "node scripts/release-tag.js --dry-run"
+    "release:tag:dry": "node scripts/release-tag.js --dry-run",
+    "audit:tarball-integrity": "node scripts/verify-tarball-integrity.js"
   },
   "devDependencies": {
     "@changesets/cli": "^2.30.0",
@@ -138,6 +139,12 @@
       "tmp": "^0.2.4",
       "workbox-build": "^7.4.0",
       "yaml@^2.0.0": "^2.8.3"
+    }
+  },
+  "greaterVerifiedTarballs": {
+    "@theory-cloud/facetheory": {
+      "url": "https://github.com/theory-cloud/FaceTheory/releases/download/v2.0.0/theory-cloud-facetheory-2.0.0.tgz",
+      "integrity": "sha512-+fYcw0uCZZZZMg2m+uWwEFSjhIuL91dCOqgQ5QGI7jNpqKxOZxoKcKSYO9Y0P+rGnCzNiiI73tGjw8oVKa4RCg=="
     }
   }
 }

--- a/packages/adapters/src/graphql/LesserGraphQLAdapter.ts
+++ b/packages/adapters/src/graphql/LesserGraphQLAdapter.ts
@@ -503,7 +503,61 @@ function createUserSafeAdapterError(
 	cause: unknown,
 	debugMessages: readonly string[] = extractDebugMessages(cause)
 ): LesserGraphQLAdapterError {
-	return new LesserGraphQLAdapterError(message, { cause, debugMessages });
+	return new LesserGraphQLAdapterError(message, {
+		cause: createSanitizedAdapterCause(cause),
+		debugMessages,
+	});
+}
+
+function createSanitizedAdapterCause(cause: unknown): Record<string, unknown> {
+	const sanitized: Record<string, unknown> = {
+		code: 'LESSER_GRAPHQL_REQUEST_FAILED',
+	};
+
+	if (cause instanceof Error) {
+		sanitized['kind'] = 'error';
+		sanitized['name'] = cause.name || 'Error';
+		return sanitized;
+	}
+
+	if (cause && typeof cause === 'object') {
+		const result = cause as {
+			data?: unknown;
+			errors?: unknown[];
+			error?: unknown;
+			graphQLErrors?: unknown[];
+			networkError?: {
+				result?: { errors?: unknown[] };
+			};
+		};
+
+		sanitized['kind'] = 'graphql-result';
+
+		if (Array.isArray(result.errors)) {
+			sanitized['errorCount'] = result.errors.length;
+		}
+
+		if (Array.isArray(result.graphQLErrors)) {
+			sanitized['graphQLErrorCount'] = result.graphQLErrors.length;
+		}
+
+		if (Array.isArray(result.networkError?.result?.errors)) {
+			sanitized['networkErrorCount'] = result.networkError.result.errors.length;
+		}
+
+		if (result.error) {
+			sanitized['hasTransportError'] = true;
+		}
+
+		if ('data' in result) {
+			sanitized['hadPartialData'] = result.data != null;
+		}
+
+		return sanitized;
+	}
+
+	sanitized['kind'] = typeof cause;
+	return sanitized;
 }
 
 export class LesserGraphQLAdapter {

--- a/packages/adapters/src/graphql/__tests__/LesserGraphQLAdapter.test.ts
+++ b/packages/adapters/src/graphql/__tests__/LesserGraphQLAdapter.test.ts
@@ -249,7 +249,7 @@ describe('LesserGraphQLAdapter', () => {
 
 		it('normalizes resolved GraphQL mutation errors before returning partial data', async () => {
 			mockApolloClient.mutate.mockResolvedValue({
-				data: { createNote: { id: 'partial-note' } },
+				data: { createNote: { id: 'partial-note', accessToken: 'secret-token' } },
 				errors: [{ message: 'authorization denied for actor_private_acl' }],
 			});
 
@@ -260,6 +260,29 @@ describe('LesserGraphQLAdapter', () => {
 			await expect(adapter.createNote({ content: 'test' } as any)).rejects.toBeInstanceOf(
 				LesserGraphQLAdapterError
 			);
+		});
+
+		it('does not expose partial mutation data through the public error cause', async () => {
+			mockApolloClient.mutate.mockResolvedValue({
+				data: { createNote: { id: 'partial-note', accessToken: 'secret-token' } },
+				errors: [{ message: 'authorization denied for actor_private_acl' }],
+			});
+
+			try {
+				await adapter.createNote({ content: 'test' } as any);
+				throw new Error('Expected mutation to fail');
+			} catch (error) {
+				expect(error).toBeInstanceOf(LesserGraphQLAdapterError);
+				const adapterError = error as LesserGraphQLAdapterError;
+				expect(adapterError.cause).toEqual({
+					code: 'LESSER_GRAPHQL_REQUEST_FAILED',
+					errorCount: 1,
+					hadPartialData: true,
+					kind: 'graphql-result',
+				});
+				expect(JSON.stringify(adapterError.cause)).not.toContain('partial-note');
+				expect(JSON.stringify(adapterError.cause)).not.toContain('secret-token');
+			}
 		});
 
 		it('normalizes resolved GraphQL mutation transport errors', async () => {

--- a/packages/cli/src/utils/registry-index.ts
+++ b/packages/cli/src/utils/registry-index.ts
@@ -120,6 +120,10 @@ export const registryIndexSchema = z.object({
 	schemaVersion: z.string().optional().default('1.0.0'),
 	version: z.string(),
 	ref: z.string(),
+	commit: z
+		.string()
+		.regex(/^[0-9a-f]{40}$/i, 'Invalid commit SHA')
+		.optional(),
 	generatedAt: z.string().datetime(),
 	checksums: z.record(z.string(), z.string()).optional().default({}),
 	components: z.record(z.string(), registryComponentSchema),
@@ -135,6 +139,10 @@ export type RegistryIndex = z.infer<typeof registryIndexSchema>;
 export const latestRefSchema = z.object({
 	ref: z.string(),
 	version: z.string(),
+	commit: z
+		.string()
+		.regex(/^[0-9a-f]{40}$/i, 'Invalid commit SHA')
+		.optional(),
 	updatedAt: z.string().optional(),
 });
 
@@ -142,6 +150,10 @@ export type LatestRef = z.infer<typeof latestRefSchema>;
 
 function isLatestAlias(ref?: string): boolean {
 	return (ref ?? '').trim().toLowerCase() === 'latest';
+}
+
+function isImmutableCommit(ref?: string): ref is string {
+	return /^[0-9a-f]{40}$/i.test((ref ?? '').trim());
 }
 
 /**
@@ -570,6 +582,9 @@ export async function resolveRef(
 	// Priority 3: Latest stable from registry/latest.json
 	try {
 		const latest = await fetchLatestRef();
+		if (isImmutableCommit(latest?.commit)) {
+			return { ref: latest.commit, source: 'latest' };
+		}
 		if (latest?.ref) {
 			return { ref: latest.ref, source: 'latest' };
 		}

--- a/packages/cli/src/utils/transform.ts
+++ b/packages/cli/src/utils/transform.ts
@@ -250,17 +250,92 @@ function transformImportPath(
  */
 const IMPORT_PATTERNS = {
 	// ES module imports: import { x } from 'path' or import x from 'path'
-	// Simplified to avoid nested quantifiers - matches import ... from 'path'
-	esImport: /import\s+[^'"]+from\s*(['"])([^'"]+)\1/g,
+	// Statement imports are anchored to statement starts so comment prose such as
+	// "Re-export ..." cannot consume the following executable import/export.
+	esImport: /(?:^|[;\n\r])\s*import\s+[^'"]+?from\s*(['"])([^'"]+)\1/g,
 	// Side-effect imports: import 'path'
-	sideEffectImport: /import\s*(['"])([^'"]+)\1/g,
+	sideEffectImport: /(?:^|[;\n\r])\s*import\s*(['"])([^'"]+)\1/g,
 	// Dynamic imports: import('path') or import("path")
-	dynamicImport: /import\s*\(\s*(['"])([^'"]+)\1\s*\)/g,
+	dynamicImport: /(?<![\w$])import\s*\(\s*(['"])([^'"]+)\1\s*\)/g,
 	// Re-exports: export { x } from 'path' or export * from 'path'
-	reExport: /export\s+[^'"]+from\s*(['"])([^'"]+)\1/g,
+	reExport: /(?:^|[;\n\r])\s*export\s+[^'"]+?from\s*(['"])([^'"]+)\1/g,
 	// CSS @import: @import 'path' or @import url('path')
 	cssImport: /@import\s+(?:url\s*\(\s*)?(['"])([^'"]+)\1(?:\s*\))?/g,
 };
+
+function isExecutableScriptMatch(content: string, offset: number): boolean {
+	let state: StripState = 'normal';
+	let escaped = false;
+
+	for (let i = 0; i < offset; i++) {
+		const char = content[i] ?? '';
+		const next = content[i + 1] ?? '';
+
+		if (state === 'line-comment') {
+			if (char === '\n') {
+				state = 'normal';
+			}
+			continue;
+		}
+
+		if (state === 'block-comment') {
+			if (char === '*' && next === '/') {
+				state = 'normal';
+				i++;
+			}
+			continue;
+		}
+
+		if (state === 'single' || state === 'double' || state === 'template') {
+			if (escaped) {
+				escaped = false;
+				continue;
+			}
+
+			if (char === '\\') {
+				escaped = true;
+				continue;
+			}
+
+			if (
+				(state === 'single' && char === "'") ||
+				(state === 'double' && char === '"') ||
+				(state === 'template' && char === '`')
+			) {
+				state = 'normal';
+			}
+			continue;
+		}
+
+		if (char === '/' && next === '/') {
+			state = 'line-comment';
+			i++;
+			continue;
+		}
+
+		if (char === '/' && next === '*') {
+			state = 'block-comment';
+			i++;
+			continue;
+		}
+
+		if (char === "'") {
+			state = 'single';
+			continue;
+		}
+
+		if (char === '"') {
+			state = 'double';
+			continue;
+		}
+
+		if (char === '`') {
+			state = 'template';
+		}
+	}
+
+	return state === 'normal';
+}
 
 /**
  * Transform imports in TypeScript/JavaScript content
@@ -275,9 +350,33 @@ function transformScriptImports(
 	const transformedPaths: Array<{ from: string; to: string }> = [];
 
 	// Process ES imports
+	const beforeEsImports = transformedContent;
 	transformedContent = transformedContent.replace(
 		IMPORT_PATTERNS.esImport,
-		(match, _quote, importPath) => {
+		(match, _quote, importPath, offset) => {
+			const statementOffset = offset + match.search(/\bimport\b/);
+			if (!isExecutableScriptMatch(beforeEsImports, statementOffset)) {
+				return match;
+			}
+			const newPath = transformImportPath(importPath, mappings, filePath);
+			if (newPath) {
+				transformedCount++;
+				transformedPaths.push({ from: importPath, to: newPath });
+				return match.replace(importPath, newPath);
+			}
+			return match;
+		}
+	);
+
+	// Process side-effect imports
+	const beforeSideEffectImports = transformedContent;
+	transformedContent = transformedContent.replace(
+		IMPORT_PATTERNS.sideEffectImport,
+		(match, _quote, importPath, offset) => {
+			const statementOffset = offset + match.search(/\bimport\b/);
+			if (!isExecutableScriptMatch(beforeSideEffectImports, statementOffset)) {
+				return match;
+			}
 			const newPath = transformImportPath(importPath, mappings, filePath);
 			if (newPath) {
 				transformedCount++;
@@ -289,9 +388,14 @@ function transformScriptImports(
 	);
 
 	// Process dynamic imports
+	const beforeDynamicImports = transformedContent;
 	transformedContent = transformedContent.replace(
 		IMPORT_PATTERNS.dynamicImport,
-		(match, _quote, importPath) => {
+		(match, _quote, importPath, offset) => {
+			const statementOffset = offset + match.search(/\bimport\b/);
+			if (!isExecutableScriptMatch(beforeDynamicImports, statementOffset)) {
+				return match;
+			}
 			const newPath = transformImportPath(importPath, mappings, filePath);
 			if (newPath) {
 				transformedCount++;
@@ -303,9 +407,14 @@ function transformScriptImports(
 	);
 
 	// Process re-exports
+	const beforeReExports = transformedContent;
 	transformedContent = transformedContent.replace(
 		IMPORT_PATTERNS.reExport,
-		(match, _quote, importPath) => {
+		(match, _quote, importPath, offset) => {
+			const statementOffset = offset + match.search(/\bexport\b/);
+			if (!isExecutableScriptMatch(beforeReExports, statementOffset)) {
+				return match;
+			}
 			const newPath = transformImportPath(importPath, mappings, filePath);
 			if (newPath) {
 				transformedCount++;

--- a/packages/cli/tests/registry-index.test.ts
+++ b/packages/cli/tests/registry-index.test.ts
@@ -88,6 +88,11 @@ const mockLatestRef = {
 	updatedAt: '2023-02-01T00:00:00.000Z',
 };
 
+const mockLatestImmutableRef = {
+	...mockLatestRef,
+	commit: '0123456789abcdef0123456789abcdef01234567',
+};
+
 describe('Registry Index', () => {
 	beforeEach(() => {
 		vi.clearAllMocks();
@@ -295,6 +300,16 @@ describe('Registry Index', () => {
 			);
 			const result = await resolveRef();
 			expect(result).toEqual({ ref: mockLatestRef.ref, source: 'latest' });
+		});
+
+		it('prefers immutable latest commit when registry/latest.json provides one', async () => {
+			vi.mocked(gitFetch.fetchFromGitTag).mockResolvedValue(
+				Buffer.from(JSON.stringify(mockLatestImmutableRef))
+			);
+
+			const result = await resolveRef();
+
+			expect(result).toEqual({ ref: mockLatestImmutableRef.commit, source: 'latest' });
 		});
 
 		it('uses fallback if everything else fails', async () => {

--- a/packages/cli/tests/transform.test.ts
+++ b/packages/cli/tests/transform.test.ts
@@ -10,6 +10,7 @@ import {
 	transformTypeScriptImports,
 	type TransformResult,
 } from '../src/utils/transform.js';
+import { readFileSync } from 'node:fs';
 
 import { createTestConfig } from './fixtures/index.js';
 
@@ -185,6 +186,15 @@ import { AuthGate } from '@equaltoai/greater-components-auth';`;
 		expect(result.content).toContain("from '$lib/components/auth'");
 	});
 
+	it('transforms side-effect imports', () => {
+		const content = `import '@equaltoai/greater-components-tokens/theme.css';`;
+
+		const result = transformTypeScriptImports(content, config);
+
+		expect(result.transformedCount).toBe(1);
+		expect(result.content).toBe(`import '$lib/greater/tokens/theme.css';`);
+	});
+
 	it('transforms type-only imports', () => {
 		const content = `import type { ButtonProps } from '@equaltoai/greater-components-primitives';`;
 
@@ -272,6 +282,33 @@ import type { GenericStatus } from '../generics/index.js';`;
 		expect(result.content).toContain("from '../integration'");
 		expect(result.content).not.toContain("from '../lib/integration'");
 		expect(result.content).toContain("from '../types'");
+	});
+
+	it('rewrites executable exports after comment prose that mentions re-exporting', () => {
+		const content = `// Re-export palette types for ThemeProvider consumers
+export type { PalettePreset } from '@equaltoai/greater-components-tokens';
+`;
+
+		const result = transformImports(content, config, 'greater/primitives/index.ts');
+
+		expect(result.transformedCount).toBe(1);
+		expect(result.content).toContain("from '$lib/greater/tokens'");
+		expect(hasGreaterImports(result.content)).toBe(false);
+	});
+
+	it('does not rewrite headless primitive package examples inside comments', () => {
+		const source = readFileSync(
+			new URL('../../headless/src/primitives/button.ts', import.meta.url),
+			'utf8'
+		);
+
+		const result = transformImports(source, config, 'greater/headless/primitives/button.ts');
+
+		expect(result.transformedCount).toBe(0);
+		expect(result.content).toContain(
+			"import { createButton } from '@equaltoai/greater-components-headless/button';"
+		);
+		expect(result.content).toContain('@module @equaltoai/greater-components-headless/button');
 	});
 });
 
@@ -505,13 +542,13 @@ describe('edge cases', () => {
 		expect(() => transformTypeScriptImports(content, config)).not.toThrow();
 	});
 
-	it('handles string literals that look like imports', () => {
+	it('does not transform string literals that look like imports', () => {
 		const content = `const example = "import { x } from '@equaltoai/greater-components-utils'";`;
 
 		const result = transformTypeScriptImports(content, config);
 
-		expect(result.transformedCount).toBe(1);
-		expect(result.content).toContain('$lib/greater/utils');
+		expect(result.transformedCount).toBe(0);
+		expect(result.content).toBe(content);
 	});
 
 	it('does not transform template literal dynamic imports', () => {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3327,7 +3327,7 @@ packages:
       '@testing-library/dom': '>=7.21.4'
 
   '@theory-cloud/facetheory@https://github.com/theory-cloud/FaceTheory/releases/download/v2.0.0/theory-cloud-facetheory-2.0.0.tgz':
-    resolution: {tarball: https://github.com/theory-cloud/FaceTheory/releases/download/v2.0.0/theory-cloud-facetheory-2.0.0.tgz}
+    resolution: {integrity: sha512-+fYcw0uCZZZZMg2m+uWwEFSjhIuL91dCOqgQ5QGI7jNpqKxOZxoKcKSYO9Y0P+rGnCzNiiI73tGjw8oVKa4RCg==, tarball: https://github.com/theory-cloud/FaceTheory/releases/download/v2.0.0/theory-cloud-facetheory-2.0.0.tgz}
     version: 2.0.0
     engines: {node: '>=24'}
     peerDependencies:

--- a/registry/index.json
+++ b/registry/index.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://equalto.ai/schemas/registry-index.schema.json",
   "schemaVersion": "1.0.0",
-  "generatedAt": "2026-05-02T20:18:59.899Z",
+  "generatedAt": "2026-05-14T19:34:42.050Z",
   "ref": "greater-v0.8.10",
   "version": "0.8.10",
   "checksums": {
@@ -828,7 +828,7 @@
     "packages/adapters/src/graphql/index.d.ts": "sha256-orLx9yyDGxzzxd5wHeLg/XKql86ntzhZSG6iUj6Tjx8=",
     "packages/adapters/src/graphql/index.ts": "sha256-13y12ovgBLm5aZQ7K90w+XVxhUWIKB/eaPVEJ4kPeBI=",
     "packages/adapters/src/graphql/LesserGraphQLAdapter.d.ts": "sha256-tS4MSxFQSiPlKqIotIdGyDRMyfu7BjJ3dpPBXfjVqtU=",
-    "packages/adapters/src/graphql/LesserGraphQLAdapter.ts": "sha256-fEK1CIJX4iwXtEKRPZqotPdcXHupgPa2l6QaQWM3gCg=",
+    "packages/adapters/src/graphql/LesserGraphQLAdapter.ts": "sha256-QgDZxOdXi8hTxp1eBT47IM3DqtTOnlvFXmUrYVMJIWE=",
     "packages/adapters/src/graphql/optimistic.d.ts": "sha256-DO9Yg7q9e9k3+suvhBSBWMn+8+pVGydTpC7e70EPO1w=",
     "packages/adapters/src/graphql/optimistic.ts": "sha256-4U/b1aHeGBfl+YC+R+XaeY0Ts8hY8Er+3XfqUhSpqWY=",
     "packages/adapters/src/HttpPollingClient.d.ts": "sha256-6UbsJSk+ur6Rth93w5bnSj3HOl2teXThMIBozc0TQqI=",
@@ -5597,8 +5597,8 @@
         },
         {
           "path": "src/graphql/LesserGraphQLAdapter.ts",
-          "checksum": "sha256-fEK1CIJX4iwXtEKRPZqotPdcXHupgPa2l6QaQWM3gCg=",
-          "size": 55497
+          "checksum": "sha256-QgDZxOdXi8hTxp1eBT47IM3DqtTOnlvFXmUrYVMJIWE=",
+          "size": 56702
         },
         {
           "path": "src/graphql/optimistic.d.ts",

--- a/registry/latest.json
+++ b/registry/latest.json
@@ -1,5 +1,6 @@
 {
   "ref": "greater-v0.8.10",
   "version": "0.8.10",
-  "updatedAt": "2026-05-02T15:07:27.344Z"
+  "updatedAt": "2026-05-02T15:07:27.344Z",
+  "commit": "599e7774d227b6dfe56c7c4afa33beee40b9dd01"
 }

--- a/schemas/registry-index.schema.json
+++ b/schemas/registry-index.schema.json
@@ -33,6 +33,11 @@
       "type": "string",
       "description": "Git tag or commit SHA this registry was generated from"
     },
+    "commit": {
+      "type": "string",
+      "pattern": "^[0-9a-fA-F]{40}$",
+      "description": "Immutable commit SHA resolved from ref when available"
+    },
     "version": {
       "type": "string",
       "pattern": "^\\d+\\.\\d+\\.\\d+(-[a-zA-Z0-9.]+)?$",

--- a/scripts/build-release-artifacts.sh
+++ b/scripts/build-release-artifacts.sh
@@ -1,9 +1,9 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+pnpm audit:tarball-integrity
 pnpm build
 pnpm --filter @equaltoai/greater-components-cli test:e2e
 node scripts/validate-registry-index.js --strict
 node scripts/validate-release-versions.js
 node scripts/pack-for-release.js --skip-build
-

--- a/scripts/generate-registry-index.js
+++ b/scripts/generate-registry-index.js
@@ -15,6 +15,7 @@
  */
 
 import { createHash } from 'node:crypto';
+import { execFileSync } from 'node:child_process';
 import fs from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
@@ -372,6 +373,36 @@ function getGitRef(version) {
 	}
 
 	return headCommit.substring(0, 12);
+}
+
+function resolveGitCommit(ref) {
+	if (!ref || ref === 'unknown') return null;
+
+	try {
+		const commit = execFileSync(
+			'git',
+			['-C', rootDir, 'rev-parse', '--verify', `${ref}^{commit}`],
+			{
+				encoding: 'utf8',
+				stdio: ['ignore', 'pipe', 'ignore'],
+			}
+		).trim();
+		return /^[0-9a-f]{40}$/i.test(commit) ? commit : null;
+	} catch {
+		return null;
+	}
+}
+
+function resolveRegistryCommit(ref) {
+	if (!/^greater-v/.test(ref) && !/^[0-9a-f]{7,40}$/i.test(ref)) return null;
+
+	const commit = resolveGitCommit(ref);
+	if (!commit) return null;
+
+	const head = resolveGitCommit('HEAD');
+	if (!head || commit.toLowerCase() !== head.toLowerCase()) return null;
+
+	return commit;
 }
 
 /**
@@ -879,6 +910,7 @@ async function main() {
 	// Get metadata
 	const version = getVersion();
 	const ref = refOverride ?? getGitRef(version);
+	const commit = resolveRegistryCommit(ref);
 	const generatedAt = new Date().toISOString();
 
 	// Get workspace versions
@@ -886,6 +918,9 @@ async function main() {
 
 	log(`📋 Version: ${version}`, colors.cyan);
 	log(`🏷️  Git ref: ${ref}`, colors.cyan);
+	if (commit) {
+		log(`🔒 Commit: ${commit}`, colors.cyan);
+	}
 	log(`📅 Generated: ${generatedAt}\n`, colors.cyan);
 
 	// Process packages
@@ -936,6 +971,7 @@ async function main() {
 		schemaVersion: SCHEMA_VERSION,
 		generatedAt,
 		ref,
+		...(commit ? { commit } : {}),
 		version,
 		checksums,
 		components,

--- a/scripts/prepare-github-release.js
+++ b/scripts/prepare-github-release.js
@@ -36,6 +36,21 @@ function writeJson(filePath, value) {
 	fs.writeFileSync(filePath, JSON.stringify(value, null, 2) + '\n');
 }
 
+function resolveCommit(ref) {
+	try {
+		const commit = execSync(`git rev-parse --verify "${ref}^{commit}"`, {
+			cwd: rootDir,
+			encoding: 'utf8',
+			stdio: ['ignore', 'pipe', 'ignore'],
+		})
+			.trim()
+			.toLowerCase();
+		return /^[0-9a-f]{40}$/.test(commit) ? commit : null;
+	} catch {
+		return null;
+	}
+}
+
 function skipWhitespace(text, i) {
 	while (i < text.length && /\s/.test(text[i])) i += 1;
 	return i;
@@ -200,6 +215,8 @@ function registryIndexMatchesTag({ version, tag }) {
 		const index = readJson(indexPath);
 		if (index?.version !== version) return false;
 		if (index?.ref !== tag) return false;
+		const commit = resolveCommit(tag);
+		if (commit && index?.commit !== commit) return false;
 
 		// Ensure checksums are valid so we don't skip regeneration when files changed.
 		execSync('node scripts/validate-registry-index.js --strict', {
@@ -238,10 +255,16 @@ function main() {
 
 	if (isStableSemver(version)) {
 		const existingLatest = fs.existsSync(latestPath) ? readJson(latestPath) : null;
-		if (existingLatest?.ref !== tag || existingLatest?.version !== version) {
+		const commit = resolveCommit(tag);
+		if (
+			existingLatest?.ref !== tag ||
+			existingLatest?.version !== version ||
+			(commit && existingLatest?.commit !== commit)
+		) {
 			writeJson(latestPath, {
 				ref: tag,
 				version,
+				...(commit ? { commit } : {}),
 				updatedAt: new Date().toISOString(),
 			});
 		}

--- a/scripts/release-tag.js
+++ b/scripts/release-tag.js
@@ -52,6 +52,17 @@ function exec(command, options = {}) {
 	});
 }
 
+function resolveCommit(ref) {
+	try {
+		const commit = exec(`git rev-parse --verify "${ref}^{commit}"`, { silent: true, stdio: 'pipe' })
+			.trim()
+			.toLowerCase();
+		return /^[0-9a-f]{40}$/.test(commit) ? commit : null;
+	} catch {
+		return null;
+	}
+}
+
 function getVersion() {
 	const packageJsonPath = path.join(rootDir, 'package.json');
 	const packageJson = JSON.parse(fs.readFileSync(packageJsonPath, 'utf8'));
@@ -60,9 +71,12 @@ function getVersion() {
 
 function updateLatestJson(version, dryRun = false) {
 	const latestPath = path.join(rootDir, 'registry', 'latest.json');
+	const ref = `greater-v${version}`;
+	const commit = resolveCommit(ref);
 	const data = {
-		ref: `greater-v${version}`,
+		ref,
 		version,
+		...(commit ? { commit } : {}),
 		updatedAt: new Date().toISOString(),
 	};
 

--- a/scripts/validate-release-versions.js
+++ b/scripts/validate-release-versions.js
@@ -40,6 +40,10 @@ function isIsoDate(value) {
 	return !Number.isNaN(date.getTime()) && value.includes('T');
 }
 
+function isCommitSha(value) {
+	return typeof value === 'string' && /^[0-9a-f]{40}$/i.test(value);
+}
+
 function isStableSemver(value) {
 	return typeof value === 'string' && /^\d+\.\d+\.\d+$/.test(value);
 }
@@ -125,6 +129,10 @@ function main() {
 		errors.push(`registry/index.json ref (${index?.ref ?? 'missing'}) must be ${expectedRef}`);
 	}
 
+	if (index?.commit !== undefined && !isCommitSha(index.commit)) {
+		errors.push(`registry/index.json commit is not a 40-character SHA: ${String(index.commit)}`);
+	}
+
 	// `registry/latest.json` is the *latest stable* release ref.
 	if (isStableSemver(version)) {
 		if (latest?.version !== version) {
@@ -135,6 +143,12 @@ function main() {
 
 		if (latest?.ref !== expectedRef) {
 			errors.push(`registry/latest.json ref (${latest?.ref ?? 'missing'}) must be ${expectedRef}`);
+		}
+
+		if (latest?.commit !== undefined && !isCommitSha(latest.commit)) {
+			errors.push(
+				`registry/latest.json commit is not a 40-character SHA: ${String(latest.commit)}`
+			);
 		}
 
 		if (latest?.updatedAt && !isIsoDate(latest.updatedAt)) {
@@ -156,6 +170,12 @@ function main() {
 		if (latest?.ref !== latestExpectedRef) {
 			errors.push(
 				`registry/latest.json ref (${latest?.ref ?? 'missing'}) must be ${latestExpectedRef || 'greater-v<stable>'}`
+			);
+		}
+
+		if (latest?.commit !== undefined && !isCommitSha(latest.commit)) {
+			errors.push(
+				`registry/latest.json commit is not a 40-character SHA: ${String(latest.commit)}`
 			);
 		}
 

--- a/scripts/verify-tarball-integrity.js
+++ b/scripts/verify-tarball-integrity.js
@@ -1,0 +1,121 @@
+#!/usr/bin/env node
+/**
+ * Verify direct GitHub release tarball dependencies are pinned with SRI.
+ *
+ * The lockfile is the install-time integrity gate, while package.json's
+ * `greaterVerifiedTarballs` map makes the human-reviewed dependency pin
+ * auditable before pnpm materializes the lock entry.
+ */
+
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const rootDir = path.join(__dirname, '..');
+
+const PACKAGE_JSON = path.join(rootDir, 'package.json');
+const LOCKFILE = path.join(rootDir, 'pnpm-lock.yaml');
+const GITHUB_RELEASE_TARBALL_RE =
+	/^https:\/\/github\.com\/[^/]+\/[^/]+\/releases\/download\/[^#\s]+\/[^#\s]+\.t(?:ar\.)?gz(?:#(?<integrity>sha512-[A-Za-z0-9+/]+=*))?$/;
+const SRI_RE = /^sha512-[A-Za-z0-9+/]+=*$/;
+
+function collectDependencySpecs(pkg) {
+	return {
+		...(pkg.dependencies ?? {}),
+		...(pkg.devDependencies ?? {}),
+		...(pkg.optionalDependencies ?? {}),
+	};
+}
+
+function findLockBlock(lockfile, spec) {
+	const packagesStart = lockfile.indexOf('\npackages:\n');
+	if (packagesStart === -1) return null;
+	const snapshotsStart = lockfile.indexOf('\nsnapshots:\n', packagesStart);
+	const packagesText = lockfile.slice(
+		packagesStart,
+		snapshotsStart === -1 ? lockfile.length : snapshotsStart
+	);
+
+	const lineStart = packagesText
+		.split('\n')
+		.find((line) => line.startsWith('  ') && !line.startsWith('    ') && line.includes(spec));
+
+	if (!lineStart) return null;
+
+	const keyIndex = lockfile.indexOf(lineStart, packagesStart);
+	const start = keyIndex + lineStart.length + 1;
+	const next = /\n\s{2}\S/g;
+	next.lastIndex = start;
+	const nextMatch = next.exec(lockfile);
+	return lockfile.slice(start, nextMatch?.index ?? lockfile.length);
+}
+
+function main() {
+	const pkg = JSON.parse(fs.readFileSync(PACKAGE_JSON, 'utf8'));
+	const lockfile = fs.readFileSync(LOCKFILE, 'utf8');
+	const deps = collectDependencySpecs(pkg);
+	const verifiedTarballs = pkg.greaterVerifiedTarballs ?? {};
+	const errors = [];
+	let checked = 0;
+
+	for (const [name, spec] of Object.entries(deps)) {
+		if (typeof spec !== 'string') continue;
+		const match = GITHUB_RELEASE_TARBALL_RE.exec(spec);
+		if (!match) continue;
+
+		checked += 1;
+		const embeddedIntegrity = match.groups?.integrity;
+		const verification = verifiedTarballs[name];
+		const integrity = verification?.integrity;
+
+		if (embeddedIntegrity) {
+			errors.push(
+				`${name}: keep the dependency URL fragment-free; record SRI in greaterVerifiedTarballs so pnpm store paths stay bounded`
+			);
+		}
+
+		if (!verification || verification.url !== spec) {
+			errors.push(`${name}: greaterVerifiedTarballs entry must match the dependency URL`);
+			continue;
+		}
+
+		if (!integrity || !SRI_RE.test(integrity)) {
+			errors.push(`${name}: greaterVerifiedTarballs entry must include a sha512 integrity value`);
+			continue;
+		}
+
+		if (!lockfile.includes(`specifier: ${spec}`)) {
+			errors.push(`${name}: pnpm-lock.yaml importer specifier does not match package.json`);
+		}
+
+		const block = findLockBlock(lockfile, spec);
+		if (!block) {
+			errors.push(`${name}: pnpm-lock.yaml is missing a package block for the exact tarball spec`);
+			continue;
+		}
+
+		if (!block.includes(`integrity: ${integrity}`)) {
+			errors.push(`${name}: pnpm-lock.yaml resolution integrity does not match package.json SRI`);
+		}
+
+		if (!block.includes(`tarball: ${spec}`)) {
+			errors.push(
+				`${name}: pnpm-lock.yaml resolution tarball does not preserve the SRI-pinned URL`
+			);
+		}
+	}
+
+	if (errors.length > 0) {
+		console.error('GitHub release tarball integrity verification failed:');
+		for (const error of errors) {
+			console.error(`- ${error}`);
+		}
+		process.exit(1);
+	}
+
+	console.log(`GitHub release tarball integrity verified (${checked} checked).`);
+}
+
+main();


### PR DESCRIPTION
## Summary

Remediates the Greater-owned findings from Security Remediation Project 28.

- #529 / `greater-components.csv:2`: redacts public GraphQL adapter error causes so partial mutation payloads and token-bearing data are not exposed through `LesserGraphQLAdapterError.cause`.
- #529 / `greater-components.csv:4`: documents the contract-sync boundary for auth/security metadata. I verified the pinned Lesser snapshot (`v1.2.54`) and current Lesser release candidates still require an upstream Lesser contract fix; Greater does not hand-edit pinned OpenAPI snapshots.
- #530 / `greater-components.csv:1`: adds immutable commit metadata to `registry/latest.json`, teaches the CLI to prefer that commit for latest resolution, and prepares release assets to emit commit metadata once the release tag exists.
- #530 / `greater-components.csv:3` and `:5`: adds an auditable `greaterVerifiedTarballs` SRI record, lockfile integrity verification, and release/artifact gates for GitHub release tarball dependencies without using long URL fragments that break pnpm store paths.
- #531 / `greater-components.csv:6`: hardens CLI import rewriting so comment/example text in headless primitives is not rewritten, side-effect imports are rewritten, and executable re-exports following comment prose are still handled.

## Contract / release notes

- Lesser contract snapshots were not edited. The auth metadata finding is recorded as an upstream contract issue: Greater must resync after Lesser publishes a corrected file-only contract release.
- Registry artifacts were regenerated via `pnpm generate-registry`; `registry/latest.json` now includes the stable tag's immutable commit.
- Release workflows run tarball-integrity verification before install and prepare immutable registry metadata after a tag exists, before upload.

## Validation

- `corepack pnpm install --frozen-lockfile`
- `corepack pnpm audit:tarball-integrity`
- `corepack pnpm validate:registry && node scripts/validate-release-versions.js`
- `corepack pnpm --filter @equaltoai/greater-components-adapters exec vitest run src/graphql/__tests__/LesserGraphQLAdapter.test.ts tests/graphql-client.security.test.ts`
- `corepack pnpm --filter @equaltoai/greater-components-cli exec vitest run tests/transform.test.ts tests/ref.test.ts tests/registry-index.test.ts`
- `corepack pnpm --filter @equaltoai/greater-components-cli test:e2e`
- `corepack pnpm lint`
- `corepack pnpm typecheck`
- `corepack pnpm build`
- Promotion rehearsal with `git merge-tree`: candidate → staging, staging → premain, staging → main, and premain → main all clean.

Closes #529.
Closes #530.
Closes #531.