### PR TITLE
ci(dco): remediate staging promotion signoff

### DIFF
--- a/.github/dco.yml
+++ b/.github/dco.yml
@@ -1,2 +1,5 @@
+allowRemediationCommits:
+  individual: true
+
 require:
   members: false


### PR DESCRIPTION
## Summary

Unblocks the `staging` -> `premain` promotion PR #540 by enabling DCO remediation commits and adding an individual remediation commit for historical staging commit `ddfbb798b43c8af16da53fa540b89def1ec77fe5`, whose squash message missed `Signed-off-by`.

This avoids rewriting already-published staging history and keeps the DCO record explicit.

## Changes

- Enables individual DCO remediation commits in `.github/dco.yml`.
- Adds an empty, signed DCO remediation commit by the original author for `ddfbb798b43c8af16da53fa540b89def1ec77fe5`.

## Validation

- `corepack pnpm format:check`
- `corepack pnpm release:rehearse -- --candidate HEAD`

## Merge method

Merge with a merge commit so the remediation commit remains visible in staging history.
