### PR TITLE
ci(dco): carry remediation workflow on staging

### DIFF
--- a/.github/dco.yml
+++ b/.github/dco.yml
@@ -1,2 +1,5 @@
+allowRemediationCommits:
+  individual: true
+
 require:
   members: false

--- a/.github/workflows/dco.yml
+++ b/.github/workflows/dco.yml
@@ -25,11 +25,19 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Fetch pull request refs
+        if: github.event_name == 'pull_request'
+        run: |
+          git fetch --no-tags --prune origin \
+            "+refs/heads/${{ github.base_ref }}:refs/remotes/origin/${{ github.base_ref }}" \
+            "+refs/pull/${{ github.event.pull_request.number }}/head:refs/remotes/pull/${{ github.event.pull_request.number }}/head"
+
       - name: DCO Check (pull_request)
         if: github.event_name == 'pull_request'
-        uses: tim-actions/dco@v1.0
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+        env:
+          BASE_REF: ${{ github.event.pull_request.base.sha }}
+          HEAD_REF: ${{ github.event.pull_request.head.sha }}
+        run: node scripts/check-dco.js --base "${BASE_REF}" --head "${HEAD_REF}"
 
       - name: DCO Check (workflow_dispatch)
         if: github.event_name == 'workflow_dispatch'
@@ -44,23 +52,4 @@ jobs:
           fi
 
           git fetch origin "${BASE_REF}:${BASE_REF}" --force
-
-          head_sha="$(git rev-parse HEAD)"
-          mapfile -t commits < <(git rev-list "${BASE_REF}..${head_sha}")
-
-          if [[ ${#commits[@]} -eq 0 ]]; then
-            echo "dco: no commits to check in ${BASE_REF}..${head_sha}"
-            exit 0
-          fi
-
-          missing=0
-          for sha in "${commits[@]}"; do
-            if ! git show -s --format=%B "${sha}" | grep -qi '^Signed-off-by:'; then
-              echo "::error::Commit ${sha} is missing Signed-off-by"
-              missing=1
-            fi
-          done
-
-          if [[ "${missing}" -ne 0 ]]; then
-            exit 1
-          fi
+          node scripts/check-dco.js --base "${BASE_REF}" --head HEAD

--- a/scripts/check-dco.js
+++ b/scripts/check-dco.js
@@ -1,0 +1,131 @@
+#!/usr/bin/env node
+import { execFileSync } from 'node:child_process';
+import { existsSync, readFileSync } from 'node:fs';
+
+const args = process.argv.slice(2);
+
+function argValue(name) {
+	const index = args.indexOf(name);
+	if (index === -1) return undefined;
+	return args[index + 1];
+}
+
+function git(gitArgs) {
+	return execFileSync('git', gitArgs, { encoding: 'utf8' }).trimEnd();
+}
+
+function error(message) {
+	console.error(`::error::${message}`);
+}
+
+function parseCommit(sha) {
+	const raw = git(['show', '-s', '--format=%H%x00%P%x00%an%x00%ae%x00%B', sha]);
+	const [commitSha, parentLine, authorName, authorEmail, ...bodyParts] = raw.split('\0');
+	return {
+		sha: commitSha,
+		parents: parentLine.length > 0 ? parentLine.split(' ') : [],
+		authorName,
+		authorEmail,
+		body: bodyParts.join('\0'),
+	};
+}
+
+function validSignoff(commit) {
+	const signoffPattern = /^Signed-off-by:\s*(.*?)\s*<([^>]+)>\s*$/gim;
+	const matches = [...commit.body.matchAll(signoffPattern)];
+	return matches.length > 0;
+}
+
+function remediationConfigEnabled() {
+	if (!existsSync('.github/dco.yml')) return false;
+	const config = readFileSync('.github/dco.yml', 'utf8');
+	return /allowRemediationCommits:\s*[\s\S]*?\bindividual:\s*true\b/i.test(config);
+}
+
+function remediationEntries(commit) {
+	const firstLine = commit.body.split(/\r?\n/, 1)[0] ?? '';
+	const header = firstLine.match(/^DCO remediation commit for (.+) <([^>]+)>\s*$/i);
+	if (!header || !validSignoff(commit)) return [];
+
+	const [, remediatorName, remediatorEmail] = header;
+	const normalizedEmail = remediatorEmail.toLowerCase();
+	if (commit.authorEmail.toLowerCase() !== normalizedEmail) return [];
+
+	const entryPattern =
+		/^I,\s*(.+)\s*<([^>]+)>,\s*hereby add my Signed-off-by to this commit:\s*([0-9a-f]{40})\s*$/gim;
+	return [...commit.body.matchAll(entryPattern)]
+		.filter((match) => match[2].toLowerCase() === normalizedEmail)
+		.map((match) => ({
+			target: match[3],
+			name: remediatorName,
+			email: remediatorEmail,
+			remediationSha: commit.sha,
+		}));
+}
+
+const base = argValue('--base') ?? process.env.DCO_BASE_REF ?? process.env.BASE_REF;
+const head = argValue('--head') ?? process.env.DCO_HEAD_REF ?? process.env.HEAD_REF ?? 'HEAD';
+
+if (!base) {
+	error('Missing DCO base ref. Pass --base <ref> or set DCO_BASE_REF.');
+	process.exit(1);
+}
+
+let commits;
+try {
+	const output = git(['rev-list', `${base}..${head}`]);
+	commits = output.length > 0 ? output.split('\n') : [];
+} catch (cause) {
+	error(`Unable to list commits for ${base}..${head}: ${cause.message}`);
+	process.exit(1);
+}
+
+if (commits.length === 0) {
+	console.log(`dco: no commits to check in ${base}..${head}`);
+	process.exit(0);
+}
+
+const parsedCommits = commits.map(parseCommit);
+const individualRemediationEnabled = remediationConfigEnabled();
+const remediations = new Map();
+
+if (individualRemediationEnabled) {
+	for (const commit of parsedCommits) {
+		for (const entry of remediationEntries(commit)) {
+			remediations.set(entry.target, entry);
+		}
+	}
+}
+
+let failed = false;
+for (const commit of parsedCommits) {
+	if (commit.parents.length > 1) {
+		console.log(`dco: skipping merge commit ${commit.sha}`);
+		continue;
+	}
+
+	if (validSignoff(commit)) {
+		console.log(`dco: ${commit.sha} signed off by ${commit.authorName} <${commit.authorEmail}>`);
+		continue;
+	}
+
+	const remediation = remediations.get(commit.sha);
+	if (
+		individualRemediationEnabled &&
+		remediation &&
+		remediation.email.toLowerCase() === commit.authorEmail.toLowerCase()
+	) {
+		console.log(
+			`dco: ${commit.sha} remediated by ${remediation.remediationSha} for ${remediation.name} <${remediation.email}>`
+		);
+		continue;
+	}
+
+	error(
+		`Commit ${commit.sha} is missing Signed-off-by for ${commit.authorName} <${commit.authorEmail}>`
+	);
+	failed = true;
+}
+
+if (failed) process.exit(1);
+console.log(`dco: PASS (${parsedCommits.length} commits checked)`);


### PR DESCRIPTION
## Summary\n- cherry-pick the repo-local DCO remediation checker onto staging\n- backmerge the premain DCO workflow repair so staging remains promotion-safe after #542\n- preserve premain ancestry; this PR must be merged with a merge commit, not squash\n\n## Validation\n- corepack pnpm release:rehearse -- --candidate HEAD\n- node scripts/check-dco.js --base origin/premain --head HEAD\n- corepack pnpm format:check\n- git diff --check\n\nThis keeps the staging→premain promotion unblocker on both sides of the promotion PR without rewriting staging history.