### PR TITLE
fix(cli): ship browser-valid raw css selectors

### DIFF
--- a/.changeset/browser-valid-raw-css.md
+++ b/.changeset/browser-valid-raw-css.md
@@ -1,0 +1,7 @@
+---
+'@equaltoai/greater-components-primitives': patch
+'@equaltoai/greater-components-social': patch
+'@equaltoai/greater-components': patch
+---
+
+Ship browser-valid raw CSS assets by replacing Svelte-only `:global(...)` selectors in registry-managed primitive and social theme CSS.

--- a/packages/cli/tests/css-assets.test.ts
+++ b/packages/cli/tests/css-assets.test.ts
@@ -14,10 +14,7 @@ import { CSS_SOURCE_PATHS } from '../src/utils/css-inject.js';
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const repoRoot = path.resolve(__dirname, '../../..');
 
-const rawCssAssetPaths = [
-	CSS_SOURCE_PATHS.primitives,
-	...Object.values(CSS_SOURCE_PATHS.faces),
-];
+const rawCssAssetPaths = [CSS_SOURCE_PATHS.primitives, ...Object.values(CSS_SOURCE_PATHS.faces)];
 
 describe('registry-managed raw CSS assets', () => {
 	it('do not contain Svelte-only :global selectors', async () => {

--- a/packages/cli/tests/css-assets.test.ts
+++ b/packages/cli/tests/css-assets.test.ts
@@ -1,0 +1,35 @@
+/**
+ * CSS Asset Tests
+ *
+ * Registry-managed raw CSS files are copied directly into consumer projects.
+ * They must be browser-valid CSS, not Svelte component style syntax.
+ */
+
+import { readFile } from 'node:fs/promises';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+import { CSS_SOURCE_PATHS } from '../src/utils/css-inject.js';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = path.resolve(__dirname, '../../..');
+
+const rawCssAssetPaths = [
+	CSS_SOURCE_PATHS.primitives,
+	...Object.values(CSS_SOURCE_PATHS.faces),
+];
+
+describe('registry-managed raw CSS assets', () => {
+	it('do not contain Svelte-only :global selectors', async () => {
+		const offenders: string[] = [];
+
+		for (const sourcePath of rawCssAssetPaths) {
+			const css = await readFile(path.join(repoRoot, sourcePath), 'utf8');
+			if (css.includes(':global(')) {
+				offenders.push(sourcePath);
+			}
+		}
+
+		expect(offenders).toEqual([]);
+	});
+});

--- a/packages/faces/social/src/theme.css
+++ b/packages/faces/social/src/theme.css
@@ -9,7 +9,7 @@
 }
 
 /* Button overrides for action bar styling */
-.gr-action-bar :global(.gr-action-bar__button) {
+.gr-action-bar .gr-action-bar__button {
 	min-width: auto;
 	padding: var(--gr-spacing-scale-2) var(--gr-spacing-scale-3);
 	color: var(--gr-semantic-foreground-secondary);
@@ -18,40 +18,40 @@
 		fill var(--gr-motion-duration-fast) var(--gr-motion-easing-out);
 }
 
-.gr-action-bar :global(.gr-action-bar__button:hover:not(:disabled):not(.gr-button--loading)) {
+.gr-action-bar .gr-action-bar__button:hover:not(:disabled):not(.gr-button--loading) {
 	background-color: var(--gr-semantic-background-secondary);
 }
 
 /* Reply button specific styles */
-.gr-action-bar :global(.gr-action-bar__button--reply:hover:not(:disabled)) {
+.gr-action-bar .gr-action-bar__button--reply:hover:not(:disabled) {
 	color: var(--gr-semantic-background-primary);
 	background-color: var(--gr-semantic-action-primary-default);
 }
 
 /* Boost button specific styles */
-.gr-action-bar :global(.gr-action-bar__button--boost:hover:not(:disabled)) {
+.gr-action-bar .gr-action-bar__button--boost:hover:not(:disabled) {
 	color: var(--gr-semantic-background-primary);
 	background-color: var(--gr-semantic-action-success-default);
 }
 
-.gr-action-bar :global(.gr-action-bar__button--boost.gr-action-bar__button--active) {
+.gr-action-bar .gr-action-bar__button--boost.gr-action-bar__button--active {
 	color: var(--gr-semantic-background-primary);
 	background-color: var(--gr-semantic-action-success-default);
 }
 
 /* Favorite button specific styles */
-.gr-action-bar :global(.gr-action-bar__button--favorite:hover:not(:disabled)) {
+.gr-action-bar .gr-action-bar__button--favorite:hover:not(:disabled) {
 	color: var(--gr-semantic-background-primary);
 	background-color: var(--gr-semantic-action-error-default);
 }
 
-.gr-action-bar :global(.gr-action-bar__button--favorite.gr-action-bar__button--active) {
+.gr-action-bar .gr-action-bar__button--favorite.gr-action-bar__button--active {
 	color: var(--gr-semantic-background-primary);
 	background-color: var(--gr-semantic-action-error-default);
 }
 
 /* Share button specific styles */
-.gr-action-bar :global(.gr-action-bar__button--share:hover:not(:disabled)) {
+.gr-action-bar .gr-action-bar__button--share:hover:not(:disabled) {
 	color: var(--gr-semantic-background-primary);
 	background-color: var(--gr-semantic-action-primary-default);
 }
@@ -66,8 +66,8 @@
 	font-weight: var(--gr-typography-fontWeight-medium);
 }
 
-.gr-action-bar :global(.gr-action-bar__button--active) .gr-action-bar__count,
-.gr-action-bar :global(.gr-action-bar__button:hover:not(:disabled)) .gr-action-bar__count {
+.gr-action-bar .gr-action-bar__button--active .gr-action-bar__count,
+.gr-action-bar .gr-action-bar__button:hover:not(:disabled) .gr-action-bar__count {
 	color: currentColor;
 }
 
@@ -87,7 +87,7 @@
 		gap: var(--gr-spacing-scale-1);
 	}
 
-	.gr-action-bar :global(.gr-action-bar__button) {
+	.gr-action-bar .gr-action-bar__button {
 		padding: var(--gr-spacing-scale-2);
 	}
 
@@ -98,19 +98,19 @@
 
 /* Reduced motion support */
 @media (prefers-reduced-motion: reduce) {
-	.gr-action-bar :global(.gr-action-bar__button) {
+	.gr-action-bar .gr-action-bar__button {
 		transition: none;
 	}
 }
 
 /* High contrast mode support */
 @media (prefers-contrast: high) {
-	.gr-action-bar :global(.gr-action-bar__button--active) {
+	.gr-action-bar .gr-action-bar__button--active {
 		outline: 2px solid currentColor;
 		outline-offset: -2px;
 	}
 
-	.gr-action-bar :global(.gr-action-bar__button) .gr-action-bar__count {
+	.gr-action-bar .gr-action-bar__button .gr-action-bar__count {
 		color: currentColor;
 	}
 }
@@ -6004,47 +6004,47 @@
 }
 
 /* Content styles */
-.content :global(p) {
+.content p {
 	margin: 0 0 var(--spacing-sm, 0.5rem);
 }
 
-.content :global(p:last-child) {
+.content p:last-child {
 	margin-bottom: 0;
 }
 
-.content :global(a) {
+.content a {
 	color: var(--color-link, #1d9bf0);
 	text-decoration: none;
 }
 
-.content :global(a:hover) {
+.content a:hover {
 	text-decoration: underline;
 }
 
-.content :global(.mention) {
+.content .mention {
 	color: var(--color-link, #1d9bf0);
 	font-weight: 500;
 }
 
-.content :global(.hashtag) {
+.content .hashtag {
 	color: var(--color-link, #1d9bf0);
 }
 
-.content :global(blockquote) {
+.content blockquote {
 	margin: var(--spacing-sm, 0.5rem) 0;
 	padding-left: var(--spacing-md, 1rem);
 	border-left: 3px solid var(--color-border, #e1e8ed);
 	color: var(--color-text-secondary, #536471);
 }
 
-.content :global(pre) {
+.content pre {
 	background: var(--color-bg-secondary, #f7f9fa);
 	padding: var(--spacing-sm, 0.5rem);
 	border-radius: var(--radius-sm, 4px);
 	overflow-x: auto;
 }
 
-.content :global(code) {
+.content code {
 	background: var(--color-bg-secondary, #f7f9fa);
 	padding: 0.125rem 0.25rem;
 	border-radius: var(--radius-xs, 2px);
@@ -6052,18 +6052,18 @@
 	font-size: 0.875em;
 }
 
-.content :global(pre code) {
+.content pre code {
 	background: none;
 	padding: 0;
 }
 
-.content :global(ul),
-.content :global(ol) {
+.content ul,
+.content ol {
 	margin: var(--spacing-sm, 0.5rem) 0;
 	padding-left: var(--spacing-lg, 1.5rem);
 }
 
-.content :global(li) {
+.content li {
 	margin: var(--spacing-xs, 0.25rem) 0;
 }
 
@@ -11555,12 +11555,12 @@
 	word-break: break-word;
 }
 
-.profile-fields__value :global(a) {
+.profile-fields__value a {
 	color: var(--primary-color, #1d9bf0);
 	text-decoration: none;
 }
 
-.profile-fields__value :global(a:hover) {
+.profile-fields__value a:hover {
 	text-decoration: underline;
 }
 
@@ -12560,12 +12560,12 @@
 	word-break: break-word;
 }
 
-.profile-header__bio :global(a) {
+.profile-header__bio a {
 	color: var(--primary-color, #1d9bf0);
 	text-decoration: none;
 }
 
-.profile-header__bio :global(a:hover) {
+.profile-header__bio a:hover {
 	text-decoration: underline;
 }
 
@@ -12600,12 +12600,12 @@
 	word-break: break-word;
 }
 
-.profile-header__field-value-content :global(a) {
+.profile-header__field-value-content a {
 	color: var(--primary-color, #1d9bf0);
 	text-decoration: none;
 }
 
-.profile-header__field-value-content :global(a:hover) {
+.profile-header__field-value-content a:hover {
 	text-decoration: underline;
 }
 
@@ -13355,21 +13355,21 @@
 	margin-bottom: var(--gr-spacing-4);
 }
 
-.gr-profile-header__bio-content :global(p) {
+.gr-profile-header__bio-content p {
 	margin: 0 0 var(--gr-spacing-2) 0;
 	line-height: var(--gr-typography-lineHeight-relaxed);
 }
 
-.gr-profile-header__bio-content :global(p:last-child) {
+.gr-profile-header__bio-content p:last-child {
 	margin-bottom: 0;
 }
 
-.gr-profile-header__bio-content :global(a) {
+.gr-profile-header__bio-content a {
 	color: var(--gr-color-primary-600);
 	text-decoration: none;
 }
 
-.gr-profile-header__bio-content :global(a:hover) {
+.gr-profile-header__bio-content a:hover {
 	text-decoration: underline;
 }
 
@@ -13414,19 +13414,19 @@
 	word-break: break-word;
 }
 
-.gr-profile-header__field-value :global(a) {
+.gr-profile-header__field-value a {
 	color: var(--gr-color-primary-600, #2563eb);
 	text-decoration: none;
 	font-weight: var(--gr-typography-fontWeight-medium);
 }
 
-.gr-profile-header__field-value :global(a:hover) {
+.gr-profile-header__field-value a:hover {
 	text-decoration: underline;
 }
 
-:global([data-theme='dark']) .gr-profile-header__field-value :global(a),
-:global([data-theme='highContrast']) .gr-profile-header__field-value :global(a),
-:global([data-theme='high-contrast']) .gr-profile-header__field-value :global(a) {
+[data-theme='dark'] .gr-profile-header__field-value a,
+[data-theme='highContrast'] .gr-profile-header__field-value a,
+[data-theme='high-contrast'] .gr-profile-header__field-value a {
 	color: var(--gr-color-primary-300, #93c5fd);
 }
 
@@ -13756,13 +13756,13 @@
 	margin: 0.25rem 0 0 0;
 }
 
-.actor-result__bio :global(.content-renderer) {
+.actor-result__bio .content-renderer {
 	font-size: 0.9375rem;
 	color: var(--text-primary, #0f1419);
 	line-height: 1.4;
 }
 
-.actor-result__bio :global(.content-renderer .content) {
+.actor-result__bio .content-renderer .content {
 	overflow: hidden;
 	text-overflow: ellipsis;
 	display: -webkit-box;
@@ -14142,19 +14142,19 @@
 	-webkit-box-orient: vertical;
 }
 
-.note-result__text :global(mark) {
+.note-result__text mark {
 	background: rgba(29, 155, 240, 0.2);
 	color: var(--text-primary, #0f1419);
 	padding: 0.125rem 0.25rem;
 	border-radius: 0.25rem;
 }
 
-.note-result__text :global(a) {
+.note-result__text a {
 	color: var(--primary-color, #1d9bf0);
 	text-decoration: none;
 }
 
-.note-result__text :global(a:hover) {
+.note-result__text a:hover {
 	text-decoration: underline;
 }
 
@@ -14591,7 +14591,7 @@
 }
 
 /* Compact density adjustments */
-:global(.status-root--compact) .status-actions {
+.status-root--compact .status-actions {
 	margin-top: var(--status-spacing-xs, 0.25rem);
 	padding-top: var(--status-spacing-xs, 0.25rem);
 }
@@ -14764,29 +14764,29 @@
 }
 
 /* Content links styling */
-.status-content :global(a) {
+.status-content a {
 	color: var(--status-link-color, #1d9bf0);
 	text-decoration: none;
 }
 
-.status-content :global(a:hover) {
+.status-content a:hover {
 	text-decoration: underline;
 }
 
 /* Mentions styling */
-.status-content :global(.mention) {
+.status-content .mention {
 	color: var(--status-mention-color, #1d9bf0);
 	font-weight: 500;
 }
 
 /* Hashtags styling */
-.status-content :global(.hashtag) {
+.status-content .hashtag {
 	color: var(--status-hashtag-color, #1d9bf0);
 	font-weight: 500;
 }
 
 /* Compact density adjustments */
-:global(.status-root--compact) .status-content {
+.status-root--compact .status-content {
 	font-size: var(--status-font-size-sm, 0.875rem);
 	margin: var(--status-spacing-xs, 0.25rem) 0;
 }
@@ -15120,7 +15120,7 @@
 }
 
 /* Compact density adjustments */
-:global(.status-root--compact) .status-media {
+.status-root--compact .status-media {
 	margin: var(--status-spacing-xs, 0.25rem) 0;
 }
 
@@ -15187,7 +15187,7 @@
 }
 
 /* Allow customization via CSS custom properties */
-:global(.status-root) {
+.status-root {
 	--status-spacing-xs: 0.25rem;
 	--status-spacing-sm: 0.5rem;
 	--status-spacing-md: 1rem;

--- a/packages/primitives/src/theme.css
+++ b/packages/primitives/src/theme.css
@@ -753,7 +753,7 @@ body.gr-scroll-locked {
 	height: 0.75rem;
 }
 
-.gr-badge--sm .gr-badge__icon :global(svg) {
+.gr-badge--sm .gr-badge__icon svg {
 	width: 0.75rem;
 	height: 0.75rem;
 }
@@ -763,7 +763,7 @@ body.gr-scroll-locked {
 	height: 0.875rem;
 }
 
-.gr-badge--md .gr-badge__icon :global(svg) {
+.gr-badge--md .gr-badge__icon svg {
 	width: 0.875rem;
 	height: 0.875rem;
 }
@@ -773,7 +773,7 @@ body.gr-scroll-locked {
 	height: 1rem;
 }
 
-.gr-badge--lg .gr-badge__icon :global(svg) {
+.gr-badge--lg .gr-badge__icon svg {
 	width: 1rem;
 	height: 1rem;
 }
@@ -2192,7 +2192,7 @@ body.gr-scroll-locked {
 	gap: 1.5rem;
 }
 
-.gr-list > :global(li) {
+.gr-list > li {
 	display: flex;
 	align-items: flex-start;
 	gap: 0.75rem;
@@ -3429,8 +3429,8 @@ body.gr-scroll-locked {
 }
 
 /* High contrast explicit overrides */
-[data-theme='high-contrast'] .gr-action-bar :global(.gr-action-bar__button:hover:not(:disabled)),
-[data-theme='high-contrast'] .gr-action-bar :global(.gr-action-bar__button--active) {
+[data-theme='high-contrast'] .gr-action-bar .gr-action-bar__button:hover:not(:disabled),
+[data-theme='high-contrast'] .gr-action-bar .gr-action-bar__button--active {
 	color: var(--gr-color-base-black);
 }
 

--- a/registry/index.json
+++ b/registry/index.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://equalto.ai/schemas/registry-index.schema.json",
   "schemaVersion": "1.0.0",
-  "generatedAt": "2026-05-17T15:57:40.535Z",
+  "generatedAt": "2026-05-17T17:28:48.041Z",
   "ref": "greater-v0.8.13",
   "version": "0.8.13",
   "checksums": {
@@ -115,7 +115,7 @@
     "packages/primitives/src/index.ts": "sha256-a6qCP88DqcK7y7Xm6xl6eU1UGHSvXZ0hxyjgUDK/6gQ=",
     "packages/primitives/src/stores/preferences.d.ts": "sha256-GL7rI1+5S8FcclMz8SCqfGyjyhRjcU4FXocMVq8SCJw=",
     "packages/primitives/src/stores/preferences.ts": "sha256-VCztWHIEKWganxzse2nh21Ngv4QkwMCbB3pJvxTqrgs=",
-    "packages/primitives/src/theme.css": "sha256-+koUti7MO4gsCREDdo6JGwny6y/IV7Ots/BD4C5jWA0=",
+    "packages/primitives/src/theme.css": "sha256-eanN4xv2AaDR1S6mSWxHJY8JJ3O9A8T27WsSRH6YMe8=",
     "packages/primitives/src/transitions/fadeDown.d.ts": "sha256-FXf0D6TrZynSTiPhD0oDMMUlosk/uwgvq+VJyrfNnWI=",
     "packages/primitives/src/transitions/fadeDown.ts": "sha256-jLBp3teCghGZrIvdIjNXAvWCFrJxM1kqby0xcR1Kl/c=",
     "packages/primitives/src/transitions/fadeUp.d.ts": "sha256-qlEMPIsb+G2gXwRngGnYieiP1JeP/5iWnKw7tJhgRWU=",
@@ -1010,7 +1010,7 @@
     "packages/faces/social/src/patterns/ThreadView.svelte": "sha256-aBLxcKZgbRmyE/ryjmaIIfer5sB9GwjISTN9uldUdDQ=",
     "packages/faces/social/src/patterns/ThreadView.types.ts": "sha256-ujiFoiGKR4V2AOnsfgVHoBcdJDas4iAR2q6hzcWiGts=",
     "packages/faces/social/src/patterns/VisibilitySelector.svelte": "sha256-u0lxPUqzx59glvkW1CH+oZSEO/hOj3uOruK9w69yIvM=",
-    "packages/faces/social/src/theme.css": "sha256-m70mS6KwvdFuzZi6UNwi3wLUhlNsRNkFxsKgvOvhnTM=",
+    "packages/faces/social/src/theme.css": "sha256-wiMgWvybANnq8ikC0qHMur1K0g4iwepGGozhYuV6QCI=",
     "packages/faces/social/src/types.ts": "sha256-WNFevRWg2/Rq6uCALtBoVQql9JGaV4B63JYW2IkZSYQ=",
     "packages/faces/social/src/utils/notificationGrouping.ts": "sha256-h/6xwSoua5lvEsXzV66EhlKfxdH5VySXQs3hs7uuN5M=",
     "packages/faces/blog/src/components/Article/Content.svelte": "sha256-yxnJHl75OM52nOstB8fd9q7pGjyNb8xX3fzD2hiK9mw=",
@@ -1955,8 +1955,8 @@
         },
         {
           "path": "src/theme.css",
-          "checksum": "sha256-+koUti7MO4gsCREDdo6JGwny6y/IV7Ots/BD4C5jWA0=",
-          "size": 104645
+          "checksum": "sha256-eanN4xv2AaDR1S6mSWxHJY8JJ3O9A8T27WsSRH6YMe8=",
+          "size": 104591
         },
         {
           "path": "src/transitions/fadeDown.d.ts",
@@ -6625,8 +6625,8 @@
         },
         {
           "path": "src/theme.css",
-          "checksum": "sha256-m70mS6KwvdFuzZi6UNwi3wLUhlNsRNkFxsKgvOvhnTM=",
-          "size": 311206
+          "checksum": "sha256-wiMgWvybANnq8ikC0qHMur1K0g4iwepGGozhYuV6QCI=",
+          "size": 310684
         },
         {
           "path": "src/types.ts",


### PR DESCRIPTION
## Milestone

Issue #558 — remove Svelte-only selector syntax from Greater CLI-installed raw CSS assets.

## Classification

Bug fix / CLI registry hygiene / test coverage.

## What changed

- Replaced `:global(...)` selectors in registry-managed raw CSS with equivalent browser-valid selectors:
  - `packages/primitives/src/theme.css`
  - `packages/faces/social/src/theme.css`
- Added a CLI regression test that guards every raw CSS path copied by local CSS install from containing Svelte-only `:global(...)` syntax.
- Regenerated `registry/index.json` so per-file checksums match the changed CSS files.
- Added patch changeset `.changeset/browser-valid-raw-css.md`.

## Why

Simulacrum reported Vite/LightningCSS production build warnings after syncing to `greater-v0.8.13`. The affected selectors were shipped from Greater-managed raw CSS files, not Sim-authored code. Raw CSS copied into consumer apps must be browser-valid CSS by the time consumer minifiers see it.

Fixes #558.

## Consumer impact

- sim: should remove LightningCSS invalid pseudo-class warning noise for Greater-managed CSS.
- host / lesser UIs / external consumers: no component API change; CSS selector syntax is normalized while preserving intended styling.
- Mastodon-compatible surfaces: no protocol behavior change.

## Specialist walks referenced

- Investigation: #558 triage found this is a Greater raw CSS asset hygiene issue.
- Component API / theming: no public prop/slot/event or token rename/semantic shift.
- Contract sync: none.
- Accessibility: no DOM/ARIA/focus/contrast change intended.
- Registry: regenerated, not hand-edited.

## Validation

- `rg ':global\\(' packages/primitives/src/theme.css packages/faces/*/src/theme.css`
- `corepack pnpm --filter @equaltoai/greater-components-cli test`
- `corepack pnpm --filter @equaltoai/greater-components-primitives test`
- `corepack pnpm --filter @equaltoai/greater-components-social test`
- `corepack pnpm test`
- `corepack pnpm lint`
- `corepack pnpm typecheck`
- `corepack pnpm build`
- `corepack pnpm generate-registry:validate`
- `git diff --check`

## Release-flow plan

- Target: `staging`
- Branch contains current `origin/main`, `origin/premain`, and `origin/staging` as ancestors as of PR creation.
- Promote through normal Greater release flow after staging merge.