### PR TITLE
feat(blog): add article display surface

### DIFF
--- a/.changeset/blog-article-display-surface.md
+++ b/.changeset/blog-article-display-surface.md
@@ -1,0 +1,6 @@
+---
+"@equaltoai/greater-components-blog": minor
+"@equaltoai/greater-components": minor
+---
+
+Add SSR-friendly Blog face ArticleReader and ArticleCard/ArticleIndexCard exports for first-app public article reader and index routes, including flat Lesser/Emdash ArticleData-shaped input normalization and migration docs.

--- a/docs/faces/blog/article-rendering.md
+++ b/docs/faces/blog/article-rendering.md
@@ -8,6 +8,23 @@ can diverge from the server contract.
 
 ## Article component
 
+For a complete SSR-safe public reader route, prefer `ArticleReader`:
+
+```svelte
+<script lang="ts">
+	import { ArticleReader } from '@equaltoai/greater-components/faces/blog';
+</script>
+
+<ArticleReader {article} />
+```
+
+`ArticleReader` accepts canonical Greater `ArticleData` and flat Lesser/Emdash
+`ArticleData`-shaped display input. It defaults browser-only affordances such as reading progress,
+table-of-contents extraction, and share actions off so server-rendered reader routes can adopt it
+without a client-only lifecycle.
+
+For custom layouts, continue using the compound components:
+
 ```svelte
 <script lang="ts">
 	import { Article } from '$lib/components/faces/blog';
@@ -114,5 +131,6 @@ labeled as fallback/plain/escaped content.
 ## Related documentation
 
 - [Getting Started](./getting-started.md)
+- [Emdash Article Surface Migration](./emdash-article-surface.md)
 - [Lesser CMS Contract Audit](./lesser-cms-contract-audit.md)
 - [Core Patterns](../../core-patterns.md)

--- a/docs/faces/blog/emdash-article-surface.md
+++ b/docs/faces/blog/emdash-article-surface.md
@@ -1,0 +1,109 @@
+# Blog Face: Emdash Article Surface Migration
+
+Project 36 issue #573 added the first-app-proven Blog face display surface Emdash needs for
+public reader and index routes. The surface is intentionally narrow: it replaces local article HTML
+render glue, not Emdash routing, auth, adapters, SEO document metadata, comments, newsletter, search,
+RSS, timelines, or rich editing.
+
+## Public exports
+
+After the Greater release that contains this change, Emdash can consume the public aggregate package
+subpath from its own Svelte/FaceTheory SSR build without adopting Greater's workspace-internal Vite
+build chain:
+
+```ts
+import {
+	ArticleReader,
+	ArticleIndexCard,
+	normalizeArticleData,
+	type ArticleDisplayData,
+} from '@equaltoai/greater-components/faces/blog';
+import '@equaltoai/greater-components/faces/blog/style.css';
+```
+
+CLI-vendored consumers can use the equivalent vendored Blog face path produced by `greater add faces/blog`.
+The lower-level compound export remains stable for custom Svelte layouts:
+
+```ts
+import { Article } from '@equaltoai/greater-components/faces/blog';
+```
+
+`Article.Reader`, `Article.Card`, and `Article.IndexCard` are additive aliases on that namespace.
+
+## SSR reader replacement
+
+Emdash currently builds an Article reader body string locally. Replace that route-local body render with
+Svelte SSR over `ArticleReader` while keeping FaceTheory document metadata in Emdash:
+
+```ts
+import { render } from 'svelte/server';
+import { ArticleReader, type ArticleDisplayData } from '@equaltoai/greater-components/faces/blog';
+
+export function renderArticleBody(article: ArticleDisplayData): string {
+	return render(ArticleReader, {
+		props: {
+			article,
+			config: {
+				// Defaults are already SSR-safe: no reading progress, no TOC, no share bar.
+				showAuthor: true,
+			},
+		},
+	}).body;
+}
+```
+
+`ArticleReader` accepts canonical Greater `ArticleData` and the flat Lesser/Emdash
+`ArticleData`-shaped display object:
+
+- `contentFormat: 'HTML' | 'MARKDOWN'` is normalized to Greater's lowercase format.
+- `author.displayName` / `author.avatarUrl` are normalized to Blog face `AuthorData`.
+- `categories` become display tags for the public reader/card.
+- `featuredImage.url` / `featuredImage.altText` feed the existing featured-image presentation.
+
+For public Lesser-backed articles, `HTML` remains the canonical rendered/sanitized path. `MARKDOWN` is
+still escaped fallback text; Greater does not become a second public Markdown renderer.
+
+## SSR index-card replacement
+
+Replace Emdash's local `renderIndexCard(article)` helper with `ArticleIndexCard`:
+
+```ts
+import { render } from 'svelte/server';
+import {
+	ArticleIndexCard,
+	type ArticleDisplayData,
+} from '@equaltoai/greater-components/faces/blog';
+
+export function renderIndexCard(article: ArticleDisplayData): string {
+	return render(ArticleIndexCard, {
+		props: {
+			article,
+			href: `/articles/${article.slug}`,
+		},
+	}).body;
+}
+```
+
+The card emits one accessible link wrapping the card content, a heading, date/author/reading-time
+metadata, excerpt text, optional featured image, and category/tag chips. Emdash keeps owning index page
+layout, route state, loading/not-configured/not-found messaging, and canonical/SEO head tags.
+
+## Export evidence to verify after release
+
+Before removing Emdash's local render glue, verify the Greater release artifact exposes the compiled
+types for both public exports:
+
+```bash
+grep -E "ArticleReader|ArticleIndexCard" \
+  node_modules/@equaltoai/greater-components/dist/faces/blog/index.d.ts
+```
+
+Expected: both names are present. In a Svelte-enabled SSR test, the render smoke should also pass:
+
+```ts
+import { render } from 'svelte/server';
+import { ArticleIndexCard, ArticleReader } from '@equaltoai/greater-components/faces/blog';
+
+render(ArticleReader, { props: { article } });
+render(ArticleIndexCard, { props: { article, href: `/articles/${article.slug}` } });
+```

--- a/docs/faces/blog/getting-started.md
+++ b/docs/faces/blog/getting-started.md
@@ -76,6 +76,31 @@ import '$lib/styles/greater/blog.css';
 </Article.Root>
 ```
 
+### SSR-friendly reader and index card
+
+For first-app public display routes that do not need custom composition, use the complete SSR-safe
+exports instead of assembling the compound parts manually:
+
+```svelte
+<script lang="ts">
+	import { ArticleReader, ArticleIndexCard } from '@equaltoai/greater-components/faces/blog';
+
+	export let article;
+	export let articles = [];
+</script>
+
+<ArticleReader {article} />
+
+<section aria-label="Article index">
+	{#each articles as post (post.id)}
+		<ArticleIndexCard article={post} href={`/articles/${post.slug}`} />
+	{/each}
+</section>
+```
+
+See [Emdash Article Surface Migration](./emdash-article-surface.md) for the Project 36 migration note,
+SSR import path, and release/export verification command.
+
 ### Author Card
 
 ```svelte
@@ -142,5 +167,6 @@ See [Article Rendering](./article-rendering.md) for the renderer/sanitizer bound
 ## Next Steps
 
 - [Article Rendering](./article-rendering.md) – Public article rendering boundary
+- [Emdash Article Surface Migration](./emdash-article-surface.md) – Replacing first-app reader/index render glue
 - [Lesser CMS Contract Audit](./lesser-cms-contract-audit.md) – Lesser CMS adapter boundary
 - [Core Patterns](../../core-patterns.md) – Common patterns and best practices

--- a/docs/faces/blog/lesser-cms-contract-audit.md
+++ b/docs/faces/blog/lesser-cms-contract-audit.md
@@ -134,6 +134,10 @@ Concrete adapter work needed by Emdash before handing Lesser CMS objects to the 
   `publishedBy`, `Draft.author`, `Publication.actor`) out
   of reusable Blog UI types.
 - Leave `tableOfContents`, `series`, `seriesOrder`, draft scheduling, publication members, newsletter
-  stats, reactions, comments, and view counts out of this milestone until Emdash proves a concrete gap.
+  stats, reactions, comments, and view counts out of reusable Blog UI until Emdash proves a concrete
+  display gap for each surface.
 
-Issue #573 polish remains gated; this audit intentionally does not add speculative component features.
+Issue #573's proven display gap is covered by `ArticleReader` and `ArticleCard` /
+`ArticleIndexCard`; those components normalize the flat Lesser/Emdash ArticleData-shaped display
+object without adding richer editor, comments, newsletter, search, RSS, timeline, trending, or
+document-hosting scope.

--- a/packages/faces/blog/README.md
+++ b/packages/faces/blog/README.md
@@ -56,6 +56,9 @@ import '@equaltoai/greater-components-blog/style.css';
 | `Article.ReadingProgress` | Scroll progress indicator                        | `position`                      |
 | `Article.ShareBar`        | Social sharing buttons                           | `platforms`                     |
 | `Article.RelatedPosts`    | Related content suggestions                      | `posts`, `limit`                |
+| `Article.Reader`          | Complete SSR-safe article reader                 | `article`, `config`, `handlers` |
+| `Article.Card`            | Accessible article list/index card               | `article`, `href`               |
+| `Article.IndexCard`       | Alias of `Article.Card` for index routes         | `article`, `href`               |
 
 ### Author Components
 
@@ -169,6 +172,25 @@ Override design tokens to customize the theme:
 ```
 
 ## Usage Examples
+
+### Complete SSR Reader and Index Card
+
+```svelte
+<script lang="ts">
+	import { ArticleReader, ArticleIndexCard } from '@equaltoai/greater-components-blog';
+
+	export let article;
+	export let articles = [];
+</script>
+
+<ArticleReader {article} />
+
+<section aria-label="Article index">
+	{#each articles as post (post.id)}
+		<ArticleIndexCard article={post} href={`/articles/${post.slug}`} />
+	{/each}
+</section>
+```
 
 ### Basic Article Display
 

--- a/packages/faces/blog/manifest.json
+++ b/packages/faces/blog/manifest.json
@@ -14,9 +14,47 @@
         "TableOfContents",
         "ReadingProgress",
         "ShareBar",
-        "RelatedPosts"
+        "RelatedPosts",
+        "Reader",
+        "Card",
+        "IndexCard"
       ],
       "props": ["article", "config", "handlers"],
+      "exports": true
+    },
+    "ArticleReader": {
+      "description": "SSR-friendly complete public article reader accepting canonical or flat ArticleData-shaped input",
+      "props": ["article", "config", "handlers"],
+      "exports": true
+    },
+    "ArticleCard": {
+      "description": "Accessible article index card for listing public articles",
+      "props": [
+        "article",
+        "href",
+        "headingLevel",
+        "showExcerpt",
+        "showAuthor",
+        "showPublishedAt",
+        "showReadingTime",
+        "showTags",
+        "maxTags"
+      ],
+      "exports": true
+    },
+    "ArticleIndexCard": {
+      "description": "Alias of ArticleCard for article index routes",
+      "props": [
+        "article",
+        "href",
+        "headingLevel",
+        "showExcerpt",
+        "showAuthor",
+        "showPublishedAt",
+        "showReadingTime",
+        "showTags",
+        "maxTags"
+      ],
       "exports": true
     },
     "Author": {

--- a/packages/faces/blog/src/components/Article/Card.svelte
+++ b/packages/faces/blog/src/components/Article/Card.svelte
@@ -1,0 +1,135 @@
+<!--
+Article.Card - SSR-friendly article index card
+
+Designed for article index/list routes that need a single accessible link to a
+canonical Article reader page.
+-->
+
+<script lang="ts">
+	import { formatDateTime } from '@equaltoai/greater-components-utils';
+	import type { ArticleInputData } from '../../types.js';
+	import { normalizeArticleData } from './normalize.js';
+
+	interface Props {
+		/** Canonical Greater ArticleData or flat Lesser/Emdash ArticleData-shaped input. */
+		article: ArticleInputData;
+		/** Link target for the article. Defaults to `/articles/{slug}`. */
+		href?: string;
+		/** Heading level for the card title. */
+		headingLevel?: 2 | 3 | 4;
+		/** Show the article description/subtitle excerpt. */
+		showExcerpt?: boolean;
+		/** Show author name in card metadata. */
+		showAuthor?: boolean;
+		/** Show published date in card metadata. */
+		showPublishedAt?: boolean;
+		/** Show reading-time metadata when available. */
+		showReadingTime?: boolean;
+		/** Show article tags/categories. */
+		showTags?: boolean;
+		/** Maximum number of tags/categories to display. */
+		maxTags?: number;
+		/** Custom CSS class. */
+		class?: string;
+	}
+
+	let {
+		article,
+		href,
+		headingLevel = 2,
+		showExcerpt = true,
+		showAuthor = true,
+		showPublishedAt = true,
+		showReadingTime = true,
+		showTags = true,
+		maxTags = 3,
+		class: className = '',
+	}: Props = $props();
+
+	const normalizedArticle = $derived(normalizeArticleData(article));
+	const metadata = $derived(normalizedArticle.metadata);
+	const articleHref = $derived(href ?? `/articles/${normalizedArticle.slug}`);
+	const titleId = $derived(`gr-blog-article-card-title-${normalizedArticle.id}`);
+	const excerpt = $derived(metadata.description || metadata.subtitle || '');
+	const tags = $derived((metadata.tags ?? []).slice(0, maxTags));
+	const cardClass = $derived(['gr-blog-article-card', className].filter(Boolean).join(' '));
+	const headingTag = $derived(`h${headingLevel}` as 'h2' | 'h3' | 'h4');
+	const publishedIso = $derived(toIso(metadata.publishedAt));
+	const publishedLabel = $derived(formatDate(metadata.publishedAt));
+	const metaItems = $derived.by(() => {
+		const items: Array<{ label: string; datetime?: string }> = [];
+		if (showPublishedAt && publishedLabel) {
+			items.push({ label: publishedLabel, datetime: publishedIso });
+		}
+		if (showAuthor) {
+			items.push({ label: normalizedArticle.author.name });
+		}
+		if (showReadingTime && metadata.readingTime) {
+			items.push({ label: `${metadata.readingTime} min read` });
+		}
+		return items;
+	});
+
+	function toIso(value: Date | string): string | undefined {
+		const date = value instanceof Date ? value : new Date(value);
+		return Number.isNaN(date.valueOf()) ? undefined : date.toISOString();
+	}
+
+	function formatDate(value: Date | string): string {
+		try {
+			return formatDateTime(value);
+		} catch {
+			return String(value);
+		}
+	}
+</script>
+
+<article class={cardClass} aria-labelledby={titleId} data-article-id={normalizedArticle.id}>
+	<a class="gr-blog-article-card__link" href={articleHref}>
+		{#if metadata.featuredImage}
+			<img
+				class="gr-blog-article-card__image"
+				src={metadata.featuredImage}
+				alt={metadata.featuredImageAlt ?? ''}
+				loading="lazy"
+			/>
+		{/if}
+
+		<div class="gr-blog-article-card__body">
+			{#if metaItems.length > 0}
+				<p class="gr-blog-article-card__meta">
+					{#each metaItems as item, index (`${item.label}-${index}`)}
+						{#if index > 0}
+							<span class="gr-blog-article-card__separator" aria-hidden="true">·</span>
+						{/if}
+						{#if item.datetime}
+							<time datetime={item.datetime}>{item.label}</time>
+						{:else}
+							<span>{item.label}</span>
+						{/if}
+					{/each}
+				</p>
+			{/if}
+
+			<svelte:element this={headingTag} id={titleId} class="gr-blog-article-card__title">
+				{metadata.title}
+			</svelte:element>
+
+			{#if metadata.subtitle}
+				<p class="gr-blog-article-card__subtitle">{metadata.subtitle}</p>
+			{/if}
+
+			{#if showExcerpt && excerpt}
+				<p class="gr-blog-article-card__excerpt">{excerpt}</p>
+			{/if}
+
+			{#if showTags && tags.length > 0}
+				<ul class="gr-blog-article-card__tags" aria-label="Article tags">
+					{#each tags as tag (tag)}
+						<li class="gr-blog-article-card__tag">{tag}</li>
+					{/each}
+				</ul>
+			{/if}
+		</div>
+	</a>
+</article>

--- a/packages/faces/blog/src/components/Article/Card.svelte
+++ b/packages/faces/blog/src/components/Article/Card.svelte
@@ -6,8 +6,8 @@ canonical Article reader page.
 -->
 
 <script lang="ts">
-	import { formatDateTime } from '@equaltoai/greater-components-utils';
 	import type { ArticleInputData } from '../../types.js';
+	import { formatArticleDateTime } from './date.js';
 	import { normalizeArticleData } from './normalize.js';
 
 	interface Props {
@@ -54,12 +54,11 @@ canonical Article reader page.
 	const tags = $derived((metadata.tags ?? []).slice(0, maxTags));
 	const cardClass = $derived(['gr-blog-article-card', className].filter(Boolean).join(' '));
 	const headingTag = $derived(`h${headingLevel}` as 'h2' | 'h3' | 'h4');
-	const publishedIso = $derived(toIso(metadata.publishedAt));
-	const publishedLabel = $derived(formatDate(metadata.publishedAt));
+	const publishedDate = $derived(formatArticleDateTime(metadata.publishedAt));
 	const metaItems = $derived.by(() => {
 		const items: Array<{ label: string; datetime?: string }> = [];
-		if (showPublishedAt && publishedLabel) {
-			items.push({ label: publishedLabel, datetime: publishedIso });
+		if (showPublishedAt && publishedDate.label) {
+			items.push({ label: publishedDate.label, datetime: publishedDate.iso });
 		}
 		if (showAuthor) {
 			items.push({ label: normalizedArticle.author.name });
@@ -69,19 +68,6 @@ canonical Article reader page.
 		}
 		return items;
 	});
-
-	function toIso(value: Date | string): string | undefined {
-		const date = value instanceof Date ? value : new Date(value);
-		return Number.isNaN(date.valueOf()) ? undefined : date.toISOString();
-	}
-
-	function formatDate(value: Date | string): string {
-		try {
-			return formatDateTime(value);
-		} catch {
-			return String(value);
-		}
-	}
 </script>
 
 <article class={cardClass} aria-labelledby={titleId} data-article-id={normalizedArticle.id}>

--- a/packages/faces/blog/src/components/Article/Header.svelte
+++ b/packages/faces/blog/src/components/Article/Header.svelte
@@ -6,11 +6,12 @@ Article.Header - Article header with title, metadata, and featured image
 
 <script lang="ts">
 	import { getArticleContext } from './context.js';
-	import { formatDateTime } from '@equaltoai/greater-components-utils';
+	import { formatArticleDateTime } from './date.js';
 
 	const context = getArticleContext();
 	const article = $derived(context.article);
 	const metadata = $derived(article.metadata);
+	const publishedDate = $derived(formatArticleDateTime(metadata.publishedAt));
 </script>
 
 <header class="gr-blog-article__header">
@@ -37,9 +38,11 @@ Article.Header - Article header with title, metadata, and featured image
 	{/if}
 
 	<div class="gr-blog-article__meta">
-		<time datetime={new Date(metadata.publishedAt).toISOString()}>
-			{formatDateTime(metadata.publishedAt)}
-		</time>
+		{#if publishedDate.label}
+			<time datetime={publishedDate.iso}>
+				{publishedDate.label}
+			</time>
+		{/if}
 
 		{#if metadata.readingTime}
 			<span class="gr-blog-article__reading-time">

--- a/packages/faces/blog/src/components/Article/Reader.svelte
+++ b/packages/faces/blog/src/components/Article/Reader.svelte
@@ -1,0 +1,57 @@
+<!--
+Article.Reader - SSR-friendly complete article display component
+
+Composes the Article compound primitives for first-app public reader pages while
+keeping the lower-level Article.* pieces available for custom layouts.
+-->
+
+<script lang="ts">
+	import type { ArticleConfig, ArticleHandlers, ArticleInputData } from '../../types.js';
+	import { normalizeArticleData } from './normalize.js';
+	import Root from './Root.svelte';
+	import Header from './Header.svelte';
+	import Content from './Content.svelte';
+	import Footer from './Footer.svelte';
+	import TableOfContents from './TableOfContents.svelte';
+	import ReadingProgress from './ReadingProgress.svelte';
+
+	interface Props {
+		/** Canonical Greater ArticleData or flat Lesser/Emdash ArticleData-shaped input. */
+		article: ArticleInputData;
+		/** Optional rendering configuration. Defaults are SSR-safe for public readers. */
+		config?: ArticleConfig;
+		/** Optional action handlers forwarded to composed Article primitives. */
+		handlers?: ArticleHandlers;
+	}
+
+	let { article, config = {}, handlers = {} }: Props = $props();
+
+	const normalizedArticle = $derived(normalizeArticleData(article));
+	const readerConfig = $derived({
+		showReadingProgress: false,
+		showTableOfContents: false,
+		showShareBar: false,
+		showRelatedPosts: false,
+		showAuthor: true,
+		...config,
+	});
+</script>
+
+<Root article={normalizedArticle} config={readerConfig} {handlers}>
+	{#if readerConfig.showReadingProgress}
+		<ReadingProgress />
+	{/if}
+
+	<Header />
+
+	{#if readerConfig.showTableOfContents}
+		<div class="gr-blog-article__layout">
+			<TableOfContents />
+			<Content />
+		</div>
+	{:else}
+		<Content />
+	{/if}
+
+	<Footer />
+</Root>

--- a/packages/faces/blog/src/components/Article/date.ts
+++ b/packages/faces/blog/src/components/Article/date.ts
@@ -1,0 +1,24 @@
+import { formatDateTime } from '@equaltoai/greater-components-utils';
+
+export interface ArticleFormattedDateTime {
+	label: string;
+	iso?: string;
+}
+
+/**
+ * Formats an article timestamp for display while preserving a machine-readable
+ * datetime value for `<time>` elements.
+ */
+export function formatArticleDateTime(
+	value: Date | string | number | null | undefined
+): ArticleFormattedDateTime {
+	if (value === null || value === undefined || value === '') {
+		return { label: '' };
+	}
+
+	const formatted = formatDateTime(value);
+	return {
+		label: formatted.absolute,
+		iso: formatted.iso || undefined,
+	};
+}

--- a/packages/faces/blog/src/components/Article/index.ts
+++ b/packages/faces/blog/src/components/Article/index.ts
@@ -4,7 +4,11 @@
  * A flexible, composable article component for displaying long-form blog content.
  * Built using compound component pattern for maximum flexibility and customization.
  *
- * @example Basic usage
+ * Complete display helpers (`ArticleReader`, `ArticleCard`, and `ArticleIndexCard`)
+ * are SSR-friendly entry points for first-app reader/index pages that do not need
+ * to compose the lower-level primitives manually.
+ *
+ * @example Basic compound usage
  * ```svelte
  * <script>
  *   import { Article } from '@equaltoai/greater-components/faces/blog';
@@ -17,37 +21,19 @@
  * </Article.Root>
  * ```
  *
+ * @example Complete SSR reader usage
+ * ```svelte
+ * <script>
+ *   import { ArticleReader, ArticleIndexCard } from '@equaltoai/greater-components/faces/blog';
+ * </script>
+ *
+ * <ArticleReader article={post} />
+ * <ArticleIndexCard article={post} />
+ * ```
+ *
  * @module @equaltoai/greater-components/faces/blog/Article
  */
 
-// Placeholder exports - components to be implemented
-export { default as Root } from './Root.svelte';
-export { default as Header } from './Header.svelte';
-export { default as Content } from './Content.svelte';
-export { default as Footer } from './Footer.svelte';
-export { default as TableOfContents } from './TableOfContents.svelte';
-export { default as ReadingProgress } from './ReadingProgress.svelte';
-export { default as ShareBar } from './ShareBar.svelte';
-export { default as RelatedPosts } from './RelatedPosts.svelte';
-
-// Export types
-export type { ArticleContext, ArticleConfig, ArticleHandlers } from './context.js';
-
-/**
- * Article compound component
- */
-export const Article = {
-	Root: {} as typeof import('./Root.svelte').default,
-	Header: {} as typeof import('./Header.svelte').default,
-	Content: {} as typeof import('./Content.svelte').default,
-	Footer: {} as typeof import('./Footer.svelte').default,
-	TableOfContents: {} as typeof import('./TableOfContents.svelte').default,
-	ReadingProgress: {} as typeof import('./ReadingProgress.svelte').default,
-	ShareBar: {} as typeof import('./ShareBar.svelte').default,
-	RelatedPosts: {} as typeof import('./RelatedPosts.svelte').default,
-};
-
-// Dynamic imports for tree-shaking
 import Root from './Root.svelte';
 import Header from './Header.svelte';
 import Content from './Content.svelte';
@@ -56,12 +42,40 @@ import TableOfContents from './TableOfContents.svelte';
 import ReadingProgress from './ReadingProgress.svelte';
 import ShareBar from './ShareBar.svelte';
 import RelatedPosts from './RelatedPosts.svelte';
+import Reader from './Reader.svelte';
+import Card from './Card.svelte';
 
-Article.Root = Root;
-Article.Header = Header;
-Article.Content = Content;
-Article.Footer = Footer;
-Article.TableOfContents = TableOfContents;
-Article.ReadingProgress = ReadingProgress;
-Article.ShareBar = ShareBar;
-Article.RelatedPosts = RelatedPosts;
+export { default as Root } from './Root.svelte';
+export { default as Header } from './Header.svelte';
+export { default as Content } from './Content.svelte';
+export { default as Footer } from './Footer.svelte';
+export { default as TableOfContents } from './TableOfContents.svelte';
+export { default as ReadingProgress } from './ReadingProgress.svelte';
+export { default as ShareBar } from './ShareBar.svelte';
+export { default as RelatedPosts } from './RelatedPosts.svelte';
+export { default as Reader } from './Reader.svelte';
+export { default as Card } from './Card.svelte';
+export { default as ArticleReader } from './Reader.svelte';
+export { default as ArticleCard } from './Card.svelte';
+export { default as ArticleIndexCard } from './Card.svelte';
+export { normalizeArticleData } from './normalize.js';
+
+// Export types
+export type { ArticleContext, ArticleConfig, ArticleHandlers } from './context.js';
+
+/**
+ * Article compound component
+ */
+export const Article = {
+	Root,
+	Header,
+	Content,
+	Footer,
+	TableOfContents,
+	ReadingProgress,
+	ShareBar,
+	RelatedPosts,
+	Reader,
+	Card,
+	IndexCard: Card,
+};

--- a/packages/faces/blog/src/components/Article/normalize.ts
+++ b/packages/faces/blog/src/components/Article/normalize.ts
@@ -1,0 +1,137 @@
+import type {
+	ArticleData,
+	ArticleInputData,
+	ArticleInputAuthor,
+	ArticleInputCategory,
+	ArticleInputFeaturedImage,
+	ArticleMetadata,
+	AuthorData,
+} from '../../types.js';
+
+function hasObjectMetadata(article: ArticleInputData): article is ArticleData {
+	return (
+		'metadata' in article &&
+		!!article.metadata &&
+		typeof article.metadata === 'object' &&
+		'title' in article.metadata &&
+		'description' in article.metadata &&
+		'publishedAt' in article.metadata
+	);
+}
+
+function normalizeContentFormat(
+	format: ArticleInputData['contentFormat']
+): ArticleData['contentFormat'] {
+	return String(format).toLowerCase() === 'html' ? 'html' : 'markdown';
+}
+
+function normalizeAuthor(author: AuthorData | ArticleInputAuthor): AuthorData {
+	if ('name' in author && typeof author.name === 'string' && author.name.trim()) {
+		return {
+			id: author.id,
+			name: author.name,
+			username: author.username,
+			bio: author.bio,
+			shortBio: author.shortBio,
+			avatar: author.avatar,
+			coverImage: author.coverImage,
+			socialLinks: author.socialLinks,
+			publication: author.publication,
+			articleCount: author.articleCount,
+			followerCount: author.followerCount,
+		};
+	}
+
+	const displayName = 'displayName' in author ? author.displayName : undefined;
+	const username = 'username' in author ? author.username : undefined;
+	const avatarUrl = 'avatarUrl' in author ? author.avatarUrl : undefined;
+
+	return {
+		id: author.id,
+		name: displayName?.trim() || (username ? `@${username}` : 'Unknown author'),
+		username,
+		bio: author.bio,
+		avatar: avatarUrl,
+	};
+}
+
+function normalizeCategoryName(category: string | ArticleInputCategory): string {
+	return typeof category === 'string' ? category : category.name;
+}
+
+function normalizeFeaturedImage(
+	featuredImage: string | ArticleInputFeaturedImage | undefined
+): Pick<ArticleMetadata, 'featuredImage' | 'featuredImageAlt' | 'featuredImageCaption'> {
+	if (!featuredImage) {
+		return {};
+	}
+
+	if (typeof featuredImage === 'string') {
+		return { featuredImage };
+	}
+
+	return {
+		featuredImage: featuredImage.url ?? featuredImage.src,
+		featuredImageAlt: featuredImage.altText ?? featuredImage.alt,
+		featuredImageCaption: featuredImage.caption,
+	};
+}
+
+/**
+ * Normalizes the canonical Greater `ArticleData` shape and the flat Lesser/Emdash
+ * article display shape into the Blog face view model consumed by Article.* components.
+ */
+export function normalizeArticleData(article: ArticleInputData): ArticleData {
+	if (hasObjectMetadata(article)) {
+		return {
+			...article,
+			contentFormat: normalizeContentFormat(article.contentFormat),
+			author: normalizeAuthor(article.author),
+			metadata: {
+				...article.metadata,
+				description:
+					article.metadata.description || article.metadata.subtitle || article.metadata.title,
+			},
+			isPublished: article.isPublished ?? true,
+		};
+	}
+
+	const categories = article.categories?.map(normalizeCategoryName).filter(Boolean) ?? [];
+	const tags = article.tags ?? article.metadata?.tags ?? categories;
+	const featuredImage = normalizeFeaturedImage(article.featuredImage);
+	const metadata: ArticleMetadata = {
+		title: article.title ?? article.metadata?.title ?? 'Untitled article',
+		subtitle: article.subtitle ?? article.metadata?.subtitle,
+		description:
+			article.description ??
+			article.excerpt ??
+			article.seoDescription ??
+			article.metadata?.description ??
+			article.subtitle ??
+			article.title ??
+			'Untitled article',
+		publishedAt: article.publishedAt ?? article.metadata?.publishedAt ?? article.updatedAt ?? '',
+		updatedAt: article.updatedAt ?? article.metadata?.updatedAt,
+		readingTime: article.readingTimeMinutes ?? article.readingTime ?? article.metadata?.readingTime,
+		wordCount: article.wordCount ?? article.metadata?.wordCount,
+		canonicalUrl: article.canonicalUrl ?? article.metadata?.canonicalUrl,
+		tags: [...tags],
+		category: article.category ?? article.metadata?.category ?? categories[0],
+		...featuredImage,
+	};
+
+	return {
+		id: article.id,
+		slug: article.slug,
+		metadata,
+		content: article.content,
+		contentFormat: normalizeContentFormat(article.contentFormat),
+		author: normalizeAuthor(article.author),
+		publication: article.publication,
+		isPublished: article.isPublished ?? true,
+		isFeatured: article.isFeatured,
+		viewCount: article.viewCount,
+		reactions: article.reactions,
+		commentCount: article.commentCount,
+	};
+}

--- a/packages/faces/blog/src/index.ts
+++ b/packages/faces/blog/src/index.ts
@@ -16,9 +16,15 @@
 // ============================================================================
 
 /**
- * Article compound component for long-form content display
+ * Article compound and complete SSR components for long-form content display
  */
-export { Article } from './components/Article/index.js';
+export {
+	Article,
+	ArticleReader,
+	ArticleCard,
+	ArticleIndexCard,
+	normalizeArticleData,
+} from './components/Article/index.js';
 
 /**
  * Author compound component for author profiles and bios
@@ -58,6 +64,12 @@ export * from './patterns/index.js';
 export type {
 	// Article types
 	ArticleData,
+	ArticleDisplayData,
+	ArticleInputData,
+	ArticleInputAuthor,
+	ArticleInputCategory,
+	ArticleInputFeaturedImage,
+	ArticleInputContentFormat,
 	ArticleMetadata,
 	ArticleConfig,
 	ArticleHandlers,

--- a/packages/faces/blog/src/theme.css
+++ b/packages/faces/blog/src/theme.css
@@ -77,6 +77,29 @@
 	--gr-blog-progress-background: var(--gr-color-neutral-700);
 }
 
+[data-theme='dark'] .gr-blog-article-card {
+	background: var(--gr-color-neutral-900);
+	border-color: var(--gr-color-neutral-700);
+}
+
+[data-theme='dark'] .gr-blog-article-card__meta {
+	color: var(--gr-color-neutral-400);
+}
+
+[data-theme='dark'] .gr-blog-article-card__title {
+	color: var(--gr-color-neutral-100);
+}
+
+[data-theme='dark'] .gr-blog-article-card__subtitle,
+[data-theme='dark'] .gr-blog-article-card__excerpt {
+	color: var(--gr-color-neutral-300);
+}
+
+[data-theme='dark'] .gr-blog-article-card__tag {
+	background: var(--gr-color-neutral-800);
+	color: var(--gr-color-neutral-200);
+}
+
 /* ============================================================================
  * Article Layout
  * ============================================================================ */
@@ -131,6 +154,116 @@
 
 .gr-blog-article__content h4 {
 	font-size: var(--gr-typography-fontSize-xl);
+}
+
+.gr-blog-article__layout {
+	display: grid;
+	gap: var(--gr-spacing-scale-8);
+	align-items: start;
+}
+
+@media (min-width: 1100px) {
+	.gr-blog-article__layout {
+		grid-template-columns: var(--gr-blog-toc-width) minmax(0, 1fr);
+	}
+}
+
+/* ============================================================================
+ * Article Cards
+ * ============================================================================ */
+
+.gr-blog-article-card {
+	background: var(--gr-color-surface, var(--gr-color-neutral-0, #ffffff));
+	border: 1px solid var(--gr-color-border, var(--gr-color-neutral-200));
+	border-radius: var(--gr-radii-lg);
+	overflow: hidden;
+	transition:
+		border-color 150ms ease,
+		box-shadow 150ms ease,
+		transform 150ms ease;
+}
+
+.gr-blog-article-card:focus-within,
+.gr-blog-article-card:hover {
+	border-color: var(--gr-color-primary-300);
+	box-shadow: var(--gr-shadow-md, 0 8px 24px rgba(15, 23, 42, 0.12));
+	transform: translateY(-1px);
+}
+
+.gr-blog-article-card__link {
+	display: block;
+	color: inherit;
+	text-decoration: none;
+}
+
+.gr-blog-article-card__link:focus-visible {
+	outline: 3px solid var(--gr-color-focus, var(--gr-color-primary-600));
+	outline-offset: 3px;
+}
+
+.gr-blog-article-card__image {
+	display: block;
+	width: 100%;
+	aspect-ratio: var(--gr-blog-featured-image-ratio);
+	object-fit: cover;
+}
+
+.gr-blog-article-card__body {
+	padding: var(--gr-spacing-scale-6);
+}
+
+.gr-blog-article-card__meta {
+	display: flex;
+	flex-wrap: wrap;
+	align-items: center;
+	gap: var(--gr-spacing-scale-2);
+	margin: 0 0 var(--gr-spacing-scale-3);
+	font-family: var(--gr-blog-font-family-heading);
+	font-size: var(--gr-typography-fontSize-sm);
+	color: var(--gr-color-neutral-600);
+}
+
+.gr-blog-article-card__separator {
+	color: var(--gr-color-neutral-400);
+}
+
+.gr-blog-article-card__title {
+	margin: 0 0 var(--gr-spacing-scale-2);
+	font-family: var(--gr-blog-font-family-heading);
+	font-size: var(--gr-typography-fontSize-2xl);
+	line-height: var(--gr-blog-line-height-heading);
+	color: var(--gr-color-neutral-900);
+}
+
+.gr-blog-article-card__subtitle,
+.gr-blog-article-card__excerpt {
+	margin: 0 0 var(--gr-spacing-scale-3);
+	color: var(--gr-color-neutral-700);
+	line-height: 1.6;
+}
+
+.gr-blog-article-card__excerpt {
+	font-size: var(--gr-typography-fontSize-base);
+}
+
+.gr-blog-article-card__tags {
+	display: flex;
+	flex-wrap: wrap;
+	gap: var(--gr-spacing-scale-2);
+	padding: 0;
+	margin: var(--gr-spacing-scale-4) 0 0;
+	list-style: none;
+}
+
+.gr-blog-article-card__tag {
+	display: inline-flex;
+	align-items: center;
+	border-radius: var(--gr-radii-full);
+	background: var(--gr-color-neutral-100);
+	color: var(--gr-color-neutral-700);
+	padding: var(--gr-spacing-scale-1) var(--gr-spacing-scale-3);
+	font-size: var(--gr-typography-fontSize-sm);
+	font-family: var(--gr-blog-font-family-heading);
 }
 
 /* ============================================================================

--- a/packages/faces/blog/src/types.ts
+++ b/packages/faces/blog/src/types.ts
@@ -81,6 +81,90 @@ export interface ArticleData {
 }
 
 /**
+ * Content formats accepted by the complete Article display components.
+ *
+ * Lowercase values are the canonical Greater view-model format. Uppercase values
+ * mirror Lesser's GraphQL enum casing so first-app adapters can hand the Blog
+ * face their ArticleData-shaped display object without a local rendering layer.
+ */
+export type ArticleInputContentFormat = ArticleData['contentFormat'] | 'HTML' | 'MARKDOWN';
+
+/**
+ * Minimal flat author shape accepted by Article.Reader and Article.Card.
+ * Canonical Greater `AuthorData` remains the normalized public view model.
+ */
+export interface ArticleInputAuthor {
+	id: string;
+	username?: string;
+	displayName?: string;
+	avatarUrl?: string;
+	bio?: string;
+}
+
+/**
+ * Minimal category/tag shape accepted by Article.Reader and Article.Card.
+ */
+export interface ArticleInputCategory {
+	id?: string;
+	name: string;
+	slug?: string;
+}
+
+/**
+ * Minimal featured image shape accepted by Article.Reader and Article.Card.
+ */
+export interface ArticleInputFeaturedImage {
+	url?: string;
+	src?: string;
+	alt?: string;
+	altText?: string;
+	caption?: string;
+	width?: number;
+	height?: number;
+}
+
+/**
+ * Flat ArticleData-shaped display input accepted by the complete Article
+ * components. This keeps first-app SSR consumers from maintaining their own
+ * article-reader/card HTML while preserving the canonical nested `ArticleData`
+ * type used by the existing compound Article.* primitives.
+ */
+export interface ArticleDisplayData {
+	id: string;
+	slug: string;
+	metadata?: Partial<ArticleMetadata>;
+	title?: string;
+	subtitle?: string;
+	description?: string;
+	excerpt?: string;
+	content: string;
+	contentFormat: ArticleInputContentFormat;
+	author: AuthorData | ArticleInputAuthor;
+	publication?: PublicationData;
+	isPublished?: boolean;
+	isFeatured?: boolean;
+	viewCount?: number;
+	reactions?: ReactionData;
+	commentCount?: number;
+	canonicalUrl?: string;
+	publishedAt?: Date | string;
+	updatedAt?: Date | string;
+	readingTime?: number;
+	readingTimeMinutes?: number;
+	wordCount?: number;
+	tags?: readonly string[];
+	category?: string;
+	categories?: ReadonlyArray<string | ArticleInputCategory>;
+	featuredImage?: string | ArticleInputFeaturedImage;
+	seoDescription?: string;
+}
+
+/**
+ * Article input accepted by complete Article display components.
+ */
+export type ArticleInputData = ArticleData | ArticleDisplayData;
+
+/**
  * Article component configuration
  */
 export interface ArticleConfig {

--- a/packages/faces/blog/tests/components/ArticleDisplay.test.ts
+++ b/packages/faces/blog/tests/components/ArticleDisplay.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, it, vi } from 'vitest';
+import { render, screen } from '@testing-library/svelte';
+import {
+	Article,
+	ArticleCard,
+	ArticleIndexCard,
+	ArticleReader,
+	normalizeArticleData,
+} from '../../src/components/Article/index.js';
+import type { ArticleDisplayData } from '../../src/types.js';
+
+vi.mock('@equaltoai/greater-components-utils', () => ({
+	formatDateTime: (date: Date | string) => new Date(date).toISOString().split('T')[0],
+	sanitizeHtml: (html: string) => html,
+}));
+
+const flatArticle: ArticleDisplayData = {
+	id: 'emdash-article-1',
+	slug: 'proven-blog-gaps',
+	title: 'Proven Blog Gaps',
+	subtitle: 'What Emdash needs from Greater',
+	excerpt: 'A first-app proven article display gap.',
+	content: '<h2>Evidence</h2><p>Rendered by Lesser.</p>',
+	contentFormat: 'HTML',
+	author: {
+		id: 'actor-1',
+		username: 'writer',
+		displayName: 'Demo Writer',
+		avatarUrl: '/avatar.png',
+	},
+	publishedAt: '2026-05-20T12:00:00.000Z',
+	updatedAt: '2026-05-20T13:00:00.000Z',
+	readingTimeMinutes: 4,
+	wordCount: 820,
+	canonicalUrl: 'https://example.test/articles/proven-blog-gaps',
+	categories: [
+		{ id: 'c1', name: 'Fediverse', slug: 'fediverse' },
+		{ id: 'c2', name: 'Greater', slug: 'greater' },
+	],
+	featuredImage: {
+		url: '/article.png',
+		altText: 'Article illustration',
+	},
+};
+
+describe('Article complete display exports', () => {
+	it('keeps additive aliases on the Article namespace', () => {
+		expect(Article.Reader).toBe(ArticleReader);
+		expect(Article.Card).toBe(ArticleCard);
+		expect(Article.IndexCard).toBe(ArticleIndexCard);
+	});
+
+	it('normalizes flat Lesser/Emdash ArticleData-shaped input', () => {
+		const article = normalizeArticleData(flatArticle);
+
+		expect(article.contentFormat).toBe('html');
+		expect(article.author.name).toBe('Demo Writer');
+		expect(article.metadata.title).toBe('Proven Blog Gaps');
+		expect(article.metadata.description).toBe('A first-app proven article display gap.');
+		expect(article.metadata.readingTime).toBe(4);
+		expect(article.metadata.tags).toEqual(['Fediverse', 'Greater']);
+		expect(article.metadata.featuredImage).toBe('/article.png');
+	});
+
+	it('renders an SSR-friendly ArticleReader without browser-only affordances by default', () => {
+		render(ArticleReader, { props: { article: flatArticle } });
+
+		expect(screen.getByRole('article')).toBeInTheDocument();
+		expect(screen.getByRole('heading', { level: 1, name: 'Proven Blog Gaps' })).toBeInTheDocument();
+		expect(screen.getByText('What Emdash needs from Greater')).toBeInTheDocument();
+		expect(screen.getByText('Rendered by Lesser.')).toBeInTheDocument();
+		expect(screen.getByText('Demo Writer')).toBeInTheDocument();
+		expect(screen.queryByRole('progressbar')).toBeNull();
+	});
+
+	it('renders an accessible ArticleCard for index routes', () => {
+		render(ArticleCard, {
+			props: {
+				article: flatArticle,
+				href: '/journal/proven-blog-gaps',
+			},
+		});
+
+		const link = screen.getByRole('link');
+		expect(link).toHaveAttribute('href', '/journal/proven-blog-gaps');
+		expect(screen.getByRole('heading', { level: 2, name: 'Proven Blog Gaps' })).toBeInTheDocument();
+		expect(screen.getByText('Demo Writer')).toBeInTheDocument();
+		expect(screen.getByText('4 min read')).toBeInTheDocument();
+		expect(screen.getByText('Fediverse')).toBeInTheDocument();
+		expect(screen.getByText('Greater')).toBeInTheDocument();
+		expect(screen.getByRole('img', { name: 'Article illustration' })).toBeInTheDocument();
+	});
+});

--- a/packages/faces/blog/tests/components/ArticleDisplay.test.ts
+++ b/packages/faces/blog/tests/components/ArticleDisplay.test.ts
@@ -1,4 +1,5 @@
-import { describe, expect, it, vi } from 'vitest';
+import { formatDateTime } from '@equaltoai/greater-components-utils';
+import { describe, expect, it } from 'vitest';
 import { render, screen } from '@testing-library/svelte';
 import {
 	Article,
@@ -8,11 +9,6 @@ import {
 	normalizeArticleData,
 } from '../../src/components/Article/index.js';
 import type { ArticleDisplayData } from '../../src/types.js';
-
-vi.mock('@equaltoai/greater-components-utils', () => ({
-	formatDateTime: (date: Date | string) => new Date(date).toISOString().split('T')[0],
-	sanitizeHtml: (html: string) => html,
-}));
 
 const flatArticle: ArticleDisplayData = {
 	id: 'emdash-article-1',
@@ -64,9 +60,12 @@ describe('Article complete display exports', () => {
 
 	it('renders an SSR-friendly ArticleReader without browser-only affordances by default', () => {
 		render(ArticleReader, { props: { article: flatArticle } });
+		const publishedLabel = formatDateTime(flatArticle.publishedAt as string).absolute;
 
 		expect(screen.getByRole('article')).toBeInTheDocument();
 		expect(screen.getByRole('heading', { level: 1, name: 'Proven Blog Gaps' })).toBeInTheDocument();
+		expect(screen.getByText(publishedLabel)).toBeInTheDocument();
+		expect(screen.queryByText('[object Object]')).toBeNull();
 		expect(screen.getByText('What Emdash needs from Greater')).toBeInTheDocument();
 		expect(screen.getByText('Rendered by Lesser.')).toBeInTheDocument();
 		expect(screen.getByText('Demo Writer')).toBeInTheDocument();
@@ -80,10 +79,13 @@ describe('Article complete display exports', () => {
 				href: '/journal/proven-blog-gaps',
 			},
 		});
+		const published = formatDateTime(flatArticle.publishedAt as string);
 
 		const link = screen.getByRole('link');
 		expect(link).toHaveAttribute('href', '/journal/proven-blog-gaps');
 		expect(screen.getByRole('heading', { level: 2, name: 'Proven Blog Gaps' })).toBeInTheDocument();
+		expect(screen.getByText(published.absolute)).toHaveAttribute('datetime', published.iso);
+		expect(screen.queryByText('[object Object]')).toBeNull();
 		expect(screen.getByText('Demo Writer')).toBeInTheDocument();
 		expect(screen.getByText('4 min read')).toBeInTheDocument();
 		expect(screen.getByText('Fediverse')).toBeInTheDocument();

--- a/packages/faces/blog/tests/ssr.test.ts
+++ b/packages/faces/blog/tests/ssr.test.ts
@@ -46,6 +46,7 @@ describe('Blog face SSR safety', () => {
 
 		expect(result.body).toContain('SSR Reader');
 		expect(result.body).toContain('Rendered by Lesser.');
+		expect(result.body).not.toContain('[object Object]');
 		expect(result.body).not.toContain('role="progressbar"');
 	});
 
@@ -65,5 +66,6 @@ describe('Blog face SSR safety', () => {
 		expect(result.body).toContain('href="/articles/server-card"');
 		expect(result.body).toContain('Server Card');
 		expect(result.body).toContain('Article tags');
+		expect(result.body).not.toContain('[object Object]');
 	});
 });

--- a/packages/faces/blog/tests/ssr.test.ts
+++ b/packages/faces/blog/tests/ssr.test.ts
@@ -3,8 +3,10 @@
 import { describe, expect, it } from 'vitest';
 import { render } from 'svelte/server';
 import { Article } from '../src/components/Article/index.js';
+import { ArticleIndexCard, ArticleReader } from '../src/index.js';
 import ArticleTestWrapper from './fixtures/ArticleTestWrapper.svelte';
 import { createMockArticle } from './mocks/mockArticle.js';
+import type { ArticleDisplayData } from '../src/types.js';
 
 describe('Blog face SSR safety', () => {
 	it('renders Article.Root with ShareBar on the server without browser globals', () => {
@@ -18,5 +20,50 @@ describe('Blog face SSR safety', () => {
 
 		expect(result.body).toContain(article.id);
 		expect(result.body).toContain('Copy Link');
+	});
+
+	it('renders ArticleReader from flat ArticleData-shaped input on the server', () => {
+		const article: ArticleDisplayData = {
+			id: 'ssr-reader',
+			slug: 'ssr-reader',
+			title: 'SSR Reader',
+			excerpt: 'Server-rendered display surface',
+			content: '<h2>Server body</h2><p>Rendered by Lesser.</p>',
+			contentFormat: 'HTML',
+			author: {
+				id: 'author-1',
+				username: 'writer',
+				displayName: 'Demo Writer',
+			},
+			publishedAt: '2026-05-20T12:00:00.000Z',
+			readingTimeMinutes: 3,
+			categories: [{ name: 'Greater' }],
+		};
+
+		const result = render(ArticleReader, {
+			props: { article },
+		});
+
+		expect(result.body).toContain('SSR Reader');
+		expect(result.body).toContain('Rendered by Lesser.');
+		expect(result.body).not.toContain('role="progressbar"');
+	});
+
+	it('renders ArticleIndexCard on the server from the public card export', () => {
+		const article = createMockArticle('ssr-card', {
+			slug: 'server-card',
+			metadata: {
+				...createMockArticle('ssr-card').metadata,
+				title: 'Server Card',
+			},
+		});
+
+		const result = render(ArticleIndexCard, {
+			props: { article, href: '/articles/server-card' },
+		});
+
+		expect(result.body).toContain('href="/articles/server-card"');
+		expect(result.body).toContain('Server Card');
+		expect(result.body).toContain('Article tags');
 	});
 });

--- a/registry/index.json
+++ b/registry/index.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://equalto.ai/schemas/registry-index.schema.json",
   "schemaVersion": "1.0.0",
-  "generatedAt": "2026-05-20T16:12:55.618Z",
+  "generatedAt": "2026-05-20T19:35:29.731Z",
   "ref": "greater-v0.8.15",
   "version": "0.8.15",
   "checksums": {
@@ -1013,11 +1013,14 @@
     "packages/faces/social/src/theme.css": "sha256-wiMgWvybANnq8ikC0qHMur1K0g4iwepGGozhYuV6QCI=",
     "packages/faces/social/src/types.ts": "sha256-WNFevRWg2/Rq6uCALtBoVQql9JGaV4B63JYW2IkZSYQ=",
     "packages/faces/social/src/utils/notificationGrouping.ts": "sha256-h/6xwSoua5lvEsXzV66EhlKfxdH5VySXQs3hs7uuN5M=",
+    "packages/faces/blog/src/components/Article/Card.svelte": "sha256-j0HGBGR7LKKS3SrsAZ2gSXT1L9B3F2oCK+tb1RbMs2E=",
     "packages/faces/blog/src/components/Article/Content.svelte": "sha256-paCAdQ5yRDaVEpY5pwfmcU6Akx1gAPOnIqSNK3WYKo0=",
     "packages/faces/blog/src/components/Article/context.ts": "sha256-bYXS4NwSLcHdl8QnpVedTKNR94Tq1CjD+lUzj4zuwKI=",
     "packages/faces/blog/src/components/Article/Footer.svelte": "sha256-4ko7rj3fBa6Wd3qPjppbqGxBXukvBrz50TgFFqMobkk=",
     "packages/faces/blog/src/components/Article/Header.svelte": "sha256-uK21b88M/aZuGibnesH7hC3VNlSkyypPTK9FkUc34xM=",
-    "packages/faces/blog/src/components/Article/index.ts": "sha256-cqVhwTmGx5Q2HYudE2DpRJvmkvfVyPxmO9p//CZmld8=",
+    "packages/faces/blog/src/components/Article/index.ts": "sha256-OQmVd0L2/zY4hGqgC9y5eeOPTrkZCru/O1sdN+r5IQk=",
+    "packages/faces/blog/src/components/Article/normalize.ts": "sha256-/rcTG3AUWshRnFGt+qbzj9Qz7mqSF535NXACjW37PRk=",
+    "packages/faces/blog/src/components/Article/Reader.svelte": "sha256-jKSgDp9ZTFhnX0qKnEs31dfZYtyuQrq3rmfo4pL1Usw=",
     "packages/faces/blog/src/components/Article/ReadingProgress.svelte": "sha256-vCMh+fX213ceffrhwZK2hi0lOUqLLmOxvw8zTJgmzk8=",
     "packages/faces/blog/src/components/Article/RelatedPosts.svelte": "sha256-nkEuNxlnEchAjNQ5rYqJJy1u6g3aftV+y1+A9ondI1c=",
     "packages/faces/blog/src/components/Article/Root.svelte": "sha256-+ktqxdP4Cvnk4KyfvraFwZlbQaJMFPUYXh3HZ/A6Rf8=",
@@ -1041,11 +1044,11 @@
     "packages/faces/blog/src/components/Publication/index.ts": "sha256-IWQslXRiAZ6zBi8RkWBXorTaHbABFZyCy1ZunrwgsHM=",
     "packages/faces/blog/src/components/Publication/NewsletterSignup.svelte": "sha256-2apj+djfbBcY5kSjOhw5zm7Sx94BAOromFLZaCE0ffE=",
     "packages/faces/blog/src/components/Publication/Root.svelte": "sha256-sJwa9osYlqvmj3ITBFP29sLBsMzZdbRyYRMVA3bl5aM=",
-    "packages/faces/blog/src/index.ts": "sha256-qxbOIjKWKSEQlX0Q/D4r59lBAPd+8f5M3WhduvnqOMw=",
+    "packages/faces/blog/src/index.ts": "sha256-CdsP4ne6cJPNyl9fVIFUD0WNjzmGAOgVMfAMwTBu9XE=",
     "packages/faces/blog/src/patterns/index.ts": "sha256-meoG+gNvG1Os36voxE5lVckTjWYsOZA+Tdff8i7HsDY=",
     "packages/faces/blog/src/share.ts": "sha256-zh34kdwk9EtN/we6XkorjmvX8eXNRaQQBC1YKwVOSCo=",
-    "packages/faces/blog/src/theme.css": "sha256-MUgaehwVg/hmQEVDoMD07vDfivv1LEcjxz24fX0OZts=",
-    "packages/faces/blog/src/types.ts": "sha256-mVXkcB9E/hVsSr5NaLkGvS0smN0ARhuHIFDrRkfcCgg=",
+    "packages/faces/blog/src/theme.css": "sha256-qsOj8QqGGo9fjdJJB2CXAPhMc3o6xcSfWr7B5vDEiis=",
+    "packages/faces/blog/src/types.ts": "sha256-O0eka2eNAnkY889rXPxc+9Km7dnqgLFaSjxAunA/FZU=",
     "packages/faces/community/src/components/Community/context.ts": "sha256-o7hAokh6NA8qRTQSPQx4gZSwM2yKGGWlgI9xWCCQTY8=",
     "packages/faces/community/src/components/Community/Header.svelte": "sha256-Cgg2NDuydM3itR8WioXBTqcdGuRWBeMnvmi/yfg7yCc=",
     "packages/faces/community/src/components/Community/index.ts": "sha256-O2i+BMNyHIDeaNrAk13XiIJjifx4MiVDHa1A5eSMJLg=",
@@ -6748,6 +6751,9 @@
       "description": "Blog/Medium-style UI components for long-form publishing applications",
       "exports": [
         "Article",
+        "ArticleReader",
+        "ArticleCard",
+        "ArticleIndexCard",
         "Author",
         "Publication",
         "Navigation",
@@ -6782,6 +6788,11 @@
       },
       "files": [
         {
+          "path": "src/components/Article/Card.svelte",
+          "checksum": "sha256-j0HGBGR7LKKS3SrsAZ2gSXT1L9B3F2oCK+tb1RbMs2E=",
+          "size": 4281
+        },
+        {
           "path": "src/components/Article/Content.svelte",
           "checksum": "sha256-paCAdQ5yRDaVEpY5pwfmcU6Akx1gAPOnIqSNK3WYKo0=",
           "size": 1697
@@ -6803,8 +6814,18 @@
         },
         {
           "path": "src/components/Article/index.ts",
-          "checksum": "sha256-cqVhwTmGx5Q2HYudE2DpRJvmkvfVyPxmO9p//CZmld8=",
-          "size": 2390
+          "checksum": "sha256-OQmVd0L2/zY4hGqgC9y5eeOPTrkZCru/O1sdN+r5IQk=",
+          "size": 2572
+        },
+        {
+          "path": "src/components/Article/normalize.ts",
+          "checksum": "sha256-/rcTG3AUWshRnFGt+qbzj9Qz7mqSF535NXACjW37PRk=",
+          "size": 4354
+        },
+        {
+          "path": "src/components/Article/Reader.svelte",
+          "checksum": "sha256-jKSgDp9ZTFhnX0qKnEs31dfZYtyuQrq3rmfo4pL1Usw=",
+          "size": 1671
         },
         {
           "path": "src/components/Article/ReadingProgress.svelte",
@@ -6923,8 +6944,8 @@
         },
         {
           "path": "src/index.ts",
-          "checksum": "sha256-qxbOIjKWKSEQlX0Q/D4r59lBAPd+8f5M3WhduvnqOMw=",
-          "size": 2085
+          "checksum": "sha256-CdsP4ne6cJPNyl9fVIFUD0WNjzmGAOgVMfAMwTBu9XE=",
+          "size": 2317
         },
         {
           "path": "src/patterns/index.ts",
@@ -6938,13 +6959,13 @@
         },
         {
           "path": "src/theme.css",
-          "checksum": "sha256-MUgaehwVg/hmQEVDoMD07vDfivv1LEcjxz24fX0OZts=",
-          "size": 16766
+          "checksum": "sha256-qsOj8QqGGo9fjdJJB2CXAPhMc3o6xcSfWr7B5vDEiis=",
+          "size": 20137
         },
         {
           "path": "src/types.ts",
-          "checksum": "sha256-mVXkcB9E/hVsSr5NaLkGvS0smN0ARhuHIFDrRkfcCgg=",
-          "size": 12341
+          "checksum": "sha256-O0eka2eNAnkY889rXPxc+9Km7dnqgLFaSjxAunA/FZU=",
+          "size": 14693
         }
       ],
       "styles": {

--- a/registry/index.json
+++ b/registry/index.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://equalto.ai/schemas/registry-index.schema.json",
   "schemaVersion": "1.0.0",
-  "generatedAt": "2026-05-20T19:35:29.731Z",
+  "generatedAt": "2026-05-20T19:53:25.999Z",
   "ref": "greater-v0.8.15",
   "version": "0.8.15",
   "checksums": {
@@ -1013,11 +1013,12 @@
     "packages/faces/social/src/theme.css": "sha256-wiMgWvybANnq8ikC0qHMur1K0g4iwepGGozhYuV6QCI=",
     "packages/faces/social/src/types.ts": "sha256-WNFevRWg2/Rq6uCALtBoVQql9JGaV4B63JYW2IkZSYQ=",
     "packages/faces/social/src/utils/notificationGrouping.ts": "sha256-h/6xwSoua5lvEsXzV66EhlKfxdH5VySXQs3hs7uuN5M=",
-    "packages/faces/blog/src/components/Article/Card.svelte": "sha256-j0HGBGR7LKKS3SrsAZ2gSXT1L9B3F2oCK+tb1RbMs2E=",
+    "packages/faces/blog/src/components/Article/Card.svelte": "sha256-wCmkXS0x7U6v7ClHnfyUwLxf0qJaI09wrhV3DlDCaIk=",
     "packages/faces/blog/src/components/Article/Content.svelte": "sha256-paCAdQ5yRDaVEpY5pwfmcU6Akx1gAPOnIqSNK3WYKo0=",
     "packages/faces/blog/src/components/Article/context.ts": "sha256-bYXS4NwSLcHdl8QnpVedTKNR94Tq1CjD+lUzj4zuwKI=",
+    "packages/faces/blog/src/components/Article/date.ts": "sha256-eX3Soy2ltg+eMjQz6s0cowt/PUVlS2tj11WYS9x6Z+8=",
     "packages/faces/blog/src/components/Article/Footer.svelte": "sha256-4ko7rj3fBa6Wd3qPjppbqGxBXukvBrz50TgFFqMobkk=",
-    "packages/faces/blog/src/components/Article/Header.svelte": "sha256-uK21b88M/aZuGibnesH7hC3VNlSkyypPTK9FkUc34xM=",
+    "packages/faces/blog/src/components/Article/Header.svelte": "sha256-T79P0Colz9PfzGJpw//7sY7PNwqaXo2B6zk/1nPLfJw=",
     "packages/faces/blog/src/components/Article/index.ts": "sha256-OQmVd0L2/zY4hGqgC9y5eeOPTrkZCru/O1sdN+r5IQk=",
     "packages/faces/blog/src/components/Article/normalize.ts": "sha256-/rcTG3AUWshRnFGt+qbzj9Qz7mqSF535NXACjW37PRk=",
     "packages/faces/blog/src/components/Article/Reader.svelte": "sha256-jKSgDp9ZTFhnX0qKnEs31dfZYtyuQrq3rmfo4pL1Usw=",
@@ -6789,8 +6790,8 @@
       "files": [
         {
           "path": "src/components/Article/Card.svelte",
-          "checksum": "sha256-j0HGBGR7LKKS3SrsAZ2gSXT1L9B3F2oCK+tb1RbMs2E=",
-          "size": 4281
+          "checksum": "sha256-wCmkXS0x7U6v7ClHnfyUwLxf0qJaI09wrhV3DlDCaIk=",
+          "size": 3887
         },
         {
           "path": "src/components/Article/Content.svelte",
@@ -6803,14 +6804,19 @@
           "size": 3179
         },
         {
+          "path": "src/components/Article/date.ts",
+          "checksum": "sha256-eX3Soy2ltg+eMjQz6s0cowt/PUVlS2tj11WYS9x6Z+8=",
+          "size": 609
+        },
+        {
           "path": "src/components/Article/Footer.svelte",
           "checksum": "sha256-4ko7rj3fBa6Wd3qPjppbqGxBXukvBrz50TgFFqMobkk=",
           "size": 1049
         },
         {
           "path": "src/components/Article/Header.svelte",
-          "checksum": "sha256-uK21b88M/aZuGibnesH7hC3VNlSkyypPTK9FkUc34xM=",
-          "size": 1395
+          "checksum": "sha256-T79P0Colz9PfzGJpw//7sY7PNwqaXo2B6zk/1nPLfJw=",
+          "size": 1449
         },
         {
           "path": "src/components/Article/index.ts",


### PR DESCRIPTION
## Summary

Closes #573.

Adds the first-app-proven Blog face display surface Emdash needs after its M6 article reader/index integration:

- adds `ArticleReader` / `Article.Reader`, an SSR-friendly complete public reader surface accepting canonical Greater `ArticleData` or flat Lesser/Emdash `ArticleData`-shaped input
- adds `ArticleCard` / `ArticleIndexCard` / `Article.Card` / `Article.IndexCard` for article index routes
- adds `normalizeArticleData` plus additive `ArticleDisplayData` / `ArticleInputData` types for uppercase Lesser `HTML`/`MARKDOWN`, flat author/category/featured-image shapes, and canonical nested Greater metadata
- updates Blog face docs with an Emdash migration note showing how to replace local reader/card render glue while keeping routing, auth, FaceTheory document metadata, and SEO local to Emdash
- regenerates the CLI registry so the new source files are checksummed

## Component-surface audit

- Semver: **minor/additive** for `@equaltoai/greater-components-blog` and aggregate `@equaltoai/greater-components`.
- Existing `Article.Root`, `Article.Header`, `Article.Content`, `Article.Footer`, etc. remain exported and unchanged.
- `Article` namespace only gains additive aliases: `Reader`, `Card`, `IndexCard`.
- Theming contract is preserved: no token renames/removals/semantic shifts; new CSS consumes existing `--gr-*` tokens.
- Mastodon/Lesser compatibility is preserved: components are protocol-neutral display surfaces; Lesser-specific enum casing is normalized at the display boundary.

## Accessibility audit

- `ArticleReader` emits the existing semantic `<article>`/header/content/footer structure and defaults browser-only affordances off for SSR.
- `ArticleCard` emits one accessible link wrapping the card, a configurable heading level, `<time datetime>`, non-interactive tag chips, and decorative-empty alt only when no featured-image alt text is supplied.
- Focus visibility is preserved via `:focus-visible`; card hover/focus styles use existing tokens.
- Tests assert article landmarks, headings, link href, image accessible name, metadata, and tag semantics.

## Release / export evidence

- Blog face registry entry now includes `ArticleReader`, `ArticleCard`, and `ArticleIndexCard` exports.
- Build output type exports verified with:

```bash
grep -E "ArticleReader|ArticleIndexCard" packages/greater-components/dist/faces/blog/index.d.ts
```

## Validation

```bash
corepack pnpm --filter @equaltoai/greater-components-blog exec vitest run tests/components/ArticleDisplay.test.ts tests/ssr.test.ts
corepack pnpm --filter @equaltoai/greater-components-blog test
corepack pnpm --filter @equaltoai/greater-components-blog typecheck
corepack pnpm --filter @equaltoai/greater-components-blog build
corepack pnpm --filter @equaltoai/greater-components build
corepack pnpm generate-registry
corepack pnpm generate-registry:validate
corepack pnpm lint
corepack pnpm typecheck
corepack pnpm build
corepack pnpm test
corepack pnpm release:rehearse -- --candidate HEAD --simulate-squash
git diff --check
```
