### PR TITLE
fix(release): surface release PR checks

### DIFF
--- a/.changeset/release-pr-check-statuses.md
+++ b/.changeset/release-pr-check-statuses.md
@@ -1,0 +1,5 @@
+---
+'greater-components': patch
+---
+
+Make release-please PR fallback validation publish visible commit statuses for main and premain release PR guard/DCO checks when GitHub suppresses pull_request workflows created by GITHUB_TOKEN.

--- a/.github/workflows/prerelease-pr.yml
+++ b/.github/workflows/prerelease-pr.yml
@@ -19,6 +19,7 @@ permissions:
   issues: write
   pull-requests: write
   actions: write
+  statuses: write
 
 jobs:
   release-please:
@@ -179,42 +180,21 @@ jobs:
           git commit -s -m "chore(release): prepare metadata"
           git push origin "${RELEASE_BRANCH}"
 
-      - name: Dispatch CI workflows for prerelease PR branch (GITHUB_TOKEN fallback)
+      - name: Validate prerelease PR checks (GITHUB_TOKEN fallback)
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GH_REPO: ${{ github.repository }}
           RELEASE_BRANCH: release-please--branches--premain--components--greater
           BASE_BRANCH: premain
+          GUARD_WORKFLOW: premain-guard.yml
+          GUARD_CONTEXT: Enforce release-candidate-only premain
           RELEASE_PLEASE_TOKEN: ${{ secrets.RELEASE_PLEASE_TOKEN }}
         run: |
           set -euo pipefail
 
           if [[ -n "${RELEASE_PLEASE_TOKEN:-}" ]]; then
-            echo "dispatch-ci: RELEASE_PLEASE_TOKEN is set; PR checks should trigger normally; skipping."
+            echo "release-pr-checks: RELEASE_PLEASE_TOKEN is set; PR checks should trigger normally; skipping fallback."
             exit 0
           fi
 
-          if ! git ls-remote --exit-code --heads origin "${RELEASE_BRANCH}" >/dev/null; then
-            echo "dispatch-ci: no release branch; skipping"
-            exit 0
-          fi
-
-          pr_number="$(
-            gh pr list \
-              --head "${RELEASE_BRANCH}" \
-              --base "${BASE_BRANCH}" \
-              --state open \
-              --json number \
-              --jq '.[0].number' \
-            || true
-          )"
-
-          if [[ -z "${pr_number}" || "${pr_number}" == "null" ]]; then
-            echo "dispatch-ci: no open PR for ${RELEASE_BRANCH} -> ${BASE_BRANCH}; skipping"
-            exit 0
-          fi
-
-          echo "dispatch-ci: triggering CI for PR #${pr_number} on ${RELEASE_BRANCH}"
-
-          gh workflow run premain-guard.yml --ref "${RELEASE_BRANCH}" --field base_ref="${BASE_BRANCH}"
-          gh workflow run dco.yml --ref "${RELEASE_BRANCH}" --field base_ref="${BASE_BRANCH}"
+          bash scripts/dispatch-release-pr-checks.sh

--- a/.github/workflows/release-pr.yml
+++ b/.github/workflows/release-pr.yml
@@ -18,6 +18,7 @@ permissions:
   issues: write
   pull-requests: write
   actions: write
+  statuses: write
 
 jobs:
   release-please:
@@ -162,42 +163,21 @@ jobs:
           git commit -s -m "chore(release): prepare metadata"
           git push origin "${RELEASE_BRANCH}"
 
-      - name: Dispatch CI workflows for release PR branch (GITHUB_TOKEN fallback)
+      - name: Validate release PR checks (GITHUB_TOKEN fallback)
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GH_REPO: ${{ github.repository }}
           RELEASE_BRANCH: release-please--branches--main--components--greater
           BASE_BRANCH: main
+          GUARD_WORKFLOW: main-guard.yml
+          GUARD_CONTEXT: Enforce promotion-only main
           RELEASE_PLEASE_TOKEN: ${{ secrets.RELEASE_PLEASE_TOKEN }}
         run: |
           set -euo pipefail
 
           if [[ -n "${RELEASE_PLEASE_TOKEN:-}" ]]; then
-            echo "dispatch-ci: RELEASE_PLEASE_TOKEN is set; PR checks should trigger normally; skipping."
+            echo "release-pr-checks: RELEASE_PLEASE_TOKEN is set; PR checks should trigger normally; skipping fallback."
             exit 0
           fi
 
-          if ! git ls-remote --exit-code --heads origin "${RELEASE_BRANCH}" >/dev/null; then
-            echo "dispatch-ci: no release branch; skipping"
-            exit 0
-          fi
-
-          pr_number="$(
-            gh pr list \
-              --head "${RELEASE_BRANCH}" \
-              --base "${BASE_BRANCH}" \
-              --state open \
-              --json number \
-              --jq '.[0].number' \
-            || true
-          )"
-
-          if [[ -z "${pr_number}" || "${pr_number}" == "null" ]]; then
-            echo "dispatch-ci: no open PR for ${RELEASE_BRANCH} -> ${BASE_BRANCH}; skipping"
-            exit 0
-          fi
-
-          echo "dispatch-ci: triggering CI for PR #${pr_number} on ${RELEASE_BRANCH}"
-
-          gh workflow run main-guard.yml --ref "${RELEASE_BRANCH}" --field base_ref="${BASE_BRANCH}"
-          gh workflow run dco.yml --ref "${RELEASE_BRANCH}" --field base_ref="${BASE_BRANCH}"
+          bash scripts/dispatch-release-pr-checks.sh

--- a/scripts/dispatch-release-pr-checks.sh
+++ b/scripts/dispatch-release-pr-checks.sh
@@ -1,0 +1,145 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# GitHub suppresses pull_request workflows when a release-please PR branch is
+# created or updated with GITHUB_TOKEN. For release PRs we intentionally run only
+# the promotion guard + DCO gate, then mirror those verified results onto the
+# release PR head SHA as commit statuses so the PR is visibly gated.
+
+: "${GH_REPO:?GH_REPO is required}"
+: "${RELEASE_BRANCH:?RELEASE_BRANCH is required}"
+: "${BASE_BRANCH:?BASE_BRANCH is required}"
+: "${GUARD_WORKFLOW:?GUARD_WORKFLOW is required}"
+: "${GUARD_CONTEXT:?GUARD_CONTEXT is required}"
+
+DCO_WORKFLOW="${DCO_WORKFLOW:-dco.yml}"
+DCO_CONTEXT="${DCO_CONTEXT:-DCO Check}"
+
+if ! git ls-remote --exit-code --heads origin "${RELEASE_BRANCH}" >/dev/null; then
+	echo "release-pr-checks: no release branch ${RELEASE_BRANCH}; skipping"
+	exit 0
+fi
+
+pr_number="$(
+	gh pr list \
+		--head "${RELEASE_BRANCH}" \
+		--base "${BASE_BRANCH}" \
+		--state open \
+		--json number \
+		--jq '.[0].number' \
+		|| true
+)"
+
+if [[ -z "${pr_number}" || "${pr_number}" == "null" ]]; then
+	echo "release-pr-checks: no open PR for ${RELEASE_BRANCH} -> ${BASE_BRANCH}; skipping"
+	exit 0
+fi
+
+head_sha="$(git ls-remote origin "refs/heads/${RELEASE_BRANCH}" | awk '{print $1}')"
+
+if [[ -z "${head_sha}" ]]; then
+	echo "::error::release-pr-checks: unable to resolve head SHA for ${RELEASE_BRANCH}"
+	exit 1
+fi
+
+echo "release-pr-checks: validating PR #${pr_number} at ${head_sha}"
+
+set_status() {
+	local context="$1"
+	local state="$2"
+	local description="$3"
+	local target_url="${4:-}"
+
+	local -a args
+	args=(
+		-X POST
+		"repos/${GH_REPO}/statuses/${head_sha}"
+		-f "state=${state}"
+		-f "context=${context}"
+		-f "description=${description}"
+	)
+
+	if [[ -n "${target_url}" ]]; then
+		args+=(-f "target_url=${target_url}")
+	fi
+
+	gh api "${args[@]}" >/dev/null
+}
+
+find_dispatched_run() {
+	local workflow="$1"
+
+	for _ in {1..12}; do
+		local run_id
+		run_id="$(
+			gh run list \
+				--workflow "${workflow}" \
+				--branch "${RELEASE_BRANCH}" \
+				--event workflow_dispatch \
+				--limit 10 \
+				--json databaseId,headSha \
+				--jq ".[] | select(.headSha == \"${head_sha}\") | .databaseId" \
+				| head -n 1
+		)"
+
+		if [[ -n "${run_id}" ]]; then
+			echo "${run_id}"
+			return 0
+		fi
+
+		sleep 5
+	done
+
+	return 1
+}
+
+run_workflow_check() {
+	local workflow="$1"
+	local context="$2"
+
+	set_status "${context}" "pending" "Running ${context}"
+
+	local output
+	if ! output="$(
+		gh workflow run "${workflow}" \
+			--ref "${RELEASE_BRANCH}" \
+			--field "base_ref=${BASE_BRANCH}" \
+			2>&1
+	)"; then
+		echo "${output}"
+		set_status "${context}" "failure" "Failed to dispatch ${context}"
+		return 1
+	fi
+	echo "${output}"
+
+	local run_id
+	run_id="$(grep -Eo 'https://github.com/[^[:space:]]+/actions/runs/[0-9]+' <<<"${output}" | tail -n 1 | awk -F/ '{print $NF}' || true)"
+
+	if [[ -z "${run_id}" ]]; then
+		run_id="$(find_dispatched_run "${workflow}" || true)"
+	fi
+
+	if [[ -z "${run_id}" ]]; then
+		set_status "${context}" "failure" "Could not find dispatched ${context} run"
+		echo "::error::release-pr-checks: could not find dispatched ${workflow} run"
+		return 1
+	fi
+
+	local run_url
+	run_url="$(gh run view "${run_id}" --json url --jq '.url')"
+
+	if gh run watch "${run_id}" --exit-status; then
+		set_status "${context}" "success" "${context} passed" "${run_url}"
+		return 0
+	fi
+
+	local conclusion
+	conclusion="$(gh run view "${run_id}" --json conclusion --jq '.conclusion // "failure"')"
+	set_status "${context}" "failure" "${context} ${conclusion}" "${run_url}"
+	return 1
+}
+
+run_workflow_check "${GUARD_WORKFLOW}" "${GUARD_CONTEXT}"
+run_workflow_check "${DCO_WORKFLOW}" "${DCO_CONTEXT}"
+
+echo "release-pr-checks: PR #${pr_number} checks passed"


### PR DESCRIPTION
## Summary

Fixes the release-please PR fallback path instead of relying on manual release/check workarounds.

## Root cause

When `RELEASE_PLEASE_TOKEN` is absent, release-please creates/updates the `release-please--branches--main--components--greater` and `release-please--branches--premain--components--greater` branches with `GITHUB_TOKEN`. GitHub suppresses `pull_request` workflow runs caused by `GITHUB_TOKEN`, so release PRs such as #596 can be created with only external checks visible. The previous fallback dispatched guard/DCO workflows, but those `workflow_dispatch` check runs did not attach to the PR check rollup, leaving the release PR looking unvalidated.

## Fix

- Add `scripts/dispatch-release-pr-checks.sh`.
- For GITHUB_TOKEN fallback release PRs, dispatch the appropriate guard workflow and DCO workflow.
- Wait for those dispatched runs to complete.
- Mirror the verified result onto the release PR head SHA as visible commit statuses using the same gate contexts:
  - `Enforce promotion-only main` for stable release PRs.
  - `Enforce release-candidate-only premain` for RC release PRs.
  - `DCO Check` for both.
- Grant `statuses: write` to the main and premain release-PR workflows.

This preserves the repo's intended governance: premain/main release PRs stay promotion/release-only and run the guard + DCO gates, while staging PRs continue to run the full suite.

## Investigation note

PR #596 (`chore(main): release greater 0.8.17`) exists and is mergeable, but its normal PR rollup currently shows only Snyk because it was generated from a GITHUB_TOKEN-authored release branch. The earlier fallback dispatched runs #26196212658 and #26196213392 successfully, but because they were plain `workflow_dispatch` runs they did not appear in `gh pr checks 596`.

## Validation

- `bash -n scripts/dispatch-release-pr-checks.sh`
- Nonexistent-branch skip path:
  - `GH_REPO=equaltoai/greater-components RELEASE_BRANCH=__nonexistent_release_branch__ BASE_BRANCH=main GUARD_WORKFLOW=main-guard.yml GUARD_CONTEXT='Enforce promotion-only main' bash scripts/dispatch-release-pr-checks.sh`
- `corepack pnpm exec prettier --write .github/workflows/release-pr.yml .github/workflows/prerelease-pr.yml`
- `git diff --check`
- `corepack pnpm lint`

## Current-release handling

This fixes the automation path. I am not creating another manual release. After this lands and is promoted, the main release-PR workflow can update the open release PR and publish visible guard/DCO statuses from automation.