### PR TITLE
[codex] fix CLI-installed svelte check errors

### DIFF
--- a/packages/faces/blog/src/components/Editor/Root.svelte
+++ b/packages/faces/blog/src/components/Editor/Root.svelte
@@ -26,7 +26,7 @@ Provides a minimal authoring experience for markdown/HTML drafts with optional a
 	const initialDraft = untrack(() => draft);
 	const initialConfig = untrack(() => config);
 
-	const state = $state<EditorContext>({
+	const editorState = $state<EditorContext>({
 		draft: initialDraft,
 		config: {
 			...DEFAULT_EDITOR_CONFIG,
@@ -37,10 +37,10 @@ Provides a minimal authoring experience for markdown/HTML drafts with optional a
 		lastSaved: initialDraft.savedAt ? new Date(initialDraft.savedAt) : null,
 	});
 
-	createEditorContext(state);
+	createEditorContext(editorState);
 
 	$effect(() => {
-		state.config = {
+		editorState.config = {
 			...DEFAULT_EDITOR_CONFIG,
 			...config,
 		};
@@ -48,53 +48,55 @@ Provides a minimal authoring experience for markdown/HTML drafts with optional a
 
 	$effect(() => {
 		// Sync draft only when the identity changes to avoid clobbering edits.
-		if (draft.id !== state.draft.id) {
-			state.draft = draft;
-			state.isDirty = false;
-			state.lastSaved = draft.savedAt ? new Date(draft.savedAt) : null;
+		if (draft.id !== editorState.draft.id) {
+			editorState.draft = draft;
+			editorState.isDirty = false;
+			editorState.lastSaved = draft.savedAt ? new Date(draft.savedAt) : null;
 		}
 	});
 
 	let textarea: HTMLTextAreaElement | null = $state(null);
 
 	const wordCount = $derived(
-		state.config.showWordCount ? (state.draft.content.trim().match(/\S+/g)?.length ?? 0) : undefined
+		editorState.config.showWordCount
+			? (editorState.draft.content.trim().match(/\S+/g)?.length ?? 0)
+			: undefined
 	);
 	const readingMinutes = $derived(
-		state.config.showReadingTime && wordCount !== undefined
+		editorState.config.showReadingTime && wordCount !== undefined
 			? Math.max(1, Math.ceil(wordCount / 200))
 			: undefined
 	);
 
 	const previewHtml = $derived(
-		state.draft.contentFormat !== 'markdown' ? sanitizeHtml(state.draft.content) : ''
+		editorState.draft.contentFormat !== 'markdown' ? sanitizeHtml(editorState.draft.content) : ''
 	);
 
 	function emitChange() {
-		state.isDirty = true;
-		onChange?.({ ...state.draft });
+		editorState.isDirty = true;
+		onChange?.({ ...editorState.draft });
 	}
 
 	async function saveDraft() {
-		if (!onSave || state.isSaving) return;
-		state.isSaving = true;
+		if (!onSave || editorState.isSaving) return;
+		editorState.isSaving = true;
 		try {
-			await onSave({ ...state.draft });
-			state.isDirty = false;
-			state.lastSaved = new Date();
-			state.draft.savedAt = state.lastSaved.toISOString();
+			await onSave({ ...editorState.draft });
+			editorState.isDirty = false;
+			editorState.lastSaved = new Date();
+			editorState.draft.savedAt = editorState.lastSaved.toISOString();
 		} finally {
-			state.isSaving = false;
+			editorState.isSaving = false;
 		}
 	}
 
 	$effect(() => {
 		if (!onSave) return;
-		const interval = state.config.autoSaveInterval;
+		const interval = editorState.config.autoSaveInterval;
 		if (!interval || interval <= 0) return;
 
 		const id = setInterval(() => {
-			if (state.isDirty && !state.isSaving) {
+			if (editorState.isDirty && !editorState.isSaving) {
 				void saveDraft();
 			}
 		}, interval);
@@ -107,12 +109,12 @@ Provides a minimal authoring experience for markdown/HTML drafts with optional a
 
 		const start = textarea.selectionStart ?? 0;
 		const end = textarea.selectionEnd ?? 0;
-		const value = state.draft.content;
+		const value = editorState.draft.content;
 		const before = value.slice(0, start);
 		const selected = value.slice(start, end);
 		const after = value.slice(end);
 
-		state.draft.content = `${before}${prefix}${selected}${suffix}${after}`;
+		editorState.draft.content = `${before}${prefix}${selected}${suffix}${after}`;
 		emitChange();
 
 		queueMicrotask(() => {
@@ -128,17 +130,17 @@ Provides a minimal authoring experience for markdown/HTML drafts with optional a
 
 		const start = textarea.selectionStart ?? 0;
 		const end = textarea.selectionEnd ?? 0;
-		const value = state.draft.content;
+		const value = editorState.draft.content;
 		const selection = value.slice(start, end) || value;
 		const next = selection
 			.split('\n')
-			.map((line) => (line.trim() ? `${prefix}${line}` : line))
+			.map((line: string) => (line.trim() ? `${prefix}${line}` : line))
 			.join('\n');
 
 		if (value.slice(start, end)) {
-			state.draft.content = `${value.slice(0, start)}${next}${value.slice(end)}`;
+			editorState.draft.content = `${value.slice(0, start)}${next}${value.slice(end)}`;
 		} else {
-			state.draft.content = next;
+			editorState.draft.content = next;
 		}
 
 		emitChange();
@@ -164,11 +166,11 @@ Provides a minimal authoring experience for markdown/HTML drafts with optional a
 				if (!textarea) return;
 				const start = textarea.selectionStart ?? 0;
 				const end = textarea.selectionEnd ?? 0;
-				const value = state.draft.content;
+				const value = editorState.draft.content;
 				const selected = value.slice(start, end) || 'link text';
 				const before = value.slice(0, start);
 				const after = value.slice(end);
-				state.draft.content = `${before}[${selected}](${href})${after}`;
+				editorState.draft.content = `${before}[${selected}](${href})${after}`;
 				emitChange();
 				break;
 			}
@@ -178,25 +180,25 @@ Provides a minimal authoring experience for markdown/HTML drafts with optional a
 	}
 </script>
 
-<section class={state.config.class} aria-label="Editor">
+<section class={editorState.config.class} aria-label="Editor">
 	{#if children}
 		{@render children?.()}
 	{:else}
-		<Toolbar disabled={state.isSaving} onAction={handleToolbarAction} />
+		<Toolbar disabled={editorState.isSaving} onAction={handleToolbarAction} />
 
 		<div class="gr-blog-editor__body">
 			<textarea
 				bind:this={textarea}
-				placeholder={state.config.placeholder}
-				bind:value={state.draft.content}
+				placeholder={editorState.config.placeholder}
+				bind:value={editorState.draft.content}
 				oninput={emitChange}
-				disabled={state.isSaving}
+				disabled={editorState.isSaving}
 			></textarea>
 
-			{#if state.config.mode === 'split'}
+			{#if editorState.config.mode === 'split'}
 				<div class="gr-blog-editor__preview" aria-label="Preview">
-					{#if state.draft.contentFormat === 'markdown'}
-						<MarkdownRenderer content={state.draft.content} />
+					{#if editorState.draft.contentFormat === 'markdown'}
+						<MarkdownRenderer content={editorState.draft.content} />
 					{:else}
 						<!-- eslint-disable-next-line svelte/no-at-html-tags -->
 						{@html previewHtml}
@@ -212,14 +214,14 @@ Provides a minimal authoring experience for markdown/HTML drafts with optional a
 			{#if readingMinutes !== undefined}
 				<span>{readingMinutes} min read</span>
 			{/if}
-			{#if state.isSaving}
+			{#if editorState.isSaving}
 				<span>Saving…</span>
-			{:else if state.isDirty}
+			{:else if editorState.isDirty}
 				<span>Unsaved changes</span>
-			{:else if state.lastSaved}
+			{:else if editorState.lastSaved}
 				<span>Saved</span>
 			{/if}
-			{#if onSave && state.isDirty && !state.isSaving}
+			{#if onSave && editorState.isDirty && !editorState.isSaving}
 				<button type="button" onclick={saveDraft}>Save</button>
 			{/if}
 		</div>

--- a/packages/faces/social/src/patterns/BookmarkManager.svelte
+++ b/packages/faces/social/src/patterns/BookmarkManager.svelte
@@ -1064,6 +1064,7 @@
 		color: var(--text-primary, #0f1419);
 		display: -webkit-box;
 		-webkit-line-clamp: 2;
+		line-clamp: 2;
 		-webkit-box-orient: vertical;
 		overflow: hidden;
 	}

--- a/packages/shared/auth/src/WalletConnect.svelte
+++ b/packages/shared/auth/src/WalletConnect.svelte
@@ -278,7 +278,10 @@
 				throw new Error('No accounts found. Please unlock your wallet.');
 			}
 
-			const [address] = accountsResult;
+			const address = accountsResult[0];
+			if (!address) {
+				throw new Error('No accounts found. Please unlock your wallet.');
+			}
 
 			// Get chain ID
 			const chainIdResult = await ethereum.request({

--- a/packages/shared/compose/src/EditorWithAutocomplete.svelte
+++ b/packages/shared/compose/src/EditorWithAutocomplete.svelte
@@ -148,8 +148,9 @@ Text editor with hashtag, mention, and emoji autocomplete support.
 			}
 			if (event.key === 'Enter' || event.key === 'Tab') {
 				event.preventDefault();
-				if (suggestions[selectedIndex]) {
-					handleSelectSuggestion(suggestions[selectedIndex]);
+				const suggestion = suggestions[selectedIndex];
+				if (suggestion) {
+					handleSelectSuggestion(suggestion);
 				}
 				return;
 			}

--- a/packages/shared/compose/src/MediaUpload.svelte
+++ b/packages/shared/compose/src/MediaUpload.svelte
@@ -128,7 +128,7 @@ Upload images, videos, and audio with drag & drop, progress tracking, and valida
 		// Validate files
 		const validation = validateFiles(fileArray, { ...config, maxFiles });
 		if (!validation.valid) {
-			error = validation.errors[0];
+			error = validation.errors[0] ?? 'Invalid file selection';
 			return;
 		}
 
@@ -142,7 +142,10 @@ Upload images, videos, and audio with drag & drop, progress tracking, and valida
 		// Start uploading if handler provided
 		if (onUpload) {
 			for (let i = 0; i < processedFiles.length; i++) {
-				uploadFile(files[startIndex + i]);
+				const mediaFile = files[startIndex + i];
+				if (mediaFile) {
+					void uploadFile(mediaFile);
+				}
 			}
 		}
 	}

--- a/packages/shared/compose/src/ThreadComposer.svelte
+++ b/packages/shared/compose/src/ThreadComposer.svelte
@@ -179,7 +179,12 @@ Create threads with multiple connected posts, each with its own character limit.
 	function movePostUp(postId: string) {
 		const index = posts.findIndex((p) => p.id === postId);
 		if (index > 0) {
-			[posts[index], posts[index - 1]] = [posts[index - 1], posts[index]];
+			const currentPost = posts[index];
+			const previousPost = posts[index - 1];
+			if (!currentPost || !previousPost) return;
+
+			posts[index - 1] = currentPost;
+			posts[index] = previousPost;
 		}
 	}
 
@@ -189,7 +194,12 @@ Create threads with multiple connected posts, each with its own character limit.
 	function movePostDown(postId: string) {
 		const index = posts.findIndex((p) => p.id === postId);
 		if (index < posts.length - 1) {
-			[posts[index], posts[index + 1]] = [posts[index + 1], posts[index]];
+			const currentPost = posts[index];
+			const nextPost = posts[index + 1];
+			if (!currentPost || !nextPost) return;
+
+			posts[index + 1] = currentPost;
+			posts[index] = nextPost;
 		}
 	}
 
@@ -213,6 +223,7 @@ Create threads with multiple connected posts, each with its own character limit.
 		if (draggedIndex !== -1 && targetIndex !== -1) {
 			const newPosts = [...posts];
 			const [draggedPost] = newPosts.splice(draggedIndex, 1);
+			if (!draggedPost) return;
 			newPosts.splice(targetIndex, 0, draggedPost);
 			posts = newPosts;
 		}

--- a/packages/shared/compose/src/VisibilitySelect.svelte
+++ b/packages/shared/compose/src/VisibilitySelect.svelte
@@ -29,18 +29,22 @@ Dropdown for selecting post visibility (public, unlisted, private, direct).
 
 	const context = getComposeContext();
 
-	const visibilityOptions: Array<{
+	type VisibilityOption = {
 		value: PostVisibility;
 		label: string;
 		icon: string;
 		description: string;
-	}> = [
-		{
-			value: 'public',
-			label: 'Public',
-			icon: '🌐',
-			description: 'Anyone can see this post',
-		},
+	};
+
+	const defaultVisibilityOption: VisibilityOption = {
+		value: 'public',
+		label: 'Public',
+		icon: '🌐',
+		description: 'Anyone can see this post',
+	};
+
+	const visibilityOptions: VisibilityOption[] = [
+		defaultVisibilityOption,
 		{
 			value: 'unlisted',
 			label: 'Unlisted',
@@ -62,7 +66,8 @@ Dropdown for selecting post visibility (public, unlisted, private, direct).
 	];
 
 	const currentOption = $derived(
-		visibilityOptions.find((opt) => opt.value === context.state.visibility) || visibilityOptions[0]
+		visibilityOptions.find((opt) => opt.value === context.state.visibility) ??
+			defaultVisibilityOption
 	);
 
 	function handleChange(event: Event) {

--- a/packages/shared/notifications/src/Group.svelte
+++ b/packages/shared/notifications/src/Group.svelte
@@ -16,7 +16,7 @@ Displays multiple similar notifications grouped together.
 
 <script lang="ts">
 	import type { Snippet } from 'svelte';
-	import type { NotificationGroup, NotificationType } from './types.js';
+	import type { Notification, NotificationGroup, NotificationType } from './types.js';
 	import { getNotificationsContext } from './context.svelte.js';
 	import { getGroupTitle } from './utils/notificationGrouping.js';
 
@@ -96,6 +96,10 @@ Displays multiple similar notifications grouped together.
 		return baseTitle;
 	});
 
+	function getAccountName(notification: Notification | undefined): string {
+		return notification?.account?.displayName || notification?.account?.username || '';
+	}
+
 	/**
 	 * Format the names of accounts
 	 */
@@ -103,12 +107,14 @@ Displays multiple similar notifications grouped together.
 		const notifications = group.notifications;
 		const count = notifications.length;
 
-		if (count === 1) {
-			return notifications[0].account?.displayName || notifications[0].account?.username || '';
+		if (count === 0) {
+			return '';
+		} else if (count === 1) {
+			return getAccountName(notifications[0]);
 		} else if (count === 2) {
-			return `${notifications[0].account?.displayName || notifications[0].account?.username} and ${notifications[1].account?.displayName || notifications[1].account?.username}`;
+			return `${getAccountName(notifications[0])} and ${getAccountName(notifications[1])}`;
 		} else {
-			return `${notifications[0].account?.displayName || notifications[0].account?.username} and ${count - 1} others`;
+			return `${getAccountName(notifications[0])} and ${count - 1} others`;
 		}
 	});
 

--- a/packages/shared/notifications/src/WorkflowNotificationItem.svelte
+++ b/packages/shared/notifications/src/WorkflowNotificationItem.svelte
@@ -12,7 +12,7 @@
 		return value
 			.split(/[_-]/g)
 			.filter(Boolean)
-			.map((part) => part[0].toUpperCase() + part.slice(1))
+			.map((part) => part.charAt(0).toUpperCase() + part.slice(1))
 			.join(' ');
 	}
 

--- a/registry/index.json
+++ b/registry/index.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://equalto.ai/schemas/registry-index.schema.json",
   "schemaVersion": "1.0.0",
-  "generatedAt": "2026-05-20T23:35:53.949Z",
+  "generatedAt": "2026-05-21T03:15:46.033Z",
   "ref": "greater-v0.8.17",
   "version": "0.8.17",
   "checksums": {
@@ -997,7 +997,7 @@
     "packages/faces/social/src/lib/timelineStore.ts": "sha256-6Uq5ymJYNtBlFyiIINxZFNqW2+IJWAl/DhiB3St4igQ=",
     "packages/faces/social/src/lib/transport.ts": "sha256-hDKlUlMmKR1MYs2UWz1G+zAIP3rq4BiBt2ZRQp4DxP4=",
     "packages/faces/social/src/mockData.ts": "sha256-4bTHyBTiEesD+0xsZuFR2RPurELEsigR6a4DYP14h2M=",
-    "packages/faces/social/src/patterns/BookmarkManager.svelte": "sha256-K3NPszNRomo4S/hJW+mBTj6gFzwFTlDml7L6zQ32Wso=",
+    "packages/faces/social/src/patterns/BookmarkManager.svelte": "sha256-E08cdokdyR6s2PNm47it7Ly6uBVcki5iEQcCzZHXyqY=",
     "packages/faces/social/src/patterns/ContentWarningHandler.svelte": "sha256-4+ilTz+HK3nUQGImQutOyalPO98HlSN/jDnoKgQqX8c=",
     "packages/faces/social/src/patterns/CustomEmojiPicker.svelte": "sha256-HyjZbpcEY7JIGRWq5vbQDhfPdOtTEoOb37XamxbNeJ8=",
     "packages/faces/social/src/patterns/FederationIndicator.svelte": "sha256-Jh/v252VLN8wxarpWI6mRzP26Q38c/fl/5XuGjwWOx0=",
@@ -1033,7 +1033,7 @@
     "packages/faces/blog/src/components/Author/Root.svelte": "sha256-pm3o4GG/uEhLx+FnExkTNFFJ+Y7JbY01A4vLd9M6IJI=",
     "packages/faces/blog/src/components/Editor/context.ts": "sha256-gkHSZEVy6p0KLViTdHninO1v1MbwngNCb3kR5tWXxiQ=",
     "packages/faces/blog/src/components/Editor/index.ts": "sha256-HO79Onqqgkq0f4ZLJjZ3l8bIaf+7dkMS3cYdRNOBM6E=",
-    "packages/faces/blog/src/components/Editor/Root.svelte": "sha256-SS6WjVVOkQfmXHmvsMc6xt3KlRPrBa67P1uq+WJ9KwU=",
+    "packages/faces/blog/src/components/Editor/Root.svelte": "sha256-fZCEM0BZdjJ3DZsA6a44RmUzTk0r7QlHtscisN01odA=",
     "packages/faces/blog/src/components/Editor/Toolbar.svelte": "sha256-xHnxtxcfRoznzcq6MNtgaQ77aRKB2rtCVeBn6BGz2E0=",
     "packages/faces/blog/src/components/Navigation/ArchiveView.svelte": "sha256-JmFtTxh5LeCtB0BxjpA7Ju/iTy3e2bm5dKaa6ksTmeQ=",
     "packages/faces/blog/src/components/Navigation/context.ts": "sha256-ncRAhl15BeOTm9wlze9zyIuHEtZnwZlTEEZSgrs2+9Q=",
@@ -1263,7 +1263,7 @@
     "packages/shared/auth/src/TwoFactorVerify.svelte": "sha256-8Dj/ideH8Va2xTa57yecY4dOAMIOlxEeABAYjoldmVI=",
     "packages/shared/auth/src/types.ts": "sha256-qkge8y9KdKsbEaMEKGz17WEN+5OS1oQP2URSz9tD5xY=",
     "packages/shared/auth/src/UserButton.svelte": "sha256-8zN7J4RC97tfl5OhhEhXj+Uwj2aSqqli+kPSIWBfS1k=",
-    "packages/shared/auth/src/WalletConnect.svelte": "sha256-895ZzZOU0tywu62JOQi/4Y0MtpnywyzrI0fxvVslmD8=",
+    "packages/shared/auth/src/WalletConnect.svelte": "sha256-XiPKhylZAECjTIT0ACXEgOjuLRPa43EUY+Za9TI0Cu4=",
     "packages/shared/auth/src/WebAuthnSetup.svelte": "sha256-/HEOFxF/jaMT81CDqCytNQcL5mf1gYxvKlnKca5k1Pg=",
     "packages/shared/compose/src/Autocomplete.ts": "sha256-0g4x1IP5ZVVwqzPXKpnur41DXa2RyuZVq6OqUCEUOks=",
     "packages/shared/compose/src/AutocompleteMenu.svelte": "sha256-8f7vu/UMrrJ/jVa2uHqKKimeBo6c4Nvt2f/vl3UoHVs=",
@@ -1272,24 +1272,24 @@
     "packages/shared/compose/src/DraftManager.ts": "sha256-uWZ2sm/Sb3vzYGs3CJmW/zeGWs7l9Lu9HMfRKFt489M=",
     "packages/shared/compose/src/DraftSaver.svelte": "sha256-2vZgRCkfSyKT7hmuE8fG9WpSJ0M/e3gYYZeRANa/dN0=",
     "packages/shared/compose/src/Editor.svelte": "sha256-o8Ax3GAjHZP/1GmYDrfG9aeAvN4/0OznF/ijBzSuBbc=",
-    "packages/shared/compose/src/EditorWithAutocomplete.svelte": "sha256-RnItKRLyp7XL7n7dh8V7/TQNRfP3YiRKuB4PLG+D8uA=",
+    "packages/shared/compose/src/EditorWithAutocomplete.svelte": "sha256-LDxzK55KYPCxE5ZpiOQtoB0O99AoeZSWSGJkwdOcFs8=",
     "packages/shared/compose/src/GraphQLAdapter.ts": "sha256-hJGSB86Fl5Ly5hvexYDHPwbcW68K+W60NPmWhZjVf4E=",
     "packages/shared/compose/src/ImageEditor.svelte": "sha256-BSJFkCPs1AqAeGyt1f7vxZd3JwzboWVxUlzRwyAQE5I=",
     "packages/shared/compose/src/index.ts": "sha256-AultexGFcwRrujaZYtuu6hJc7PMdJBvR/oznEEfOGw4=",
-    "packages/shared/compose/src/MediaUpload.svelte": "sha256-GGkLgf+duniKyv7tc+ZHBhLpL9jDyBYmepFehKbXS2Y=",
+    "packages/shared/compose/src/MediaUpload.svelte": "sha256-2JF6kFxFkK/PaVcvvWxe3CbiuE6Ar2dq4po9Lzal1YI=",
     "packages/shared/compose/src/MediaUploadHandler.ts": "sha256-yrlp/QNy5pfrhxLypX+li8yX+LgqVyQUKAA0DiFbQxY=",
     "packages/shared/compose/src/Root.svelte": "sha256-Z7GshOaltslRFeDPbFETYAYy6USpvW7L004QTeTMGSQ=",
     "packages/shared/compose/src/Submit.svelte": "sha256-vlQapz78vCRaXRojfrudP/4yY/DTyHDQ9bxueJwLD0U=",
-    "packages/shared/compose/src/ThreadComposer.svelte": "sha256-zfnmg1WWLbQ3vuaYmPnFgzCpKn5Dj1kI/P3wnAQadTg=",
+    "packages/shared/compose/src/ThreadComposer.svelte": "sha256-bRhMDOb4iz0fSOxf0PAeWtvYiLfIPfbdvH02acdlj18=",
     "packages/shared/compose/src/ThreadControls.svelte": "sha256-78UTTyLXw4Kj1UPVhpiBATrkWBx8Pnhh1LYugLhG7Vs=",
     "packages/shared/compose/src/types.ts": "sha256-8ovFbZvdAJ0m03hrxIOeAPd9aimhX2mAt/DQ8HZcby0=",
     "packages/shared/compose/src/UnicodeCounter.ts": "sha256-NSa7uxa1qqByrpywxeCI1RQG0BZZYujkKCMYgVI74z0=",
-    "packages/shared/compose/src/VisibilitySelect.svelte": "sha256-cguhZxbRISAreQO4QEkW5DOJXvTiz+1iB6CS5dwhszg=",
+    "packages/shared/compose/src/VisibilitySelect.svelte": "sha256-9PPOYRyxlhF5e5hQfs8P7PT8LSlqpepJqI1l3xEiG8Y=",
     "packages/shared/notifications/src/CommunicationNotificationItem.svelte": "sha256-Tk+BCXJQIehdy+B2C1MxB4+En0QWaUNRJL36NFI679M=",
     "packages/shared/notifications/src/components/Notifications/context.ts": "sha256-ZIahHLN75uqj58+s9KTYLXte5DRYLiGx8YK9qwWqsNI=",
     "packages/shared/notifications/src/context.svelte.ts": "sha256-d14bVvqv1AhU/ALFY2f/0mzcvAecnWKLwRVJVuDM82U=",
     "packages/shared/notifications/src/Filter.svelte": "sha256-vYfqHN/0a3T4e6IAaZm8OHeLrsMSU13lFRrhwlqm7Mk=",
-    "packages/shared/notifications/src/Group.svelte": "sha256-ckSQRSl6WqYQ+le8jaVrWgqPxB4YMti/9tQhv1Vlcuw=",
+    "packages/shared/notifications/src/Group.svelte": "sha256-I3Y/QVHVhUTQeDv2ZyKwUj0HVr3FcSHYC98w4804dYw=",
     "packages/shared/notifications/src/index.ts": "sha256-9eyj5MyjNqtWPLeX+bcvu7t8DovelyOy2RQR+MipSS0=",
     "packages/shared/notifications/src/Item.svelte": "sha256-EPrur6uZrlYm4lBpJHwrK73LWU5eBv9b2TpINVcyAJc=",
     "packages/shared/notifications/src/LesserNotificationItem.svelte": "sha256-5t6c2CfohfEah6P4wmk1L/5YhAuEo8gQb2X7klRAxJU=",
@@ -1299,7 +1299,7 @@
     "packages/shared/notifications/src/Root.svelte": "sha256-3HnRKd8wRgk9RcZ6p5U1cm9iKWjko7jlDYhJVPo0uvM=",
     "packages/shared/notifications/src/types.ts": "sha256-32eBNEBl6OL4mSQQRv7mIcLi74CuZCuYbObBae/2ud0=",
     "packages/shared/notifications/src/utils/notificationGrouping.ts": "sha256-anq0l4YvXEJ+0XAk/whfRxrSeSyN2PC098wpFr9btBc=",
-    "packages/shared/notifications/src/WorkflowNotificationItem.svelte": "sha256-7XTzJ8eeJXSPb3whS+BcBde1rht+lp6/brIlW+x+Rak=",
+    "packages/shared/notifications/src/WorkflowNotificationItem.svelte": "sha256-TjqrKn4zuIpDrOdG6kCDN9/EOFYbtk06tyGuTNkNdjc=",
     "packages/shared/search/src/ActorResult.svelte": "sha256-RpYCEGRK7sgDSUn11ndhdbFdb0Cx8+im9XH9y/79hhs=",
     "packages/shared/search/src/Bar.svelte": "sha256-g4snrnmzDkEt8TWrq0ZDRTJGKUovIdGFStqB7NPLOxU=",
     "packages/shared/search/src/context.svelte.ts": "sha256-8zhR96FWRkozhMg02nNp9OtMn9jxzOPxaeyE9W6IYr4=",
@@ -6564,8 +6564,8 @@
         },
         {
           "path": "src/patterns/BookmarkManager.svelte",
-          "checksum": "sha256-K3NPszNRomo4S/hJW+mBTj6gFzwFTlDml7L6zQ32Wso=",
-          "size": 27383
+          "checksum": "sha256-E08cdokdyR6s2PNm47it7Ly6uBVcki5iEQcCzZHXyqY=",
+          "size": 27400
         },
         {
           "path": "src/patterns/ContentWarningHandler.svelte",
@@ -6890,8 +6890,8 @@
         },
         {
           "path": "src/components/Editor/Root.svelte",
-          "checksum": "sha256-SS6WjVVOkQfmXHmvsMc6xt3KlRPrBa67P1uq+WJ9KwU=",
-          "size": 5990
+          "checksum": "sha256-fZCEM0BZdjJ3DZsA6a44RmUzTk0r7QlHtscisN01odA=",
+          "size": 6274
         },
         {
           "path": "src/components/Editor/Toolbar.svelte",
@@ -8411,8 +8411,8 @@
         },
         {
           "path": "src/WalletConnect.svelte",
-          "checksum": "sha256-895ZzZOU0tywu62JOQi/4Y0MtpnywyzrI0fxvVslmD8=",
-          "size": 14472
+          "checksum": "sha256-XiPKhylZAECjTIT0ACXEgOjuLRPa43EUY+Za9TI0Cu4=",
+          "size": 14567
         },
         {
           "path": "src/WebAuthnSetup.svelte",
@@ -8521,8 +8521,8 @@
         },
         {
           "path": "src/EditorWithAutocomplete.svelte",
-          "checksum": "sha256-RnItKRLyp7XL7n7dh8V7/TQNRfP3YiRKuB4PLG+D8uA=",
-          "size": 5369
+          "checksum": "sha256-LDxzK55KYPCxE5ZpiOQtoB0O99AoeZSWSGJkwdOcFs8=",
+          "size": 5388
         },
         {
           "path": "src/GraphQLAdapter.ts",
@@ -8541,8 +8541,8 @@
         },
         {
           "path": "src/MediaUpload.svelte",
-          "checksum": "sha256-GGkLgf+duniKyv7tc+ZHBhLpL9jDyBYmepFehKbXS2Y=",
-          "size": 14115
+          "checksum": "sha256-2JF6kFxFkK/PaVcvvWxe3CbiuE6Ar2dq4po9Lzal1YI=",
+          "size": 14209
         },
         {
           "path": "src/MediaUploadHandler.ts",
@@ -8561,8 +8561,8 @@
         },
         {
           "path": "src/ThreadComposer.svelte",
-          "checksum": "sha256-zfnmg1WWLbQ3vuaYmPnFgzCpKn5Dj1kI/P3wnAQadTg=",
-          "size": 9803
+          "checksum": "sha256-bRhMDOb4iz0fSOxf0PAeWtvYiLfIPfbdvH02acdlj18=",
+          "size": 10062
         },
         {
           "path": "src/ThreadControls.svelte",
@@ -8581,8 +8581,8 @@
         },
         {
           "path": "src/VisibilitySelect.svelte",
-          "checksum": "sha256-cguhZxbRISAreQO4QEkW5DOJXvTiz+1iB6CS5dwhszg=",
-          "size": 2092
+          "checksum": "sha256-9PPOYRyxlhF5e5hQfs8P7PT8LSlqpepJqI1l3xEiG8Y=",
+          "size": 2209
         }
       ],
       "dependencies": [
@@ -8652,8 +8652,8 @@
         },
         {
           "path": "src/Group.svelte",
-          "checksum": "sha256-ckSQRSl6WqYQ+le8jaVrWgqPxB4YMti/9tQhv1Vlcuw=",
-          "size": 5029
+          "checksum": "sha256-I3Y/QVHVhUTQeDv2ZyKwUj0HVr3FcSHYC98w4804dYw=",
+          "size": 5072
         },
         {
           "path": "src/index.ts",
@@ -8702,8 +8702,8 @@
         },
         {
           "path": "src/WorkflowNotificationItem.svelte",
-          "checksum": "sha256-7XTzJ8eeJXSPb3whS+BcBde1rht+lp6/brIlW+x+Rak=",
-          "size": 3293
+          "checksum": "sha256-TjqrKn4zuIpDrOdG6kCDN9/EOFYbtk06tyGuTNkNdjc=",
+          "size": 3300
         }
       ],
       "dependencies": [


### PR DESCRIPTION
## Summary

Fixes the `pnpm svelte-check` errors reported by emdash against CLI-installed `faces/blog` source at `greater-v0.8.17`.

- Renames the Blog Editor internal `$state` binding away from `state` so Svelte 5 runes are not parsed as a legacy `$state` store subscription in consumer `svelte-check`.
- Hardens CLI-installed auth, compose, and notifications surfaces for strict consumers using `noUncheckedIndexedAccess`.
- Adds the standard `line-clamp` property alongside `-webkit-line-clamp` for the social BookmarkManager warning.
- Regenerates `registry/index.json` so copied-source checksums match the fixed files.

## Root cause

The high-priority Editor failure came from naming the local editor context object `state` while initializing it with the `$state` rune. In strict consumer `svelte-check`, that was interpreted as a self-referential `$state` store subscription and produced the `$state used before declaration` cascade.

The remaining errors were unchecked array-index reads in transitive CLI-installed source that are valid at runtime but fail under `strict: true` + `noUncheckedIndexedAccess: true`.

## Validation

- `GREATER_CLI_LOCAL_REPO_ROOT=$PWD greater add faces/blog -a --force --ref local` into a detached emdash worktree
- `pnpm --dir <temp-emdash-worktree> run svelte-check` → `0 errors and 0 warnings`
- `GREATER_CLI_LOCAL_REPO_ROOT=$PWD greater diff faces/blog --cwd <temp-emdash-worktree>` → up to date, 0 modifications
- `GREATER_CLI_LOCAL_REPO_ROOT=$PWD greater doctor --cwd <temp-emdash-worktree>` → 0 errors; 158 files verified
- `pnpm typecheck`
- `pnpm lint`
- `pnpm generate-registry:validate`
- Package tests: blog, auth, compose, notifications, social
- Package builds: blog, auth, compose, notifications, social (compose re-run after adapters build, because the first parallel compose build raced adapter declaration output)
