### PR TITLE
fix: add OpenAPI auth contract probe for CSR-041 (Project 38 M2.4)

### DIFF
--- a/docs/lesser/contracts/README.md
+++ b/docs/lesser/contracts/README.md
@@ -36,6 +36,40 @@ Security/auth metadata guidance:
 - Do not hand-edit `openapi.yaml` in Greater to add auth requirements; fix the Lesser route contract, publish a Lesser
   release tag, then resync this directory from that tag so the pinned snapshot remains auditable.
 
+### Auth gap verification (CSR-041)
+
+Greater includes an auth contract probe (`scripts/check-openapi-auth.mjs`) that audits the pinned OpenAPI
+snapshot for sensitive endpoints (POST, PUT, DELETE, PATCH) that are missing a `security:` block.
+The probe compares against a committable baseline (`openapi-auth-baseline.json`) that records the exact
+endpoints known to lack auth metadata.
+
+**Run the probe:**
+
+```bash
+# Check for new auth gaps (exit 0 if all gaps are known, exit 1 if new gaps found)
+pnpm check:openapi-auth
+
+# Strict mode — treat known upstream gaps as errors (exit non-zero)
+pnpm check:openapi-auth:strict
+```
+
+**When you resync the OpenAPI snapshot from Lesser:**
+
+1. Copy the updated `openapi.yaml` into this directory.
+2. Run `pnpm check:openapi-auth` — if new gaps appear, investigate whether they are:
+   - New upstream gaps (Lesser needs to fix route contracts) → update the baseline
+   - New intentionally-public endpoints → add to `KNOWN_PUBLIC_PATHS` in the probe
+3. Regenerate the baseline to match current state:
+   ```bash
+   node scripts/check-openapi-auth.mjs --write-baseline
+   ```
+4. Commit `openapi.yaml`, the updated baseline, and any probe changes together.
+
+**Known state (as of Lesser snapshot sync):** 32 sensitive endpoints lack `security:` blocks in
+the pinned Lesser OpenAPI snapshot. The fix belongs in Lesser's route contracts — specifically,
+adding per-endpoint `security:` declarations or a global `security:` default with explicit
+`security: [{}]` overrides on public endpoints. See the baseline file for the full inventory.
+
 ## GraphQL (Published schema)
 
 - Published contract: `docs/contracts/graphql-schema.graphql`
@@ -69,3 +103,25 @@ wallet-backed agent access lease flow.
 ```bash
 ./lesser verify
 ```
+
+## Greater-side resync workflow
+
+When Lesser publishes a new release and this directory is resynced:
+
+1. Copy the updated contracts from the Lesser release tag into this directory.
+2. Regenerate Greater adapter code:
+   ```bash
+   pnpm generate
+   ```
+3. Run the auth contract probe to detect new auth gaps:
+   ```bash
+   pnpm check:openapi-auth
+   ```
+4. If new gaps appear, investigate and update the baseline:
+   ```bash
+   node scripts/check-openapi-auth.mjs --write-baseline
+   ```
+5. Run the full validation suite:
+   ```bash
+   pnpm lint && pnpm typecheck && pnpm test && pnpm build && pnpm generate-registry:validate
+   ```

--- a/docs/lesser/contracts/openapi-auth-baseline.json
+++ b/docs/lesser/contracts/openapi-auth-baseline.json
@@ -1,0 +1,245 @@
+{
+  "_comment": "Auth gap baseline for docs/lesser/contracts/openapi.yaml. Each entry is an endpoint missing a `security:` block in the pinned Lesser OpenAPI snapshot. The fix belongs in Lesser's route contracts. Do not hand-edit openapi.yaml in Greater.",
+  "_instructions": "When Lesser publishes a release with auth metadata fixes, resync this snapshot and regenerate this baseline via: node scripts/check-openapi-auth.mjs --write-baseline",
+  "known_gaps": [
+    {
+      "method": "POST",
+      "path": "/api/v1/agents/delegate",
+      "tags": [
+        "agents"
+      ]
+    },
+    {
+      "method": "PATCH",
+      "path": "/api/v1/agents/{username}",
+      "tags": [
+        "agents"
+      ]
+    },
+    {
+      "method": "DELETE",
+      "path": "/api/v1/agents/{username}",
+      "tags": [
+        "agents"
+      ]
+    },
+    {
+      "method": "POST",
+      "path": "/api/v1/agents/{username}/access-leases",
+      "tags": [
+        "agents"
+      ]
+    },
+    {
+      "method": "POST",
+      "path": "/api/v1/agents/{username}/access-leases/challenge/agent",
+      "tags": [
+        "agents"
+      ]
+    },
+    {
+      "method": "POST",
+      "path": "/api/v1/agents/{username}/access-leases/challenge/principal",
+      "tags": [
+        "agents"
+      ]
+    },
+    {
+      "method": "POST",
+      "path": "/api/v1/agents/{username}/access-leases/{leaseID}/renew/challenge",
+      "tags": [
+        "agents"
+      ]
+    },
+    {
+      "method": "POST",
+      "path": "/api/v1/agents/{username}/access-leases/{leaseID}/revoke",
+      "tags": [
+        "agents"
+      ]
+    },
+    {
+      "method": "POST",
+      "path": "/api/v1/agents/{username}/access-leases/{leaseID}/session-key",
+      "tags": [
+        "agents"
+      ]
+    },
+    {
+      "method": "POST",
+      "path": "/api/v1/agents/{username}/access-leases/{leaseID}/session-key/challenge",
+      "tags": [
+        "agents"
+      ]
+    },
+    {
+      "method": "POST",
+      "path": "/api/v1/agents/{username}/access-leases/{leaseID}/token",
+      "tags": [
+        "agents"
+      ]
+    },
+    {
+      "method": "POST",
+      "path": "/api/v1/agents/{username}/runtime-sessions/{sessionID}/revoke",
+      "tags": [
+        "agents"
+      ]
+    },
+    {
+      "method": "POST",
+      "path": "/api/v1/announcements/{id}/dismiss",
+      "tags": [
+        "announcements"
+      ]
+    },
+    {
+      "method": "POST",
+      "path": "/api/v1/follow_requests/{account_id}/authorize",
+      "tags": [
+        "follow_requests"
+      ]
+    },
+    {
+      "method": "POST",
+      "path": "/api/v1/follow_requests/{account_id}/reject",
+      "tags": [
+        "follow_requests"
+      ]
+    },
+    {
+      "method": "POST",
+      "path": "/api/v1/moderation/flag",
+      "tags": [
+        "moderation"
+      ]
+    },
+    {
+      "method": "POST",
+      "path": "/api/v1/moderation/review",
+      "tags": [
+        "moderation"
+      ]
+    },
+    {
+      "method": "PUT",
+      "path": "/api/v1/moderation/trust",
+      "tags": [
+        "moderation"
+      ]
+    },
+    {
+      "method": "POST",
+      "path": "/api/v1/notes",
+      "tags": [
+        "notes"
+      ]
+    },
+    {
+      "method": "POST",
+      "path": "/api/v1/notes/{id}/vote",
+      "tags": [
+        "notes"
+      ]
+    },
+    {
+      "method": "POST",
+      "path": "/api/v1/notifications/deliver",
+      "tags": [
+        "notifications"
+      ]
+    },
+    {
+      "method": "POST",
+      "path": "/api/v1/push/subscription",
+      "tags": [
+        "push"
+      ]
+    },
+    {
+      "method": "PUT",
+      "path": "/api/v1/push/subscription",
+      "tags": [
+        "push"
+      ]
+    },
+    {
+      "method": "DELETE",
+      "path": "/api/v1/push/subscription",
+      "tags": [
+        "push"
+      ]
+    },
+    {
+      "method": "POST",
+      "path": "/api/v1/reports",
+      "tags": [
+        "reports"
+      ]
+    },
+    {
+      "method": "POST",
+      "path": "/api/v1/reputation/export",
+      "tags": [
+        "reputation"
+      ]
+    },
+    {
+      "method": "POST",
+      "path": "/api/v1/reputation/import",
+      "tags": [
+        "reputation"
+      ]
+    },
+    {
+      "method": "POST",
+      "path": "/api/v1/reputation/verify",
+      "tags": [
+        "reputation"
+      ]
+    },
+    {
+      "method": "POST",
+      "path": "/api/v1/statuses/{id}/translate",
+      "tags": [
+        "statuses"
+      ]
+    },
+    {
+      "method": "DELETE",
+      "path": "/api/v1/suggestions/{account_id}",
+      "tags": [
+        "suggestions"
+      ]
+    },
+    {
+      "method": "POST",
+      "path": "/api/v1/vouches",
+      "tags": [
+        "vouches"
+      ]
+    },
+    {
+      "method": "DELETE",
+      "path": "/api/v1/vouches/{vouch_id}",
+      "tags": [
+        "vouches"
+      ]
+    }
+  ],
+  "meta": {
+    "spec_path": "docs/lesser/contracts/openapi.yaml",
+    "generated_at": "2026-05-23T20:40:49.741Z",
+    "has_global_security": false,
+    "has_security_schemes": true,
+    "security_scheme_names": [
+      "bearerAuth",
+      "oauth2",
+      "setupBearer"
+    ],
+    "total_paths": 293,
+    "sensitive_checked": 169,
+    "with_security": 115,
+    "without_security": 32
+  }
+}

--- a/package.json
+++ b/package.json
@@ -55,9 +55,11 @@
     "validate:exports": "node scripts/audit-exports.mjs",
     "validate:ids": "node scripts/validate-ids.js",
     "validate:versions": "node scripts/validate-release-versions.js",
-    "validate:package": "pnpm validate:exports && pnpm validate:dist && pnpm validate:deps && pnpm validate:cli && pnpm validate:tokens && pnpm validate:ids && pnpm validate:csp && pnpm validate:versions",
+    "validate:package": "pnpm validate:exports && pnpm validate:dist && pnpm validate:deps && pnpm validate:cli && pnpm validate:tokens && pnpm validate:ids && pnpm validate:csp && pnpm validate:versions && pnpm check:openapi-auth",
     "validate:registry": "node scripts/validate-registry-index.js --strict && pnpm validate:versions",
     "validate:tokens": "node scripts/audit-tokens-placeholders.mjs",
+    "check:openapi-auth": "node scripts/check-openapi-auth.mjs",
+    "check:openapi-auth:strict": "node scripts/check-openapi-auth.mjs --strict",
     "playwright:install": "pnpm --filter @equaltoai/greater-components-testing exec playwright install",
     "playwright:install:with-deps": "pnpm --filter @equaltoai/greater-components-testing exec playwright install --with-deps",
     "typecheck": "NODE_OPTIONS='--max-old-space-size=16384' pnpm run sveltekit:sync && NODE_OPTIONS='--max-old-space-size=16384' tsc --noEmit",
@@ -103,7 +105,8 @@
     "typescript": "^6.0.2",
     "typescript-eslint": "^8.58.0",
     "vite": "^8.0.8",
-    "vitest": "^4.1.4"
+    "vitest": "^4.1.4",
+    "yaml": "^2.8.3"
   },
   "packageManager": "pnpm@10.25.0",
   "engines": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -135,6 +135,9 @@ importers:
       vitest:
         specifier: ^4.1.4
         version: 4.1.4(@opentelemetry/api@1.9.0)(@types/node@25.6.0)(@vitest/coverage-v8@4.1.4)(@vitest/ui@4.1.4)(jsdom@29.0.2(@noble/hashes@1.8.0))(vite@8.0.8(@types/node@25.6.0)(esbuild@0.25.12)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
+      yaml:
+        specifier: ^2.8.3
+        version: 2.8.3
 
   apps/docs:
     dependencies:

--- a/scripts/check-openapi-auth.mjs
+++ b/scripts/check-openapi-auth.mjs
@@ -1,0 +1,311 @@
+#!/usr/bin/env node
+/**
+ * OpenAPI Auth Contract Probe — CSR-041.
+ *
+ * Audits `docs/lesser/contracts/openapi.yaml` for sensitive REST endpoints
+ * (POST, PUT, DELETE, PATCH) that are missing a `security:` block.
+ * The pinned OpenAPI snapshot is a generated contract from Lesser (upstream);
+ * Greater must not hand-edit it to add auth requirements.
+ *
+ * This probe:
+ * - Flags every sensitive verb+path without `security:`.
+ * - Compares against a committable baseline (`openapi-auth-baseline.json`)
+ *   that records the exact endpoints known to lack auth metadata.
+ * - New gaps (not in the baseline) exit non-zero so CI can catch regressions
+ *   after resync.
+ * - Known gaps exit zero with a warning — the fix belongs in Lesser's route
+ *   contracts, not here.
+ *
+ * USAGE:
+ *   node scripts/check-openapi-auth.mjs [--baseline PATH] [--strict]
+ *
+ *   --baseline  Path to baseline JSON (default: docs/lesser/contracts/openapi-auth-baseline.json)
+ *   --strict    Treat known upstream gaps as errors (exit non-zero)
+ *   --write-baseline  Update the baseline to reflect current state
+ */
+
+import { parse as parseYaml } from 'yaml';
+import { readFileSync, writeFileSync } from 'node:fs';
+import { resolve, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { parseArgs } from 'node:util';
+
+// ── Paths ──────────────────────────────────────────────────────────────────
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const ROOT = resolve(__dirname, '..');
+const DEFAULT_SPEC = resolve(ROOT, 'docs', 'lesser', 'contracts', 'openapi.yaml');
+const DEFAULT_BASELINE = resolve(ROOT, 'docs', 'lesser', 'contracts', 'openapi-auth-baseline.json');
+
+// ── Known public endpoints ─────────────────────────────────────────────────
+const KNOWN_PUBLIC_PREFIXES = [
+  '/.well-known/',         // WebFinger, nodeinfo, etc.
+  '/nodeinfo/',            // nodeinfo (alternative path)
+  '/oauth/',               // OAuth authorization/token flow
+  '/api/v1/apps',          // OAuth app registration (public)
+  '/api/v1/instance',      // Instance metadata
+  '/api/v1/custom_emojis', // Public emoji listing
+  '/api/v1/trends',        // Public trends
+  '/api/v1/directory',     // Public profile directory
+  '/api/v2/instance',      // Instance metadata v2
+];
+
+const KNOWN_PUBLIC_PATHS = new Map([
+  ['POST /api/v1/accounts', 'public account registration'],
+  ['POST /api/v1/auth/webauthn/login/begin', 'WebAuthn login challenge (no prior auth)'],
+  ['POST /api/v1/auth/webauthn/login/finish', 'WebAuthn login completion (no prior auth)'],
+  ['POST /auth/wallet/challenge', 'wallet auth challenge (no prior auth)'],
+  ['POST /auth/wallet/login', 'wallet login (no prior auth)'],
+  ['POST /auth/wallet/verify', 'wallet verification (no prior auth)'],
+  ['POST /inbox', 'shared ActivityPub inbox (HTTP Signatures, not bearer)'],
+  ['POST /users/{username}/inbox', 'user ActivityPub inbox (HTTP Signatures, not bearer)'],
+  ['POST /users/{username}/outbox', 'user ActivityPub outbox (HTTP Signatures, not bearer)'],
+  ['POST /api/v1/agents/register', 'agent registration (wallet challenge auth)'],
+  ['POST /api/v1/agents/register/challenge', 'agent registration challenge (public)'],
+  ['POST /api/v1/agents/auth/challenge', 'agent auth challenge (public)'],
+  ['POST /api/v1/agents/auth/token', 'agent auth token exchange (public)'],
+  ['POST /setup/bootstrap/challenge', 'setup bootstrap challenge (no prior auth)'],
+  ['POST /setup/bootstrap/verify', 'setup bootstrap verification (no prior auth)'],
+]);
+
+// ── Helpers ────────────────────────────────────────────────────────────────
+
+function loadOpenapi(specPath) {
+  const text = readFileSync(specPath, 'utf-8');
+  return parseYaml(text);
+}
+
+function isPublicByDesign(method, path) {
+  const key = `${method.toUpperCase()} ${path}`;
+  if (KNOWN_PUBLIC_PATHS.has(key)) {
+    return KNOWN_PUBLIC_PATHS.get(key);
+  }
+  for (const prefix of KNOWN_PUBLIC_PREFIXES) {
+    if (path.startsWith(prefix)) {
+      return `matches public prefix: ${prefix}`;
+    }
+  }
+  return null;
+}
+
+function auditAuth(spec) {
+  const paths = spec.paths ?? {};
+  const schemes = spec.components?.securitySchemes ?? {};
+  const globalSecurity = spec.security;
+
+  const gaps = [];
+  const allPaths = new Set();
+  let sensitiveChecked = 0;
+  let withSecurity = 0;
+  let withoutSecurity = 0;
+
+  for (const [rawPath, methods] of Object.entries(paths).sort(([a], [b]) => a.localeCompare(b))) {
+    if (typeof methods !== 'object' || methods === null) continue;
+    for (const [method, details] of Object.entries(methods)) {
+      if (!['post', 'put', 'delete', 'patch'].includes(method)) continue;
+      allPaths.add(`${method.toUpperCase()} ${rawPath}`);
+
+      sensitiveChecked++;
+      const hasSec = 'security' in details;
+
+      if (!hasSec) {
+        const reason = isPublicByDesign(method, rawPath);
+        if (reason) {
+          // Intentionally public — not a gap
+          continue;
+        }
+        withoutSecurity++;
+        gaps.push({
+          method: method.toUpperCase(),
+          path: rawPath,
+          tags: details.tags ?? [],
+        });
+      } else {
+        withSecurity++;
+      }
+    }
+  }
+
+  return {
+    gaps: gaps.sort((a, b) => a.path.localeCompare(b.path)),
+    hasGlobalSecurity: globalSecurity !== undefined,
+    hasSecuritySchemes: Object.keys(schemes).length > 0,
+    securitySchemeNames: Object.keys(schemes),
+    totalPaths: Object.keys(paths).length,
+    sensitiveChecked,
+    withSecurity,
+    withoutSecurity,
+  };
+}
+
+function loadBaseline(baselinePath) {
+  try {
+    const data = JSON.parse(readFileSync(baselinePath, 'utf-8'));
+    return new Set((data.known_gaps ?? []).map(g => `${g.method} ${g.path}`));
+  } catch {
+    return new Set();
+  }
+}
+
+function writeBaseline(baselinePath, gaps, meta) {
+  const baseline = {
+    _comment: (
+      'Auth gap baseline for docs/lesser/contracts/openapi.yaml. ' +
+      'Each entry is an endpoint missing a `security:` block in the ' +
+      'pinned Lesser OpenAPI snapshot. The fix belongs in Lesser\'s ' +
+      'route contracts. Do not hand-edit openapi.yaml in Greater.'
+    ),
+    _instructions: (
+      'When Lesser publishes a release with auth metadata fixes, ' +
+      'resync this snapshot and regenerate this baseline via: ' +
+      'node scripts/check-openapi-auth.mjs --write-baseline'
+    ),
+    known_gaps: gaps.sort((a, b) => a.path.localeCompare(b.path)),
+    meta,
+  };
+  writeFileSync(baselinePath, JSON.stringify(baseline, null, 2) + '\n', 'utf-8');
+}
+
+// ── CLI ────────────────────────────────────────────────────────────────────
+
+function printUsage() {
+  console.error('Usage: node scripts/check-openapi-auth.mjs [options]');
+  console.error('');
+  console.error('Options:');
+  console.error('  --spec PATH         Path to OpenAPI YAML spec');
+  console.error('  --baseline PATH     Path to baseline JSON');
+  console.error('  --strict            Treat known upstream gaps as errors');
+  console.error('  --write-baseline    Update the baseline to reflect current state');
+  console.error('  --help              Show this help');
+}
+
+function parseCliArgs() {
+  // parseArgs in Node 24
+  const { values } = parseArgs({
+    options: {
+      spec: { type: 'string' },
+      baseline: { type: 'string' },
+      strict: { type: 'boolean', default: false },
+      'write-baseline': { type: 'boolean', default: false },
+      help: { type: 'boolean', default: false },
+    },
+    allowPositionals: false,
+    strict: false,
+  });
+  return values;
+}
+
+function main() {
+  const args = parseCliArgs();
+
+  if (args.help) {
+    printUsage();
+    process.exit(0);
+  }
+
+  const specPath = args.spec ?? DEFAULT_SPEC;
+  const baselinePath = args.baseline ?? DEFAULT_BASELINE;
+
+  // Check that spec exists
+  try {
+    readFileSync(specPath);
+  } catch {
+    console.error(`ERROR: spec not found: ${specPath}`);
+    process.exit(2);
+  }
+
+  const spec = loadOpenapi(specPath);
+  const result = auditAuth(spec);
+
+  // ── Write baseline mode ──────────────────────────────────────────────
+  if (args['write-baseline']) {
+    const meta = {
+      spec_path: specPath,
+      generated_at: new Date().toISOString(),
+      has_global_security: result.hasGlobalSecurity,
+      has_security_schemes: result.hasSecuritySchemes,
+      security_scheme_names: result.securitySchemeNames,
+      total_paths: result.totalPaths,
+      sensitive_checked: result.sensitiveChecked,
+      with_security: result.withSecurity,
+      without_security: result.withoutSecurity,
+    };
+    writeBaseline(baselinePath, result.gaps, meta);
+    console.log(`Baseline written: ${baselinePath} (${result.gaps.length} known gaps)`);
+    return;
+  }
+
+  // ── Check mode ───────────────────────────────────────────────────────
+  const knownGapKeys = loadBaseline(baselinePath);
+
+  const newGaps = [];
+  const knownGaps = [];
+  for (const gap of result.gaps) {
+    const key = `${gap.method} ${gap.path}`;
+    if (knownGapKeys.has(key)) {
+      knownGaps.push(gap);
+    } else {
+      newGaps.push(gap);
+    }
+  }
+
+  // Print report
+  console.log('='.repeat(72));
+  console.log('OpenAPI Auth Contract Probe — CSR-041');
+  console.log('='.repeat(72));
+  console.log(`Spec:               ${specPath}`);
+  console.log(`Baseline:           ${baselinePath}`);
+  console.log(`Total paths:        ${result.totalPaths}`);
+  console.log(`Sensitive checked:  ${result.sensitiveChecked}`);
+  console.log(`  With security:    ${result.withSecurity}`);
+  console.log(`  Without security: ${result.withoutSecurity}`);
+  console.log(`Global security:    ${result.hasGlobalSecurity ? 'defined' : 'MISSING'}`);
+  console.log(`Security schemes:   ${result.securitySchemeNames.join(', ')}`);
+  console.log();
+
+  if (knownGaps.length > 0) {
+    console.log(`Known upstream gaps (in baseline): ${knownGaps.length}`);
+    for (const g of knownGaps.slice(0, 5)) {
+      console.log(`  [${g.method.padEnd(6)}] ${g.path}`);
+    }
+    if (knownGaps.length > 5) {
+      console.log(`  ... and ${knownGaps.length - 5} more (see baseline file for full list)`);
+    }
+    console.log();
+  }
+
+  if (newGaps.length > 0) {
+    console.log(`NEW gaps (not in baseline): ${newGaps.length}`);
+    for (const g of newGaps) {
+      console.log(`  [${g.method.padEnd(6)}] ${g.path}  tags=${JSON.stringify(g.tags)}`);
+    }
+    console.log();
+    console.log('ACTION: These endpoints are missing `security:` blocks and are not in');
+    console.log('the baseline. If the gap is real, update the baseline. If new endpoints');
+    console.log('were added by a Lesser resync that should have auth, report upstream.');
+    console.log();
+    console.log('POLICY: Do not hand-edit openapi.yaml in Greater. The fix belongs in');
+    console.log('Lesser\'s route contracts. See docs/lesser/contracts/README.md.');
+    process.exit(1);
+  }
+
+  if (result.gaps.length === 0) {
+    console.log('No auth gaps found. All sensitive endpoints have `security:` blocks.');
+    process.exit(0);
+  }
+
+  console.log(`Status: All ${result.gaps.length} auth gaps are known and in the baseline.`);
+  console.log('The fix belongs upstream in Lesser\'s route contracts.');
+  console.log();
+  console.log('To regenerate the baseline after a Lesser resync:');
+  console.log('  node scripts/check-openapi-auth.mjs --write-baseline');
+
+  if (args.strict) {
+    console.log();
+    console.log('--strict mode: treating known upstream gaps as errors.');
+    process.exit(1);
+  }
+
+  process.exit(0);
+}
+
+main();


### PR DESCRIPTION
## Summary

- Adds an OpenAPI auth contract probe (`scripts/check-openapi-auth.mjs`) that audits the pinned Lesser OpenAPI snapshot for sensitive endpoints missing `security:` blocks
- Creates a committable baseline (`docs/lesser/contracts/openapi-auth-baseline.json`) documenting 32 known upstream auth gaps
- Updates contract README with auth verification workflow and resync guidance
- Wires `check:openapi-auth` into `validate:package` for CI coverage
- Script is Node.js (ESM, `.mjs`) using the repo&apos;s declared `yaml` npm devDependency — no undeclared system dependencies

## CSR-041 Disposition

**Disposition:** `upstream-dependency`

The finding is **real** — 32 sensitive POST/PUT/DELETE/PATCH endpoints in the pinned Lesser OpenAPI snapshot are missing `security:` blocks. The fix belongs in Lesser&apos;s route contracts, not Greater. Greater must not hand-edit `openapi.yaml` (per longstanding policy in the contracts README).

The probe + baseline approach:
1. **Detects regressions** — if a Lesser resync adds new sensitive endpoints without auth, CI catches it
2. **Documents known state** — the baseline is a committable, reviewable inventory of 32 endpoints across agents, push, moderation, follow_requests, notes, reputation, vouches, and single-endpoint tags
3. **Shrinks as Lesser fixes** — when Lesser adds auth metadata and we resync, the baseline shrinks automatically (`--write-baseline`)

## Changes

| File | Change |
|------|--------|
| `scripts/check-openapi-auth.mjs` | New: Node.js auth contract probe |
| `docs/lesser/contracts/openapi-auth-baseline.json` | New: 32 known gaps baseline |
| `docs/lesser/contracts/README.md` | Updated: auth verification + resync workflow |
| `package.json` | Updated: `check:openapi-auth` / `check:openapi-auth:strict` (Node-based) + `yaml` devDependency |

## Validation

- [x] Probe: detects 32 gaps, all in baseline → exit 0
- [x] `--strict` mode: exit 1
- [x] `--write-baseline`: valid JSON output
- [x] `pnpm check:openapi-auth`: passes (Node.js, no undeclared deps)
- [x] `pnpm check:openapi-auth:strict`: exit 1 as expected
- [ ] Full greater gates — not run; script-only change, no component/type/contract impact

## Impact Assessment

- **Component API / Theming:** None
- **Lesser Contract-Sync:** Probe validates but does not modify the snapshot
- **Accessibility:** None
- **Registry / Generated Artifacts:** None
- **Mastodon / Fediverse Compat:** None
- **AGPL / Dependencies:** `yaml` npm package (v2.8.3, already in pnpm overrides) added as direct devDependency; AGPL-compatible (ISC)

## Issue linkage

Closes #614