### PR TITLE
fix(security): sync lesser-host x402 grant contracts for CSR-035

### DIFF
--- a/docs/lesser-host/contracts/LESSER_HOST_REF.txt
+++ b/docs/lesser-host/contracts/LESSER_HOST_REF.txt
@@ -1,2 +1,2 @@
-tag: v0.4.4
-commit: 1235e7e25016eb1def426f8e9a301c5a79a2c58d
+commit: 24c8d4b3d6055e79499f4c69947f79d4795024a5
+branch: project-38-security-remediation (post-v0.4.4, CSR-035 x402 grant security remediation)

--- a/docs/lesser-host/contracts/openapi.yaml
+++ b/docs/lesser-host/contracts/openapi.yaml
@@ -2915,13 +2915,15 @@ paths:
     post:
       operationId: soulX402IssueInvocationGrant
       summary: Issue a scoped x402 invocation grant
+      security:
+        - instanceKeyAuth: []
       description: |
         Issues a host-side off-chain invocation grant for a configured public paid caller. The grant binds the
         `agentId`, `capability`, `tool`, `resource`, invocation `requestHash`, caller subject hash, payment evidence
         hash, amount/network metadata, nonce, idempotency key hash, expiry, max usage, and caller-access payment policy
         version.
 
-        This public route returns a raw `grantToken` only on the first successful issue. Idempotent replays return the
+        This instance-key authenticated route returns a raw `grantToken` only on the first successful issue. Idempotent replays return the
         same grant metadata with `tokenReturned=false`; callers must retain the original token. Host stores only hashes
         of caller subject, payment evidence, optional payment id, idempotency key, and grant token. Generic
         `x402.grant_unavailable` errors avoid exposing private soul state, private comm reachability, unresolved payment

--- a/docs/lesser-host/spec/v3/schemas/soul-x402-invocation-grant.consume.request.schema.json
+++ b/docs/lesser-host/spec/v3/schemas/soul-x402-invocation-grant.consume.request.schema.json
@@ -4,7 +4,7 @@
   "title": "POST /api/v1/soul/x402/grants/{grantId}/consume request",
   "type": "object",
   "additionalProperties": false,
-  "required": ["grantToken", "agentId", "capability", "tool", "resource", "requestHash", "idempotencyKey"],
+  "required": ["grantToken", "agentId", "capability", "tool", "resource", "requestHash", "paymentEvidenceHash", "idempotencyKey"],
   "properties": {
     "grantToken": { "type": "string", "minLength": 1, "maxLength": 512 },
     "agentId": { "type": "string", "pattern": "^0x[0-9a-fA-F]{64}$" },
@@ -12,6 +12,7 @@
     "tool": { "type": "string", "minLength": 1, "maxLength": 128 },
     "resource": { "type": "string", "minLength": 1, "maxLength": 512 },
     "requestHash": { "type": "string", "pattern": "^(sha256:)?[0-9a-fA-F]{64}$" },
+    "paymentEvidenceHash": { "type": "string", "pattern": "^(sha256:)?[0-9a-fA-F]{64}$", "description": "Hash of the x402 payment evidence presented by the caller. Host compares against the stored grant payment evidence hash before any usage is recorded." },
     "idempotencyKey": { "type": "string", "minLength": 1, "maxLength": 256 }
   }
 }

--- a/docs/lesser-host/spec/v3/schemas/soul-x402-invocation-grant.issue.request.schema.json
+++ b/docs/lesser-host/spec/v3/schemas/soul-x402-invocation-grant.issue.request.schema.json
@@ -2,7 +2,7 @@
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "https://lesser.host/spec/v3/schemas/soul-x402-invocation-grant.issue.request.schema.json",
   "title": "POST /api/v1/soul/x402/grants request",
-  "description": "Issues a host-side scoped x402 invocation grant for configured public paid callers. Raw caller and payment evidence may be supplied for hashing but is never returned by the public route.",
+  "description": "Issues a host-side scoped x402 invocation grant for configured public paid callers. Raw caller and payment evidence may be supplied for hashing but is never returned by the instance-key authenticated route.",
   "type": "object",
   "additionalProperties": false,
   "required": ["agentId", "capability", "tool", "resource", "requestHash", "caller", "payment", "nonce", "idempotencyKey", "expiresAt"],

--- a/packages/adapters/src/__tests__/X402GrantContracts.test.ts
+++ b/packages/adapters/src/__tests__/X402GrantContracts.test.ts
@@ -1,0 +1,208 @@
+import { describe, expect, it } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import yaml from 'yaml';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+/** Read & parse the vendored lesser-host OpenAPI contract. */
+function loadLesserHostOpenAPI(): Record<string, unknown> {
+	const contractPath = path.join(
+		__dirname,
+		'..',
+		'..',
+		'..',
+		'..',
+		'docs',
+		'lesser-host',
+		'contracts',
+		'openapi.yaml',
+	);
+	const raw = fs.readFileSync(contractPath, 'utf8');
+	return yaml.parse(raw);
+}
+
+/** Load a vendored JSON schema file from docs/lesser-host/spec/v3/schemas/. */
+function loadLesserHostSchema(filename: string): Record<string, unknown> {
+	const schemaPath = path.join(
+		__dirname,
+		'..',
+		'..',
+		'..',
+		'..',
+		'docs',
+		'lesser-host',
+		'spec',
+		'v3',
+		'schemas',
+		filename,
+	);
+	const raw = fs.readFileSync(schemaPath, 'utf8');
+	return JSON.parse(raw);
+}
+
+describe('CSR-035: x402 grant contracts', () => {
+	// ── consume request schema ──────────────────────────────────────
+	describe('SoulX402InvocationGrantConsumeRequest', () => {
+		it('requires paymentEvidenceHash', () => {
+			const schema = loadLesserHostSchema(
+				'soul-x402-invocation-grant.consume.request.schema.json',
+			);
+			expect(schema.required).toContain('paymentEvidenceHash');
+		});
+
+		it('defines paymentEvidenceHash with sha256 pattern and description', () => {
+			const schema = loadLesserHostSchema(
+				'soul-x402-invocation-grant.consume.request.schema.json',
+			);
+			expect(schema.properties).toHaveProperty('paymentEvidenceHash');
+			const prop = schema.properties.paymentEvidenceHash as Record<string, unknown>;
+			expect(prop.type).toBe('string');
+			expect(prop.pattern).toBe('^(sha256:)?[0-9a-fA-F]{64}$');
+			expect(typeof prop.description).toBe('string');
+			expect(prop.description).toMatch(/payment evidence/i);
+		});
+
+		it('retains all original required fields plus paymentEvidenceHash', () => {
+			const schema = loadLesserHostSchema(
+				'soul-x402-invocation-grant.consume.request.schema.json',
+			);
+			const originalRequired = [
+				'grantToken',
+				'agentId',
+				'capability',
+				'tool',
+				'resource',
+				'requestHash',
+				'idempotencyKey',
+			];
+			for (const field of originalRequired) {
+				expect(schema.required).toContain(field);
+			}
+			expect(schema.required).toHaveLength(originalRequired.length + 1);
+		});
+	});
+
+	// ── issue request schema ────────────────────────────────────────
+	describe('SoulX402InvocationGrantIssueRequest', () => {
+		it('describes the route as instance-key authenticated', () => {
+			const schema = loadLesserHostSchema(
+				'soul-x402-invocation-grant.issue.request.schema.json',
+			);
+			expect(typeof schema.description).toBe('string');
+			expect(schema.description).toMatch(/instance-key authenticated/);
+			expect(schema.description).not.toMatch(/public route/);
+		});
+
+		it('still requires caller and payment with hash semantics', () => {
+			const schema = loadLesserHostSchema(
+				'soul-x402-invocation-grant.issue.request.schema.json',
+			);
+			expect(schema.required).toContain('caller');
+			expect(schema.required).toContain('payment');
+			expect(schema.required).toContain('agentId');
+			expect(schema.required).toContain('expiresAt');
+
+			const caller = schema.properties.caller as Record<string, unknown>;
+			expect(caller.properties).toHaveProperty('subjectHash');
+
+			const payment = schema.properties.payment as Record<string, unknown>;
+			expect(payment.properties).toHaveProperty('evidenceHash');
+		});
+	});
+
+	// ── OpenAPI path contract ───────────────────────────────────────
+	describe('OpenAPI x402 grant paths', () => {
+		const contract = loadLesserHostOpenAPI();
+
+		it('issue endpoint requires instanceKeyAuth', () => {
+			const paths =
+				(contract as { paths?: Record<string, unknown> }).paths ?? {};
+			const issuePath = paths['/api/v1/soul/x402/grants'] as {
+				post?: { security?: Array<Record<string, string[]>> };
+			};
+			expect(issuePath).toBeDefined();
+			expect(issuePath.post).toBeDefined();
+
+			const security = issuePath.post!.security;
+			expect(security).toBeDefined();
+			expect(security).toHaveLength(1);
+			expect(security![0]).toHaveProperty('instanceKeyAuth');
+		});
+
+		it('consume endpoint requires instanceKeyAuth (unchanged)', () => {
+			const paths =
+				(contract as { paths?: Record<string, unknown> }).paths ?? {};
+			const consumePath = paths[
+				'/api/v1/soul/x402/grants/{grantId}/consume'
+			] as {
+				post?: { security?: Array<Record<string, string[]>> };
+			};
+			expect(consumePath).toBeDefined();
+			expect(consumePath.post).toBeDefined();
+
+			const security = consumePath.post!.security;
+			expect(security).toBeDefined();
+			expect(security).toHaveLength(1);
+			expect(security![0]).toHaveProperty('instanceKeyAuth');
+		});
+
+		it('issue endpoint description references instance-key auth', () => {
+			const paths =
+				(contract as { paths?: Record<string, unknown> }).paths ?? {};
+			const issuePath = paths['/api/v1/soul/x402/grants'] as {
+				post?: { description?: string };
+			};
+			expect(issuePath.post?.description).toMatch(/instance-key authenticated route/);
+			expect(issuePath.post?.description).not.toMatch(/public route/);
+		});
+	});
+
+	// ── Grant schema (unchanged core) ───────────────────────────────
+	describe('SoulX402InvocationGrant', () => {
+		it('includes evidenceHash in the payment object (grant record)', () => {
+			const schema = loadLesserHostSchema(
+				'soul-x402-invocation-grant.schema.json',
+			);
+			const payment = schema.properties.payment as Record<string, unknown>;
+			expect(payment.required).toContain('evidenceHash');
+			expect(payment.properties).toHaveProperty('evidenceHash');
+		});
+
+		it('has facilitatorTrustBoundary set to caller_provided_unverified', () => {
+			const schema = loadLesserHostSchema(
+				'soul-x402-invocation-grant.schema.json',
+			);
+			const payment = schema.properties.payment as Record<string, unknown>;
+			expect(payment.required).toContain('facilitatorTrustBoundary');
+			expect(payment.properties).toHaveProperty('facilitatorTrustBoundary');
+			const ftb = payment.properties
+				.facilitatorTrustBoundary as Record<string, unknown>;
+			expect(ftb.enum).toEqual(['caller_provided_unverified']);
+		});
+	});
+
+	// ── LESSER_HOST_REF pin ─────────────────────────────────────────
+	describe('LESSER_HOST_REF contract pin', () => {
+		it('pins to the CSR-035 remediated commit', () => {
+			const refPath = path.join(
+				__dirname,
+				'..',
+				'..',
+				'..',
+				'..',
+				'docs',
+				'lesser-host',
+				'contracts',
+				'LESSER_HOST_REF.txt',
+			);
+			const refContent = fs.readFileSync(refPath, 'utf8');
+			expect(refContent).toMatch(
+				/24c8d4b3d6055e79499f4c69947f79d4795024a5/,
+			);
+			expect(refContent).toMatch(/CSR-035/);
+		});
+	});
+});

--- a/packages/adapters/src/rest/generated/lesser-host-api.ts
+++ b/packages/adapters/src/rest/generated/lesser-host-api.ts
@@ -523,7 +523,7 @@ export interface paths {
          *     hash, amount/network metadata, nonce, idempotency key hash, expiry, max usage, and caller-access payment policy
          *     version.
          *
-         *     This public route returns a raw `grantToken` only on the first successful issue. Idempotent replays return the
+         *     This instance-key authenticated route returns a raw `grantToken` only on the first successful issue. Idempotent replays return the
          *     same grant metadata with `tokenReturned=false`; callers must retain the original token. Host stores only hashes
          *     of caller subject, payment evidence, optional payment id, idempotency key, and grant token. Generic
          *     `x402.grant_unavailable` errors avoid exposing private soul state, private comm reachability, unresolved payment
@@ -1578,7 +1578,7 @@ export interface components {
         };
         /**
          * POST /api/v1/soul/x402/grants request
-         * @description Issues a host-side scoped x402 invocation grant for configured public paid callers. Raw caller and payment evidence may be supplied for hashing but is never returned by the public route.
+         * @description Issues a host-side scoped x402 invocation grant for configured public paid callers. Raw caller and payment evidence may be supplied for hashing but is never returned by the instance-key authenticated route.
          */
         "soul-x402-invocation-grant.issue.request.schema": {
             agentId: string;
@@ -1682,6 +1682,8 @@ export interface components {
             tool: string;
             resource: string;
             requestHash: string;
+            /** @description Hash of the x402 payment evidence presented by the caller. Host compares against the stored grant payment evidence hash before any usage is recorded. */
+            paymentEvidenceHash: string;
             idempotencyKey: string;
         };
         /** POST /api/v1/soul/x402/grants/{grantId}/consume response */


### PR DESCRIPTION
## Summary

Completes **CSR-035** for greater-components: syncs the vendored lesser-host contracts and regenerates the REST adapter to incorporate x402 grant security remediation from Host PR [equaltoai/lesser-host#367](https://github.com/equaltoai/lesser-host/pull/367) (merged as `24c8d4b`).

### Contract changes

| File | Change |
|---|---|
| `docs/lesser-host/contracts/openapi.yaml` | Add `instanceKeyAuth` security to x402 grant **issue** endpoint (was previously public / unauthenticated) |
| `docs/lesser-host/spec/v3/schemas/soul-x402-invocation-grant.consume.request.schema.json` | Add required `paymentEvidenceHash` field with sha256 pattern and description |
| `docs/lesser-host/spec/v3/schemas/soul-x402-invocation-grant.issue.request.schema.json` | Update description: "public route" → "instance-key authenticated route" |
| `docs/lesser-host/contracts/LESSER_HOST_REF.txt` | Pin to host commit `24c8d4b` (project-38-security-remediation, post-v0.4.4) |

### Adapter regeneration

- Ran `pnpm generate:openapi:lesser-host` to regenerate `packages/adapters/src/rest/generated/lesser-host-api.ts`
- Generated types now include `paymentEvidenceHash: string` in `SoulX402InvocationGrantConsumeRequest`

### Validation

- Added `packages/adapters/src/__tests__/X402GrantContracts.test.ts` with **11 contract/regression tests** covering:
  - Consume request requires `paymentEvidenceHash` with correct sha256 pattern
  - All original required fields preserved
  - Issue request schema describes instance-key auth (not "public route")
  - OpenAPI paths: issue + consume both require `instanceKeyAuth`
  - Grant schema preserves `evidenceHash` and `facilitatorTrustBoundary`
  - LESSER_HOST_REF pin verification

### CI checks

- [x] `pnpm generate:openapi:lesser-host` — regenerates cleanly
- [x] `vitest run` — **542 tests pass, 0 failures** (31 test files, includes 11 new contract tests)
- [x] `tsc --noEmit` — clean typecheck
- [x] DCO signed-off

### CSR-035 disposition

| Finding | Status |
|---|---|
| CSR-035 — x402 grant issue auth missing | **FIXED** — issue endpoint now requires `instanceKeyAuth` |
| CSR-035 — consume paymentEvidenceHash not required | **FIXED** — `paymentEvidenceHash` is now a required field |

### Cross-repo linkage

Closes equaltoai/lesser-body#277

Note: CSR-011 was already handled in equaltoai/lesser-body#281; this PR completes CSR-035.

🤖 Generated with [Claude Code](https://claude.com/claude-code)