### PR TITLE
feat(shell): add accessible CommandPalette for Host M0 navigation (#634)

### DIFF
--- a/.changeset/command-palette-g1.md
+++ b/.changeset/command-palette-g1.md
@@ -1,0 +1,30 @@
+---
+'greater-components': minor
+'@equaltoai/greater-components': minor
+'@equaltoai/greater-components-shell': minor
+---
+
+Add `CommandPalette` to the `@equaltoai/greater-components/shell` surface — an accessible, strict-CSP-safe command palette for app navigation, quick actions, and settings search (lesser-host web M0.7 / Project 39 Greater Signal D).
+
+Highlights:
+
+- **W3C ARIA combobox + listbox pattern with virtual focus.** Real focus stays on the search input; ArrowUp / ArrowDown / Home / End move `aria-activedescendant` through results, skipping disabled items. Enter activates the current item; Escape closes; outside-pointerdown closes; focus returns to the opener.
+- **Composes existing headless behaviors.** Uses `createFocusTrap`, `createDismissable`, and `createLiveRegion` from `@equaltoai/greater-components-headless` rather than reimplementing focus management, ESC handling, or live-region announcements.
+- **Grouped or flat results.** Pass `groups: CommandPaletteGroup[]` to render one `<ul role="listbox">` per group (each `<section role="group">` with linked `aria-labelledby` header) or `items: CommandPaletteItem[]` for a single flat listbox.
+- **Dependency-free fuzzy filter.** Bundled at `@equaltoai/greater-components/shell/fuzzy-filter` (also exported as `filterAndRankCommandPaletteItems`, `scoreCommandPaletteItem`, `tokenizeCommandPaletteQuery` from the shell barrel). No cmdk, no runtime dependency, no `unsafe-eval`. Multi-token queries require every token to match; ranking prefers exact > prefix > word-boundary > substring across label / description / keywords. Override with a `filter` prop.
+- **Customizable rendering.** `itemTemplate(item, isActive)`, `emptyState`, and `loadingState` snippets let consumers theme the palette without forking.
+- **Strict CSP + SSR safe.** No inline event handlers; no `style` attributes set at runtime; no module-level browser globals. Stable per-instance ids via `useStableId` (same primitive Modal / TextArea / Panel / StatCard already use).
+- **Theming via additive `--gr-shell-*` tokens.** The command-palette root class is included in the broad `:where(...)` defaults selector, so standalone usage outside a `Shell` ancestor still has working spacing.
+
+API:
+
+```ts
+import { CommandPalette } from '@equaltoai/greater-components/shell';
+import type {
+	CommandPaletteItem,
+	CommandPaletteGroup,
+	CommandPaletteFilter,
+} from '@equaltoai/greater-components/shell/types';
+```
+
+No existing exports are renamed or removed. No Lesser / Lesser Host adapter or contract changes.

--- a/apps/playground/src/routes/+page.svelte
+++ b/apps/playground/src/routes/+page.svelte
@@ -84,6 +84,9 @@
 			<Button variant="outline" size="lg" onclick={() => navigateTo('/shell')}>
 				Shell Components Demo
 			</Button>
+			<Button variant="outline" size="lg" onclick={() => navigateTo('/command-palette')}>
+				Command Palette Demo
+			</Button>
 		</div>
 	</section>
 

--- a/apps/playground/src/routes/command-palette/+page.svelte
+++ b/apps/playground/src/routes/command-palette/+page.svelte
@@ -1,0 +1,210 @@
+<!--
+CommandPalette playground demo.
+
+Exercises the @equaltoai/greater-components-shell CommandPalette with:
+- Grouped results (Pages + Actions)
+- Disabled item (skipped by keyboard navigation)
+- Shortcut chip
+- Click-to-open trigger (Cmd/Ctrl + K binding lives in the consumer; this
+  demo uses a plain button to keep the demo self-contained and CSP-safe).
+
+Strict-CSP safe: no inline handlers; all event handlers are real Svelte
+handlers; all styling consumes --gr-* tokens via the bundled shell.css.
+-->
+<script lang="ts">
+	import { CommandPalette } from '@equaltoai/greater-components-shell';
+	import type {
+		CommandPaletteGroup,
+		CommandPaletteItem,
+	} from '@equaltoai/greater-components-shell';
+	import '@equaltoai/greater-components-shell/shell.css';
+
+	let open = $state(false);
+	let lastSelected = $state<string | null>(null);
+	let triggerEl = $state<HTMLButtonElement | null>(null);
+
+	const groups: CommandPaletteGroup[] = [
+		{
+			id: 'pages',
+			label: 'Pages',
+			items: [
+				{
+					id: 'overview',
+					label: 'Overview',
+					description: 'Fleet overview dashboard',
+					keywords: ['home', 'fleet'],
+					shortcut: '⌘O',
+				},
+				{
+					id: 'instances',
+					label: 'Instances',
+					description: 'Provisioned instances',
+					keywords: ['servers', 'nodes'],
+				},
+				{
+					id: 'billing',
+					label: 'Billing & invoicing',
+					description: 'Monthly cycles, usage, invoices',
+					keywords: ['cost', 'invoice'],
+				},
+				{
+					id: 'settings',
+					label: 'Settings',
+					description: 'Account, security, team',
+					keywords: ['preferences', 'account'],
+				},
+			],
+		},
+		{
+			id: 'actions',
+			label: 'Actions',
+			items: [
+				{
+					id: 'refresh',
+					label: 'Refresh',
+					description: 'Reload current view',
+					shortcut: '⌘R',
+				},
+				{
+					id: 'theme-toggle',
+					label: 'Toggle theme',
+					description: 'Switch between light, dark, and high contrast',
+					keywords: ['dark', 'light', 'mode'],
+					shortcut: 'T',
+				},
+				{
+					id: 'invite',
+					label: 'Invite teammate',
+					keywords: ['email', 'collaborator'],
+				},
+				{
+					id: 'archive',
+					label: 'Archive instance',
+					description: 'Coming soon',
+					disabled: true,
+				},
+			],
+		},
+	];
+
+	function openPalette() {
+		open = true;
+	}
+
+	function handleSelect(item: CommandPaletteItem) {
+		lastSelected = item.label;
+		open = false;
+	}
+</script>
+
+<svelte:head>
+	<title>CommandPalette — Greater Components Playground</title>
+</svelte:head>
+
+<div class="page">
+	<header>
+		<h1>CommandPalette</h1>
+		<p>
+			Accessible, strict-CSP-safe command palette. Open with the button below, then type to filter,
+			use ArrowUp/ArrowDown/Home/End to navigate, Enter to activate, Escape to close.
+		</p>
+	</header>
+
+	<section>
+		<button
+			type="button"
+			bind:this={triggerEl}
+			onclick={openPalette}
+			aria-haspopup="dialog"
+			aria-expanded={open}
+		>
+			Open command palette
+		</button>
+
+		{#if lastSelected}
+			<p class="last-selected">
+				<strong>Last selected:</strong>
+				{lastSelected}
+			</p>
+		{/if}
+	</section>
+
+	<section>
+		<h2>Accessibility behaviors covered</h2>
+		<ul>
+			<li>Dialog role + accessible name (`Command palette`).</li>
+			<li>
+				Combobox + listbox virtual focus via <code>aria-activedescendant</code>; keyboard input
+				stays on the search field.
+			</li>
+			<li>
+				ArrowUp / ArrowDown / Home / End navigate options, skipping disabled items.
+				<em>Archive instance</em> is disabled and skipped.
+			</li>
+			<li>
+				Enter activates the active option; Escape closes; clicking outside closes; focus is returned
+				to the opener button.
+			</li>
+			<li>Grouped results expose <code>role="group"</code> with linked group headers.</li>
+			<li>Live region politely announces result counts and empty / loading state changes.</li>
+		</ul>
+	</section>
+
+	<CommandPalette
+		bind:open
+		label="Greater playground command palette"
+		inputLabel="Search pages and actions"
+		placeholder="Type to search…"
+		{groups}
+		returnFocusTo={triggerEl}
+		onselect={handleSelect}
+	/>
+</div>
+
+<style>
+	.page {
+		max-width: 48rem;
+		margin: 2rem auto;
+		padding: 0 1.5rem;
+		font-family:
+			ui-sans-serif,
+			system-ui,
+			-apple-system,
+			'Segoe UI',
+			Roboto,
+			sans-serif;
+		color: var(--gr-semantic-foreground-primary, #111827);
+	}
+	header {
+		margin-bottom: 1.5rem;
+	}
+	h1 {
+		margin: 0 0 0.5rem;
+		font-size: 1.5rem;
+	}
+	section {
+		margin-top: 1.5rem;
+	}
+	button {
+		font: inherit;
+		padding: 0.5rem 1rem;
+		border-radius: 0.375rem;
+		border: 1px solid var(--gr-semantic-border-subtle, #e5e7eb);
+		background: var(--gr-semantic-background-surface, #fff);
+		cursor: pointer;
+	}
+	button:hover {
+		background: var(--gr-semantic-background-secondary, #f3f4f6);
+	}
+	.last-selected {
+		margin-top: 1rem;
+		padding: 0.5rem 0.75rem;
+		border-radius: 0.375rem;
+		background: var(--gr-color-success-50, #f0fdf4);
+		color: var(--gr-color-success-900, #14532d);
+	}
+	code {
+		font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+		font-size: 0.875em;
+	}
+</style>

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -1400,20 +1400,21 @@ The Shell package provides app-shell layout components for app-shaped consumers
 (e.g. lesser-host web, sim). All components are Svelte 5 runes, strict-CSP safe, and
 meet WCAG 2.1 AA from first release.
 
-**Components (10):**
+**Components (11):**
 
-| Component      | Element                                               | Required props            | Snippets / slots                          |
-| -------------- | ----------------------------------------------------- | ------------------------- | ----------------------------------------- |
-| `Shell`        | `<div>` with `<main>`                                 | —                         | `topbar`, `sidebar`, `children`           |
-| `Sidebar`      | `<nav aria-label>`                                    | `label`                   | `header`, `footer`, `children`            |
-| `Topbar`       | `<header>`                                            | —                         | `start`, `center`, `end`, `children`      |
-| `Panel`        | `<section>`                                           | —                         | `header`, `actions`, `footer`, `children` |
-| `StatCard`     | `<div role="group">`                                  | `label`, `value`          | `icon`                                    |
-| `SummaryStrip` | `<section aria-label>`                                | `label`                   | `children`                                |
-| `PageFrame`    | `<div>` with optional `<header>`/`<aside>`/`<footer>` | —                         | `header`, `footer`, `aside`, `children`   |
-| `PageTitle`    | `<header>` containing `<h1>` or `<h2>`                | `title`                   | `actions`                                 |
-| `Breadcrumb`   | `<nav aria-label>` + `<ol>`                           | `items: BreadcrumbItem[]` | —                                         |
-| `Callout`      | `<div role>`                                          | —                         | `icon`, `actions`, `children`             |
+| Component        | Element                                                                       | Required props                    | Snippets / slots                                             |
+| ---------------- | ----------------------------------------------------------------------------- | --------------------------------- | ------------------------------------------------------------ |
+| `Shell`          | `<div>` with `<main>`                                                         | —                                 | `topbar`, `sidebar`, `children`                              |
+| `Sidebar`        | `<nav aria-label>`                                                            | `label`                           | `header`, `footer`, `children`                               |
+| `Topbar`         | `<header>`                                                                    | —                                 | `start`, `center`, `end`, `children`                         |
+| `Panel`          | `<section>`                                                                   | —                                 | `header`, `actions`, `footer`, `children`                    |
+| `StatCard`       | `<div role="group">`                                                          | `label`, `value`                  | `icon`                                                       |
+| `SummaryStrip`   | `<section aria-label>`                                                        | `label`                           | `children`                                                   |
+| `PageFrame`      | `<div>` with optional `<header>`/`<aside>`/`<footer>`                         | —                                 | `header`, `footer`, `aside`, `children`                      |
+| `PageTitle`      | `<header>` containing `<h1>` or `<h2>`                                        | `title`                           | `actions`                                                    |
+| `Breadcrumb`     | `<nav aria-label>` + `<ol>`                                                   | `items: BreadcrumbItem[]`         | —                                                            |
+| `Callout`        | `<div role>`                                                                  | —                                 | `icon`, `actions`, `children`                                |
+| `CommandPalette` | `<div role="dialog">` + `<input role="combobox">` + `<ul role="listbox">` × N | exactly one of `groups` / `items` | `itemTemplate(item, isActive)`, `emptyState`, `loadingState` |
 
 **Key prop unions** (from `@equaltoai/greater-components/shell/types`):
 
@@ -1433,6 +1434,9 @@ meet WCAG 2.1 AA from first release.
 - `BreadcrumbItem = { label: string; href?: string; current?: boolean }`
 - `CalloutTone = 'info' | 'success' | 'warning' | 'danger' | 'neutral'`
 - `CalloutRole = 'status' | 'alert' | 'note'`
+- `CommandPaletteItem = { id: string; label: string; description?: string; keywords?: string[]; shortcut?: string; disabled?: boolean }`
+- `CommandPaletteGroup = { id: string; label: string; items: CommandPaletteItem[] }`
+- `CommandPaletteFilter = (item, query) => number | null | undefined`
 
 **Accessibility:**
 
@@ -1446,6 +1450,13 @@ meet WCAG 2.1 AA from first release.
   assertive.
 - Breadcrumb auto-marks the last item with `aria-current="page"` unless an explicit
   `current` flag is set; separators are `aria-hidden`.
+- CommandPalette implements the W3C ARIA combobox + listbox pattern. The input keeps
+  real focus; arrow keys move `aria-activedescendant` virtual focus through results.
+  Composes `createFocusTrap` + `createDismissable` + `createLiveRegion` from
+  `@equaltoai/greater-components/headless`. ESC closes; outside-pointerdown closes;
+  focus is restored to the opener. Disabled items are skipped during keyboard
+  navigation and ignored on Enter / click. Live region announces result counts and
+  loading / empty state changes politely.
 
 **Theming:**
 
@@ -1474,8 +1485,28 @@ import '@equaltoai/greater-components/shell/style.css';
 greater add shell
 ```
 
-This copies the 10 components, their CSS, types, and barrel into the consumer's
-`$lib/greater/shell` directory. The CLI registry validates per-file checksums on install.
+This copies the 11 components, their CSS, types, dependency-free fuzzy filter, and
+barrel into the consumer's `$lib/greater/shell` directory. The CLI registry validates
+per-file checksums on install.
+
+**CommandPalette fuzzy filter:**
+
+The package ships a dependency-free filter at
+`@equaltoai/greater-components/shell/fuzzy-filter` (also re-exported as
+`filterAndRankCommandPaletteItems`, `scoreCommandPaletteItem`, and
+`tokenizeCommandPaletteQuery` from the shell barrel). It is strict-CSP-safe —
+no `unsafe-eval`, no dynamic codegen, no runtime dependencies. Consumers can
+override the built-in scorer with the `filter` prop:
+
+```ts
+import { CommandPalette } from '@equaltoai/greater-components/shell';
+import type { CommandPaletteFilter } from '@equaltoai/greater-components/shell/types';
+
+const customFilter: CommandPaletteFilter = (item, query) => {
+	// Return a numeric score (higher = better) or null to exclude.
+	return item.label.toLowerCase().startsWith(query.toLowerCase()) ? 1 : null;
+};
+```
 
 See also the [Shell section of the component inventory](./component-inventory.md#shell-package-libgreatershell) for a full
 component-by-component description.

--- a/docs/component-inventory.md
+++ b/docs/component-inventory.md
@@ -1225,28 +1225,30 @@ to the shell surface without inheriting the broader primitives bundle.
 - Content containers with heading hierarchy and actions groups
 - Metric / summary surfaces (`StatCard`, `SummaryStrip`)
 - Status-aware call-outs with derived live-region semantics
+- Accessible command palette (`CommandPalette`) with virtual focus, grouped
+  results, and a dependency-free fuzzy filter
 
 **What Shell Does NOT Provide:**
 
 ❌ NO data fetching (Shell is presentational; bring your own adapters)
 ❌ NO routing (consume your router's `<a>` / `<button>` / store integrations)
 ❌ NO state management (use stores from your app or `$lib/greater/utils`)
-❌ NO command palette yet (planned for G1 — see #634)
 
-### All 10 Components
+### All 11 Components
 
-| Component        | Element                                                   | Purpose                                                                                                                                                                 |
-| ---------------- | --------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------- |
-| **Shell**        | `<div>` containing `<main>`                               | Root grid layout combining sidebar, topbar, and main content. Always renders a single `<main>` landmark; accepts an optional `mainLabel`.                               |
-| **Sidebar**      | `<nav aria-label>`                                        | Semantic navigation sidebar. Requires `label` prop; consumers populate children with real `<a>` (with `aria-current="page"` on the active link) or `<button>` controls. |
-| **Topbar**       | `<header>`                                                | Site/app header bar with optional `start` / `center` / `end` regions. Supports `sticky` and `variant="default"                                                          | "flat"                          | "elevated"`.                                                                                                                                   |
-| **Panel**        | `<section>` with auto `aria-labelledby`                   | Content container with title heading, optional `header`, `actions`, `footer` slots. `headerLevel` selects `<h1>`–`<h6>`.                                                |
-| **StatCard**     | `<div role="group">` with composed `aria-labelledby`      | Metric display card (`label`, `value`, optional `trend`, `description`, `icon`, `status`).                                                                              |
-| **SummaryStrip** | `<section aria-label>`                                    | Labeled responsive grid grouping summary items. `columns` accepts `'auto'` or `1` – `6`; `gap` accepts `'sm'                                                            | 'md'                            | 'lg'`.                                                                                                                                         |
-| **PageFrame**    | `<div>` with optional `<header>` / `<aside>` / `<footer>` | Content-level wrapper that sits inside Shell's `<main>`. `width` selects `narrow` / `default` / `wide` / `full`.                                                        |
-| **PageTitle**    | `<header>` containing `<h1>`/`<h2>`                       | Page heading with eyebrow / subtitle / description / actions. `level` selects 1 or 2.                                                                                   |
-| **Breadcrumb**   | `<nav aria-label>` + `<ol>`                               | Breadcrumb list. The current item (last item by default; can be set explicitly) carries `aria-current="page"`. Separators are `aria-hidden`.                            |
-| **Callout**      | `<div role="status"                                       | "alert"                                                                                                                                                                 | "note">`with derived`aria-live` | Informational call-out. `tone` of `info` / `success` / `neutral` defaults to `role="status"`; `warning` / `danger` defaults to `role="alert"`. |
+| Component          | Element                                                                              | Purpose                                                                                                                                                                                                                                 |
+| ------------------ | ------------------------------------------------------------------------------------ | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Shell**          | `<div>` containing `<main>`                                                          | Root grid layout combining sidebar, topbar, and main content. Always renders a single `<main>` landmark; accepts an optional `mainLabel`.                                                                                               |
+| **Sidebar**        | `<nav aria-label>`                                                                   | Semantic navigation sidebar. Requires `label` prop; consumers populate children with real `<a>` (with `aria-current="page"` on the active link) or `<button>` controls.                                                                 |
+| **Topbar**         | `<header>`                                                                           | Site/app header bar with optional `start` / `center` / `end` regions. Supports `sticky` and `variant="default"                                                                                                                          | "flat"                          | "elevated"`.                                                                                                                                   |
+| **Panel**          | `<section>` with auto `aria-labelledby`                                              | Content container with title heading, optional `header`, `actions`, `footer` slots. `headerLevel` selects `<h1>`–`<h6>`.                                                                                                                |
+| **StatCard**       | `<div role="group">` with composed `aria-labelledby`                                 | Metric display card (`label`, `value`, optional `trend`, `description`, `icon`, `status`).                                                                                                                                              |
+| **SummaryStrip**   | `<section aria-label>`                                                               | Labeled responsive grid grouping summary items. `columns` accepts `'auto'` or `1` – `6`; `gap` accepts `'sm'                                                                                                                            | 'md'                            | 'lg'`.                                                                                                                                         |
+| **PageFrame**      | `<div>` with optional `<header>` / `<aside>` / `<footer>`                            | Content-level wrapper that sits inside Shell's `<main>`. `width` selects `narrow` / `default` / `wide` / `full`.                                                                                                                        |
+| **PageTitle**      | `<header>` containing `<h1>`/`<h2>`                                                  | Page heading with eyebrow / subtitle / description / actions. `level` selects 1 or 2.                                                                                                                                                   |
+| **Breadcrumb**     | `<nav aria-label>` + `<ol>`                                                          | Breadcrumb list. The current item (last item by default; can be set explicitly) carries `aria-current="page"`. Separators are `aria-hidden`.                                                                                            |
+| **Callout**        | `<div role="status"                                                                  | "alert"                                                                                                                                                                                                                                 | "note">`with derived`aria-live` | Informational call-out. `tone` of `info` / `success` / `neutral` defaults to `role="status"`; `warning` / `danger` defaults to `role="alert"`. |
+| **CommandPalette** | `<div role="dialog" aria-modal>` + `<input role="combobox">` + `<ul role="listbox">` | Accessible command palette for app navigation / quick actions. Combobox + listbox pattern with virtual focus via `aria-activedescendant`; ESC/outside-click close; focus trap; live-region announcements; dependency-free fuzzy filter. |
 
 ### Accessibility guarantees
 
@@ -1281,8 +1283,67 @@ forking the package.
 greater add shell
 ```
 
-This copies all 10 shell components, their CSS, types, and the barrel into the consumer's
-project. The CLI registry verifies per-file checksums on install (see [CLI guide](./cli.md)).
+This copies all 11 shell components, their CSS, types, the dependency-free
+fuzzy filter, and the barrel into the consumer's project. The CLI registry
+verifies per-file checksums on install (see [CLI guide](./cli.md)).
+
+### CommandPalette quick reference
+
+The CommandPalette implements the W3C ARIA combobox + listbox pattern:
+
+- Renders a `<div role="dialog" aria-modal="true">` overlay with an inner
+  `<input role="combobox" aria-autocomplete="list" aria-expanded="true">` and
+  `<ul role="listbox">` (or one listbox per group when `groups` is supplied).
+- Virtual focus: real focus stays on the input; arrow keys move the
+  `aria-activedescendant` pointer through results without blurring the input.
+- Keyboard lifecycle: `ArrowUp` / `ArrowDown` navigate skipping disabled items;
+  `Home` / `End` jump to the first / last selectable item; `Enter` activates
+  the current item; `Escape` closes; outside-pointerdown closes; focus is
+  restored to the opener.
+- Live region: result counts and empty / loading states are announced
+  politely via `createLiveRegion` (no DOM noise — uses a global, off-screen
+  region).
+- Filter: pass `filter` to override the built-in scorer; the default scores
+  exact label match > prefix > word-boundary > substring across label,
+  description, and keywords; multi-token queries require every token to match.
+- Item shape: `{ id, label, description?, keywords?, shortcut?, disabled? }`.
+  Groups wrap items with `{ id, label, items[] }`.
+
+Minimum host wiring:
+
+```svelte
+<script lang="ts">
+	import { CommandPalette } from '@equaltoai/greater-components/shell';
+
+	let open = $state(false);
+
+	const groups = [
+		{
+			id: 'pages',
+			label: 'Pages',
+			items: [
+				{ id: 'overview', label: 'Overview' },
+				{ id: 'instances', label: 'Instances' },
+			],
+		},
+		{
+			id: 'actions',
+			label: 'Actions',
+			items: [{ id: 'refresh', label: 'Refresh', shortcut: '⌘R' }],
+		},
+	];
+</script>
+
+<CommandPalette
+	bind:open
+	label="Command palette"
+	{groups}
+	onselect={(item) => {
+		open = false;
+		navigate(item.id);
+	}}
+/>
+```
 
 ### Usage example
 

--- a/packages/cli/src/registry/index.ts
+++ b/packages/cli/src/registry/index.ts
@@ -207,12 +207,12 @@ export const componentRegistry: Record<string, ComponentMetadata> = {
 		name: 'shell',
 		type: 'shared',
 		description:
-			'App shell layout components (Shell, Sidebar, Topbar, Panel, StatCard, SummaryStrip, PageFrame, PageTitle, Breadcrumb, Callout) for app-shaped Fediverse / Lesser-aware consumers',
+			'App shell layout components (Shell, Sidebar, Topbar, Panel, StatCard, SummaryStrip, PageFrame, PageTitle, Breadcrumb, Callout, CommandPalette) for app-shaped Fediverse / Lesser-aware consumers',
 		files: [{ path: 'greater/shell/index.ts', content: '', type: 'component' }],
 		dependencies: [],
 		devDependencies: [],
-		registryDependencies: ['tokens'],
-		tags: ['core', 'shell', 'layout', 'navigation'],
+		registryDependencies: ['tokens', 'utils', 'headless'],
+		tags: ['core', 'shell', 'layout', 'navigation', 'command-palette'],
 		version: '1.0.0',
 	},
 

--- a/packages/greater-components/package.json
+++ b/packages/greater-components/package.json
@@ -89,6 +89,10 @@
       "types": "./dist/shell/types.d.ts",
       "import": "./dist/shell/types.js"
     },
+    "./shell/fuzzy-filter": {
+      "types": "./dist/shell/utils/fuzzy-filter.d.ts",
+      "import": "./dist/shell/utils/fuzzy-filter.js"
+    },
     "./shell/shell.css": "./dist/shell/shell.css",
     "./shell/style.css": "./dist/shell/shell.css",
     "./utils": {

--- a/packages/shell/package.json
+++ b/packages/shell/package.json
@@ -70,6 +70,15 @@
       "svelte": "./dist/components/Callout.svelte",
       "import": "./dist/components/Callout.svelte"
     },
+    "./CommandPalette": {
+      "types": "./dist/components/CommandPalette.svelte.d.ts",
+      "svelte": "./dist/components/CommandPalette.svelte",
+      "import": "./dist/components/CommandPalette.svelte"
+    },
+    "./fuzzy-filter": {
+      "types": "./dist/utils/fuzzy-filter.d.ts",
+      "import": "./dist/utils/fuzzy-filter.js"
+    },
     "./components/*.svelte": {
       "types": "./dist/components/*.svelte.d.ts",
       "svelte": "./dist/components/*.svelte",
@@ -104,9 +113,11 @@
     "svelte": "^5.43.6"
   },
   "dependencies": {
+    "@equaltoai/greater-components-headless": "workspace:*",
     "@equaltoai/greater-components-utils": "workspace:*"
   },
   "devDependencies": {
+    "@equaltoai/greater-components-headless": "workspace:*",
     "@equaltoai/greater-components-tokens": "workspace:*",
     "@equaltoai/greater-components-utils": "workspace:*",
     "@sveltejs/package": "^2.5.7",

--- a/packages/shell/src/components/CommandPalette.css
+++ b/packages/shell/src/components/CommandPalette.css
@@ -115,6 +115,12 @@
 	padding: 0.5rem var(--gr-shell-gutter);
 	cursor: pointer;
 	min-width: 0;
+	/*
+	 * `role="option"` elements render as <div> so the listbox can wrap them in
+	 * <div role="group"> sections. Reset any default block-flow weirdness so
+	 * groups look identical to the flat list layout.
+	 */
+	box-sizing: border-box;
 }
 
 .gr-shell-command-palette__option--active {

--- a/packages/shell/src/components/CommandPalette.css
+++ b/packages/shell/src/components/CommandPalette.css
@@ -1,0 +1,188 @@
+.gr-shell-command-palette {
+	position: fixed;
+	inset: 0;
+	display: flex;
+	align-items: flex-start;
+	justify-content: center;
+	padding-top: 10vh;
+	background: var(--gr-semantic-background-overlay, rgba(0, 0, 0, 0.5));
+	z-index: 1000;
+	overflow-y: auto;
+}
+
+.gr-shell-command-palette__sr-only {
+	position: absolute;
+	width: 1px;
+	height: 1px;
+	padding: 0;
+	margin: -1px;
+	overflow: hidden;
+	clip: rect(0, 0, 0, 0);
+	white-space: nowrap;
+	border: 0;
+}
+
+.gr-shell-command-palette__panel {
+	width: min(40rem, calc(100% - 2 * var(--gr-shell-gutter)));
+	max-height: 70vh;
+	background: var(--gr-semantic-background-surface, var(--gr-color-base-white, #fff));
+	color: var(--gr-semantic-foreground-primary, var(--gr-color-gray-900, #111827));
+	border: 1px solid var(--gr-semantic-border-subtle, var(--gr-color-gray-200, #e5e7eb));
+	border-radius: 0.75rem;
+	box-shadow: var(--gr-shadows-lg, 0 10px 25px -5px rgb(0 0 0 / 0.2));
+	display: flex;
+	flex-direction: column;
+	min-height: 0;
+	overflow: hidden;
+}
+
+.gr-shell-command-palette__input-row {
+	display: flex;
+	align-items: center;
+	padding: 0 var(--gr-shell-gutter);
+	border-bottom: 1px solid var(--gr-semantic-border-subtle, var(--gr-color-gray-200, #e5e7eb));
+}
+
+.gr-shell-command-palette__input-label {
+	display: block;
+	padding: 0.5rem 0;
+	font-size: 0.75rem;
+	font-weight: 600;
+	color: var(--gr-semantic-foreground-secondary, var(--gr-color-gray-700, #374151));
+}
+
+.gr-shell-command-palette__input {
+	flex: 1 1 auto;
+	width: 100%;
+	min-width: 0;
+	padding: 1rem 0;
+	border: none;
+	background: transparent;
+	color: inherit;
+	font: inherit;
+	font-size: 1rem;
+	outline: none;
+}
+.gr-shell-command-palette__input:focus-visible {
+	outline: none;
+}
+.gr-shell-command-palette__input::placeholder {
+	color: var(--gr-semantic-foreground-tertiary, var(--gr-color-gray-500, #6b7280));
+}
+
+.gr-shell-command-palette__results {
+	flex: 1 1 auto;
+	min-height: 0;
+	overflow-y: auto;
+	padding: 0.5rem 0;
+}
+
+.gr-shell-command-palette__loading,
+.gr-shell-command-palette__empty {
+	padding: 1rem var(--gr-shell-gutter);
+	color: var(--gr-semantic-foreground-secondary, var(--gr-color-gray-700, #374151));
+	font-size: 0.9375rem;
+}
+
+.gr-shell-command-palette__group {
+	display: block;
+}
+.gr-shell-command-palette__group + .gr-shell-command-palette__group {
+	border-top: 1px solid var(--gr-semantic-border-subtle, var(--gr-color-gray-200, #e5e7eb));
+	margin-top: 0.25rem;
+	padding-top: 0.25rem;
+}
+
+.gr-shell-command-palette__group-header {
+	padding: 0.5rem var(--gr-shell-gutter) 0.25rem;
+	font-size: 0.75rem;
+	font-weight: 600;
+	text-transform: uppercase;
+	letter-spacing: 0.04em;
+	color: var(--gr-semantic-foreground-tertiary, var(--gr-color-gray-500, #6b7280));
+}
+
+.gr-shell-command-palette__listbox {
+	margin: 0;
+	padding: 0;
+	list-style: none;
+}
+
+.gr-shell-command-palette__option {
+	display: flex;
+	align-items: center;
+	gap: 0.75rem;
+	padding: 0.5rem var(--gr-shell-gutter);
+	cursor: pointer;
+	min-width: 0;
+}
+
+.gr-shell-command-palette__option--active {
+	background: var(--gr-semantic-background-secondary, var(--gr-color-gray-100, #f3f4f6));
+	color: var(--gr-semantic-foreground-primary, var(--gr-color-gray-900, #111827));
+}
+
+.gr-shell-command-palette__option--disabled {
+	cursor: not-allowed;
+	opacity: 0.55;
+}
+
+.gr-shell-command-palette__option-body {
+	display: flex;
+	flex-direction: column;
+	gap: 0.125rem;
+	flex: 1 1 auto;
+	min-width: 0;
+}
+
+.gr-shell-command-palette__option-label {
+	font-size: 0.9375rem;
+	font-weight: 500;
+}
+
+.gr-shell-command-palette__option-description {
+	font-size: 0.8125rem;
+	color: var(--gr-semantic-foreground-tertiary, var(--gr-color-gray-500, #6b7280));
+}
+
+.gr-shell-command-palette__option-shortcut {
+	flex: 0 0 auto;
+	font-size: 0.75rem;
+	font-family: var(
+		--gr-typography-fontFamily-mono,
+		ui-monospace,
+		SFMono-Regular,
+		Menlo,
+		Monaco,
+		Consolas,
+		monospace
+	);
+	padding: 0.125rem 0.375rem;
+	border-radius: 0.25rem;
+	border: 1px solid var(--gr-semantic-border-subtle, var(--gr-color-gray-200, #e5e7eb));
+	background: var(--gr-semantic-background-secondary, var(--gr-color-gray-100, #f3f4f6));
+	color: var(--gr-semantic-foreground-secondary, var(--gr-color-gray-700, #374151));
+}
+
+.gr-shell-command-palette__status {
+	padding: 0.5rem var(--gr-shell-gutter);
+	font-size: 0.75rem;
+	color: var(--gr-semantic-foreground-tertiary, var(--gr-color-gray-500, #6b7280));
+	border-top: 1px solid var(--gr-semantic-border-subtle, var(--gr-color-gray-200, #e5e7eb));
+}
+
+@media (prefers-reduced-motion: no-preference) {
+	.gr-shell-command-palette__panel {
+		animation: gr-shell-command-palette-pop 100ms ease-out;
+	}
+}
+@keyframes gr-shell-command-palette-pop {
+	from {
+		transform: translateY(-0.5rem);
+		opacity: 0;
+	}
+	to {
+		transform: translateY(0);
+		opacity: 1;
+	}
+}

--- a/packages/shell/src/components/CommandPalette.svelte
+++ b/packages/shell/src/components/CommandPalette.svelte
@@ -579,18 +579,25 @@ tokens via the bundled `shell.css`.
 						{#if emptyState}{@render emptyState()}{:else}{emptyMessage}{/if}
 					</div>
 				{:else if filteredGroups}
-					{#each filteredGroups as group (group.id)}
-						{@const headerId = groupHeaderDomId(stableId.value, group.id)}
-						<div class="gr-shell-command-palette__group" role="group" aria-labelledby={headerId}>
-							<div class="gr-shell-command-palette__group-header" id={headerId}>
-								{group.label}
-							</div>
-							<ul
-								id={`${listboxOwningId}-${group.id}`}
-								class="gr-shell-command-palette__listbox"
-								role="listbox"
-								aria-labelledby={headerId}
-							>
+					<!--
+						Grouped mode: one parent listbox owns every option. Each group is
+						a role="group" child whose `aria-labelledby` references the
+						visible group header. ARIA listboxes accept role="group"
+						children that wrap their options — this matches the W3C
+						APG "Combobox with Listbox Popup, Grouped Options" pattern
+						and resolves the input's aria-controls IDREF.
+					-->
+					<div
+						id={listboxOwningId}
+						class="gr-shell-command-palette__listbox gr-shell-command-palette__listbox--grouped"
+						role="listbox"
+					>
+						{#each filteredGroups as group (group.id)}
+							{@const headerId = groupHeaderDomId(stableId.value, group.id)}
+							<div class="gr-shell-command-palette__group" role="group" aria-labelledby={headerId}>
+								<div class="gr-shell-command-palette__group-header" id={headerId}>
+									{group.label}
+								</div>
 								{#each group.items as item (item.id)}
 									{@const entryIndex = itemEntries.findIndex(
 										(e) => e.groupId === group.id && e.item.id === item.id
@@ -604,8 +611,18 @@ tokens via the bundled `shell.css`.
 										still need a click handler, but Svelte's a11y_click_events_have_key_events
 										linter incorrectly flags it. Documented exception per ARIA APG.
 									-->
+									<!--
+	W3C ARIA Combobox + Listbox pattern (virtual focus):
+	- The combobox input is the single tab stop; options are NOT in the
+	  tab order. They receive virtual focus via `aria-activedescendant`.
+	- Mouse activation still needs a click handler, but svelte's
+	  a11y_click_events_have_key_events linter expects a key handler
+	  alongside it — keyboard interaction is owned by the input. We
+	  suppress both warnings here per ARIA APG guidance.
+-->
 									<!-- svelte-ignore a11y_click_events_have_key_events -->
-									<li
+									<!-- svelte-ignore a11y_interactive_supports_focus -->
+									<div
 										id={optId}
 										class={[
 											'gr-shell-command-palette__option',
@@ -643,19 +660,33 @@ tokens via the bundled `shell.css`.
 												</kbd>
 											{/if}
 										{/if}
-									</li>
+									</div>
 								{/each}
-							</ul>
-						</div>
-					{/each}
+							</div>
+						{/each}
+					</div>
 				{:else if filteredItems}
-					<ul id={listboxOwningId} class="gr-shell-command-palette__listbox" role="listbox">
+					<div
+						id={listboxOwningId}
+						class="gr-shell-command-palette__listbox gr-shell-command-palette__listbox--flat"
+						role="listbox"
+					>
 						{#each filteredItems as item (item.id)}
 							{@const entryIndex = itemEntries.findIndex((e) => e.item.id === item.id)}
 							{@const isActive = entryIndex === activeIndex}
 							{@const optId = optionDomId(stableId.value, undefined, item.id)}
+							<!--
+	W3C ARIA Combobox + Listbox pattern (virtual focus):
+	- The combobox input is the single tab stop; options are NOT in the
+	  tab order. They receive virtual focus via `aria-activedescendant`.
+	- Mouse activation still needs a click handler, but svelte's
+	  a11y_click_events_have_key_events linter expects a key handler
+	  alongside it — keyboard interaction is owned by the input. We
+	  suppress both warnings here per ARIA APG guidance.
+-->
 							<!-- svelte-ignore a11y_click_events_have_key_events -->
-							<li
+							<!-- svelte-ignore a11y_interactive_supports_focus -->
+							<div
 								id={optId}
 								class={[
 									'gr-shell-command-palette__option',
@@ -687,9 +718,9 @@ tokens via the bundled `shell.css`.
 										</kbd>
 									{/if}
 								{/if}
-							</li>
+							</div>
 						{/each}
-					</ul>
+					</div>
 				{/if}
 			</div>
 

--- a/packages/shell/src/components/CommandPalette.svelte
+++ b/packages/shell/src/components/CommandPalette.svelte
@@ -1,0 +1,712 @@
+<!--
+@component
+CommandPalette — accessible, strict-CSP-safe command palette for app
+navigation, quick actions, and settings search.
+
+Implements the WAI-ARIA combobox + listbox pattern with virtual focus
+(`aria-activedescendant`). The input keeps real focus; arrow keys move
+a virtual selection through the rendered options. Screen-reader users
+hear result counts and active-option labels via a polite live region.
+
+Composition:
+- `<div role="dialog" aria-modal="true" aria-label>` overlay
+- `<input role="combobox" aria-autocomplete="list" aria-expanded
+   aria-controls aria-activedescendant>` query input
+- `<ul role="listbox">` per group (when groups are provided) or one
+  flat `<ul role="listbox">` (when items are provided)
+- Each `<li role="option" aria-selected={isActive} aria-disabled>` item
+
+Headless behaviors reused from `@equaltoai/greater-components-headless`:
+- `createFocusTrap` — traps focus inside the panel; returns focus to the
+  opener on close (or to `returnFocusTo` when supplied)
+- `createDismissable` — ESC + outside-click close, integrated into the
+  shared layer stack so nested overlays close in the correct order
+- `createLiveRegion` — polite announcements for result counts and
+  loading / empty state changes
+
+Strict-CSP safe: no inline event handlers, no `style` attributes set at
+runtime, no module-level browser globals. All keyboard handling goes
+through real Svelte event handlers; all styling consumes `--gr-*`
+tokens via the bundled `shell.css`.
+
+@example
+```svelte
+<CommandPalette
+	open={paletteOpen}
+	label="Command palette"
+	inputLabel="Search commands"
+	groups={[
+		{ id: 'pages', label: 'Pages', items: [
+			{ id: 'overview', label: 'Overview', description: 'Fleet overview' },
+			{ id: 'instances', label: 'Instances' },
+		] },
+		{ id: 'actions', label: 'Actions', items: [
+			{ id: 'refresh', label: 'Refresh', shortcut: '⌘R' },
+		] },
+	]}
+	onclose={() => (paletteOpen = false)}
+	onselect={(item) => {
+		paletteOpen = false;
+		navigate(item.id);
+	}}
+/>
+```
+-->
+<script lang="ts">
+	import type { HTMLAttributes } from 'svelte/elements';
+	import type { Snippet } from 'svelte';
+	import { onDestroy, tick, untrack } from 'svelte';
+	import { useStableId } from '@equaltoai/greater-components-utils';
+	import {
+		createFocusTrap,
+		createDismissable,
+		createLiveRegion,
+		type FocusTrap,
+		type Dismissable,
+		type LiveRegion,
+	} from '@equaltoai/greater-components-headless';
+	import type { CommandPaletteFilter, CommandPaletteGroup, CommandPaletteItem } from '../types.js';
+	import { filterAndRankItems, tokenizeQuery } from '../utils/fuzzy-filter.js';
+
+	interface Props extends Omit<HTMLAttributes<HTMLDivElement>, 'aria-label'> {
+		/**
+		 * Whether the palette is open. Bind with `bind:open` or control via
+		 * `onopen` / `onclose`.
+		 * @public
+		 */
+		open?: boolean;
+
+		/**
+		 * Accessible name for the dialog. Strongly recommended; defaults to
+		 * `'Command palette'`.
+		 * @public
+		 */
+		label?: string;
+
+		/**
+		 * Accessible name for the search input. Defaults to `'Search commands'`.
+		 * The label is rendered visually-hidden by default; consumers can opt
+		 * into a visible label by setting `inputLabelHidden={false}` (the
+		 * default is `true` for the typical palette UX).
+		 * @public
+		 */
+		inputLabel?: string;
+
+		/**
+		 * When false, the input label is rendered visibly above the input.
+		 * Default is `true` (label is sr-only).
+		 * @public
+		 */
+		inputLabelHidden?: boolean;
+
+		/** Placeholder text shown when the input is empty. @public */
+		placeholder?: string;
+
+		/**
+		 * Externally-controlled query string. Bind with `bind:query` or
+		 * read via `onquerychange`.
+		 * @public
+		 */
+		query?: string;
+
+		/**
+		 * Grouped items. When supplied, the palette renders one `<ul role="listbox">`
+		 * per group with the group label exposed via `aria-labelledby`. Exactly
+		 * one of `groups` or `items` must be supplied.
+		 * @public
+		 */
+		groups?: CommandPaletteGroup[];
+
+		/**
+		 * Flat item list. When supplied, the palette renders a single
+		 * `<ul role="listbox">`. Exactly one of `groups` or `items` must be
+		 * supplied.
+		 * @public
+		 */
+		items?: CommandPaletteItem[];
+
+		/**
+		 * Optional custom filter / ranker. When omitted, the built-in
+		 * `scoreCommandPaletteItem` is used. Return `null` to exclude an item;
+		 * otherwise return a numeric score (higher = better).
+		 * @public
+		 */
+		filter?: CommandPaletteFilter;
+
+		/**
+		 * When true, the palette shows a loading state instead of results.
+		 * The live region announces the change.
+		 * @public
+		 */
+		loading?: boolean;
+
+		/** Status message rendered while `loading` is true. @public */
+		loadingMessage?: string;
+
+		/** Status message rendered when no items match the query. @public */
+		emptyMessage?: string;
+
+		/**
+		 * Element to return focus to on close. Defaults to the previously
+		 * focused element (typically the trigger button).
+		 * @public
+		 */
+		returnFocusTo?: HTMLElement | null;
+
+		/** Additional CSS classes. @public */
+		class?: string;
+
+		/**
+		 * Custom item renderer. Receives the `item` and a boolean `active`
+		 * (true when this item is the current virtual-focus target). When
+		 * omitted, the default renderer shows label / description / shortcut.
+		 * @public
+		 */
+		itemTemplate?: Snippet<[CommandPaletteItem, boolean]>;
+
+		/** Empty-state slot override (when query yields no matches). @public */
+		emptyState?: Snippet;
+
+		/** Loading-state slot override. @public */
+		loadingState?: Snippet;
+
+		/** Called when the palette transitions from closed to open. @public */
+		onopen?: () => void;
+
+		/** Called when the palette closes (ESC, outside click, programmatic). @public */
+		onclose?: () => void;
+
+		/** Called whenever the query input changes. @public */
+		onquerychange?: (value: string) => void;
+
+		/** Called when a (non-disabled) item is activated. @public */
+		onselect?: (item: CommandPaletteItem) => void;
+	}
+
+	let {
+		open = $bindable(false),
+		label = 'Command palette',
+		inputLabel = 'Search commands',
+		inputLabelHidden = true,
+		placeholder = 'Type to search…',
+		query = $bindable(''),
+		groups,
+		items,
+		filter,
+		loading = false,
+		loadingMessage = 'Loading…',
+		emptyMessage = 'No results.',
+		returnFocusTo,
+		class: className = '',
+		itemTemplate,
+		emptyState,
+		loadingState,
+		onopen,
+		onclose,
+		onquerychange,
+		onselect,
+		style: _style,
+		...restProps
+	}: Props = $props();
+
+	// Stable per-instance ids. SSR/hydration-safe via useStableId.
+	const stableId = useStableId('shell-cmdk');
+	const labelId = $derived(stableId.value ? `${stableId.value}-label` : undefined);
+	const inputId = $derived(stableId.value ? `${stableId.value}-input` : undefined);
+	const inputLabelId = $derived(stableId.value ? `${stableId.value}-input-label` : undefined);
+	const listboxOwningId = $derived(stableId.value ? `${stableId.value}-listbox` : undefined);
+	const statusId = $derived(stableId.value ? `${stableId.value}-status` : undefined);
+
+	// Element refs.
+	let panelEl = $state<HTMLDivElement | null>(null);
+	let inputEl = $state<HTMLInputElement | null>(null);
+
+	// Headless behaviors.
+	let focusTrap: FocusTrap | null = null;
+	let dismissable: Dismissable | null = null;
+	let liveRegion: LiveRegion | null = null;
+
+	// Derived: filter groups / items by query.
+	function applyFilter(list: CommandPaletteItem[], q: string): CommandPaletteItem[] {
+		const tokens = tokenizeQuery(q);
+		if (tokens.length === 0) return list.slice();
+		if (filter) {
+			const scored: Array<{ item: CommandPaletteItem; score: number; index: number }> = [];
+			for (let i = 0; i < list.length; i++) {
+				const it = list[i]!;
+				const s = filter(it, q);
+				if (typeof s === 'number') scored.push({ item: it, score: s, index: i });
+			}
+			scored.sort((a, b) => (b.score !== a.score ? b.score - a.score : a.index - b.index));
+			return scored.map((e) => e.item);
+		}
+		return filterAndRankItems(list, q);
+	}
+
+	type FlatEntry =
+		| { kind: 'item'; item: CommandPaletteItem; groupId?: string; optionId: string }
+		| { kind: 'group-header'; groupId: string };
+
+	const filteredGroups = $derived.by<CommandPaletteGroup[] | null>(() => {
+		if (!groups) return null;
+		return groups
+			.map((g) => ({ ...g, items: applyFilter(g.items, query) }))
+			.filter((g) => g.items.length > 0);
+	});
+
+	const filteredItems = $derived.by<CommandPaletteItem[] | null>(() => {
+		if (!items) return null;
+		return applyFilter(items, query);
+	});
+
+	function optionDomId(baseId: string | undefined, groupId: string | undefined, itemId: string) {
+		const safeBase = baseId ?? 'gr-shell-cmdk';
+		return groupId ? `${safeBase}-opt-${groupId}-${itemId}` : `${safeBase}-opt-${itemId}`;
+	}
+
+	function groupHeaderDomId(baseId: string | undefined, groupId: string) {
+		const safeBase = baseId ?? 'gr-shell-cmdk';
+		return `${safeBase}-group-${groupId}`;
+	}
+
+	const flatEntries = $derived.by<FlatEntry[]>(() => {
+		const out: FlatEntry[] = [];
+		const base = stableId.value;
+		if (filteredGroups) {
+			for (const g of filteredGroups) {
+				out.push({ kind: 'group-header', groupId: g.id });
+				for (const it of g.items) {
+					out.push({
+						kind: 'item',
+						item: it,
+						groupId: g.id,
+						optionId: optionDomId(base, g.id, it.id),
+					});
+				}
+			}
+		} else if (filteredItems) {
+			for (const it of filteredItems) {
+				out.push({ kind: 'item', item: it, optionId: optionDomId(base, undefined, it.id) });
+			}
+		}
+		return out;
+	});
+
+	const itemEntries = $derived(
+		flatEntries.filter((e): e is FlatEntry & { kind: 'item' } => e.kind === 'item')
+	);
+	const totalItems = $derived(itemEntries.length);
+
+	// Virtual focus pointer. Clamped to [0, totalItems-1] reactively.
+	let activeIndex = $state(0);
+
+	// When totalItems or query changes, snap activeIndex to the first selectable item.
+	$effect(() => {
+		// Reset whenever the result set shrinks or the query changes meaningfully.
+		void totalItems;
+		void query;
+		untrack(() => {
+			if (totalItems === 0) {
+				activeIndex = 0;
+				return;
+			}
+			// Move to first non-disabled item.
+			const first = findNextEnabledIndex(-1, 1);
+			activeIndex = first === -1 ? 0 : first;
+		});
+	});
+
+	const activeOptionId = $derived.by<string | undefined>(() => {
+		if (totalItems === 0) return undefined;
+		const safe = Math.min(Math.max(0, activeIndex), totalItems - 1);
+		return itemEntries[safe]?.optionId;
+	});
+
+	function findNextEnabledIndex(fromIndex: number, step: 1 | -1): number {
+		if (itemEntries.length === 0) return -1;
+		const n = itemEntries.length;
+		let i = fromIndex;
+		for (let visited = 0; visited < n; visited++) {
+			i = (i + step + n) % n;
+			const entry = itemEntries[i];
+			if (entry && !entry.item.disabled) return i;
+		}
+		// All items disabled — return the first.
+		return 0;
+	}
+
+	function moveActive(step: 1 | -1) {
+		const next = findNextEnabledIndex(activeIndex, step);
+		if (next >= 0) activeIndex = next;
+	}
+
+	function moveToEdge(edge: 'start' | 'end') {
+		if (totalItems === 0) return;
+		if (edge === 'start') {
+			const first = findNextEnabledIndex(-1, 1);
+			if (first >= 0) activeIndex = first;
+		} else {
+			const last = findNextEnabledIndex(itemEntries.length, -1);
+			if (last >= 0) activeIndex = last;
+		}
+	}
+
+	function activateActive() {
+		if (totalItems === 0) return;
+		const safe = Math.min(Math.max(0, activeIndex), totalItems - 1);
+		const entry = itemEntries[safe];
+		if (entry && !entry.item.disabled) {
+			onselect?.(entry.item);
+		}
+	}
+
+	function close() {
+		if (!open) return;
+		open = false;
+		onclose?.();
+	}
+
+	function handleQueryInput(event: Event) {
+		const value = (event.currentTarget as HTMLInputElement).value;
+		query = value;
+		onquerychange?.(value);
+	}
+
+	function handleInputKeydown(event: KeyboardEvent) {
+		switch (event.key) {
+			case 'ArrowDown':
+				event.preventDefault();
+				moveActive(1);
+				return;
+			case 'ArrowUp':
+				event.preventDefault();
+				moveActive(-1);
+				return;
+			case 'Home':
+				event.preventDefault();
+				moveToEdge('start');
+				return;
+			case 'End':
+				event.preventDefault();
+				moveToEdge('end');
+				return;
+			case 'Enter':
+				event.preventDefault();
+				activateActive();
+				return;
+			case 'Escape':
+				event.preventDefault();
+				close();
+				return;
+			default:
+				return;
+		}
+	}
+
+	function handleOptionPointerEnter(index: number) {
+		if (index < 0 || index >= itemEntries.length) return;
+		activeIndex = index;
+	}
+
+	function handleOptionClick(entry: FlatEntry & { kind: 'item' }) {
+		if (entry.item.disabled) return;
+		onselect?.(entry.item);
+	}
+
+	function handleBackdropPointerDown(event: PointerEvent) {
+		// Click on backdrop (outside the panel) closes the palette.
+		const target = event.target as HTMLElement;
+		if (panelEl && !panelEl.contains(target)) {
+			close();
+		}
+	}
+
+	// Open/close lifecycle: activate/deactivate behaviors.
+	$effect(() => {
+		const isOpen = open;
+
+		if (!isOpen) {
+			// Cleanup on close.
+			if (focusTrap) {
+				focusTrap.deactivate();
+				focusTrap = null;
+			}
+			if (dismissable) {
+				dismissable.deactivate();
+				dismissable = null;
+			}
+			return;
+		}
+
+		// Defer until DOM nodes exist.
+		void tick().then(() => {
+			if (!panelEl) return;
+			onopen?.();
+
+			focusTrap = createFocusTrap({
+				initialFocus: () => inputEl,
+				returnFocusTo: returnFocusTo ?? undefined,
+				returnFocus: true,
+				autoFocus: true,
+			});
+			focusTrap.activate(panelEl);
+
+			dismissable = createDismissable({
+				closeOnEscape: true,
+				closeOnClickOutside: false, // handled by backdrop pointerdown for precise targeting
+				onDismiss: () => {
+					close();
+				},
+			});
+			dismissable.activate(panelEl);
+		});
+	});
+
+	// Announce result-count / loading / empty changes via a polite live region.
+	$effect(() => {
+		// Listen to relevant state.
+		const isLoading = loading;
+		const count = totalItems;
+		const tokens = tokenizeQuery(query);
+		void open;
+
+		untrack(() => {
+			if (!liveRegion) {
+				liveRegion = createLiveRegion({ politeness: 'polite' });
+			}
+			if (!open) return;
+			if (isLoading) {
+				liveRegion.announce(loadingMessage, { politeness: 'polite' });
+				return;
+			}
+			if (tokens.length === 0) {
+				// Quietly announce initial state once on open (without flooding).
+				liveRegion.announce(`${count} result${count === 1 ? '' : 's'} available.`, {
+					politeness: 'polite',
+				});
+				return;
+			}
+			if (count === 0) {
+				liveRegion.announce(emptyMessage, { politeness: 'polite' });
+			} else {
+				liveRegion.announce(`${count} result${count === 1 ? '' : 's'} for ${query.trim()}.`, {
+					politeness: 'polite',
+				});
+			}
+		});
+	});
+
+	onDestroy(() => {
+		focusTrap?.deactivate();
+		dismissable?.deactivate();
+		liveRegion?.destroy();
+		focusTrap = null;
+		dismissable = null;
+		liveRegion = null;
+	});
+
+	// Visible status text (separate from the live region so it can be styled).
+	const statusText = $derived.by<string>(() => {
+		if (loading) return loadingMessage;
+		if (totalItems === 0) return emptyMessage;
+		const q = query.trim();
+		if (q.length === 0) return `${totalItems} result${totalItems === 1 ? '' : 's'}`;
+		return `${totalItems} result${totalItems === 1 ? '' : 's'} for "${q}"`;
+	});
+
+	const rootClass = $derived(() =>
+		['gr-shell-command-palette', className].filter(Boolean).join(' ')
+	);
+</script>
+
+{#if open}
+	<!--
+		Backdrop is a sibling, not a parent, so clicking it doesn't dispatch
+		through the panel's event handlers. Backdrop pointerdown closes.
+	-->
+	<div
+		class={rootClass()}
+		role="dialog"
+		aria-modal="true"
+		aria-labelledby={labelId}
+		onpointerdown={handleBackdropPointerDown}
+		{...restProps}
+	>
+		<span id={labelId} class="gr-shell-command-palette__sr-only">{label}</span>
+
+		<div class="gr-shell-command-palette__panel" bind:this={panelEl} role="presentation">
+			<div class="gr-shell-command-palette__input-row">
+				{#if !inputLabelHidden}
+					<label id={inputLabelId} for={inputId} class="gr-shell-command-palette__input-label">
+						{inputLabel}
+					</label>
+				{:else}
+					<label
+						id={inputLabelId}
+						for={inputId}
+						class="gr-shell-command-palette__input-label gr-shell-command-palette__sr-only"
+					>
+						{inputLabel}
+					</label>
+				{/if}
+				<input
+					id={inputId}
+					bind:this={inputEl}
+					type="text"
+					autocomplete="off"
+					spellcheck={false}
+					{placeholder}
+					value={query}
+					role="combobox"
+					aria-autocomplete="list"
+					aria-expanded="true"
+					aria-controls={listboxOwningId}
+					aria-activedescendant={activeOptionId}
+					aria-labelledby={inputLabelId}
+					oninput={handleQueryInput}
+					onkeydown={handleInputKeydown}
+					class="gr-shell-command-palette__input"
+				/>
+			</div>
+
+			<div class="gr-shell-command-palette__results" aria-busy={loading ? 'true' : undefined}>
+				{#if loading}
+					<div class="gr-shell-command-palette__loading">
+						{#if loadingState}{@render loadingState()}{:else}{loadingMessage}{/if}
+					</div>
+				{:else if totalItems === 0}
+					<div class="gr-shell-command-palette__empty">
+						{#if emptyState}{@render emptyState()}{:else}{emptyMessage}{/if}
+					</div>
+				{:else if filteredGroups}
+					{#each filteredGroups as group (group.id)}
+						{@const headerId = groupHeaderDomId(stableId.value, group.id)}
+						<div class="gr-shell-command-palette__group" role="group" aria-labelledby={headerId}>
+							<div class="gr-shell-command-palette__group-header" id={headerId}>
+								{group.label}
+							</div>
+							<ul
+								id={`${listboxOwningId}-${group.id}`}
+								class="gr-shell-command-palette__listbox"
+								role="listbox"
+								aria-labelledby={headerId}
+							>
+								{#each group.items as item (item.id)}
+									{@const entryIndex = itemEntries.findIndex(
+										(e) => e.groupId === group.id && e.item.id === item.id
+									)}
+									{@const isActive = entryIndex === activeIndex}
+									{@const optId = optionDomId(stableId.value, group.id, item.id)}
+									<!--
+										W3C ARIA Combobox / Listbox pattern: option elements receive
+										virtual focus via aria-activedescendant; real focus stays on the
+										combobox input, which owns the keyboard handlers. Mouse clicks
+										still need a click handler, but Svelte's a11y_click_events_have_key_events
+										linter incorrectly flags it. Documented exception per ARIA APG.
+									-->
+									<!-- svelte-ignore a11y_click_events_have_key_events -->
+									<li
+										id={optId}
+										class={[
+											'gr-shell-command-palette__option',
+											isActive && 'gr-shell-command-palette__option--active',
+											item.disabled && 'gr-shell-command-palette__option--disabled',
+										]
+											.filter(Boolean)
+											.join(' ')}
+										role="option"
+										aria-selected={isActive}
+										aria-disabled={item.disabled ? 'true' : undefined}
+										onclick={() =>
+											handleOptionClick({
+												kind: 'item',
+												item,
+												groupId: group.id,
+												optionId: optId,
+											})}
+										onpointerenter={() => handleOptionPointerEnter(entryIndex)}
+									>
+										{#if itemTemplate}
+											{@render itemTemplate(item, isActive)}
+										{:else}
+											<span class="gr-shell-command-palette__option-body">
+												<span class="gr-shell-command-palette__option-label">{item.label}</span>
+												{#if item.description}
+													<span class="gr-shell-command-palette__option-description">
+														{item.description}
+													</span>
+												{/if}
+											</span>
+											{#if item.shortcut}
+												<kbd class="gr-shell-command-palette__option-shortcut" aria-hidden="true">
+													{item.shortcut}
+												</kbd>
+											{/if}
+										{/if}
+									</li>
+								{/each}
+							</ul>
+						</div>
+					{/each}
+				{:else if filteredItems}
+					<ul id={listboxOwningId} class="gr-shell-command-palette__listbox" role="listbox">
+						{#each filteredItems as item (item.id)}
+							{@const entryIndex = itemEntries.findIndex((e) => e.item.id === item.id)}
+							{@const isActive = entryIndex === activeIndex}
+							{@const optId = optionDomId(stableId.value, undefined, item.id)}
+							<!-- svelte-ignore a11y_click_events_have_key_events -->
+							<li
+								id={optId}
+								class={[
+									'gr-shell-command-palette__option',
+									isActive && 'gr-shell-command-palette__option--active',
+									item.disabled && 'gr-shell-command-palette__option--disabled',
+								]
+									.filter(Boolean)
+									.join(' ')}
+								role="option"
+								aria-selected={isActive}
+								aria-disabled={item.disabled ? 'true' : undefined}
+								onclick={() => handleOptionClick({ kind: 'item', item, optionId: optId })}
+								onpointerenter={() => handleOptionPointerEnter(entryIndex)}
+							>
+								{#if itemTemplate}
+									{@render itemTemplate(item, isActive)}
+								{:else}
+									<span class="gr-shell-command-palette__option-body">
+										<span class="gr-shell-command-palette__option-label">{item.label}</span>
+										{#if item.description}
+											<span class="gr-shell-command-palette__option-description">
+												{item.description}
+											</span>
+										{/if}
+									</span>
+									{#if item.shortcut}
+										<kbd class="gr-shell-command-palette__option-shortcut" aria-hidden="true">
+											{item.shortcut}
+										</kbd>
+									{/if}
+								{/if}
+							</li>
+						{/each}
+					</ul>
+				{/if}
+			</div>
+
+			<!--
+				Visible status text. The live region (created via createLiveRegion)
+				announces this content politely to assistive tech; this element is
+				the visible affordance.
+			-->
+			<div class="gr-shell-command-palette__status" id={statusId} aria-live="off">
+				{statusText}
+			</div>
+		</div>
+	</div>
+{/if}
+
+<style>
+	/* Component CSS lives in CommandPalette.css and is bundled into shell.css.
+	   This empty <style> exists so the file is a valid Svelte component module
+	   even when consumers haven't imported the CSS bundle. */
+</style>

--- a/packages/shell/src/index.ts
+++ b/packages/shell/src/index.ts
@@ -36,6 +36,14 @@ export { default as PageFrame } from './components/PageFrame.svelte';
 export { default as PageTitle } from './components/PageTitle.svelte';
 export { default as Breadcrumb } from './components/Breadcrumb.svelte';
 export { default as Callout } from './components/Callout.svelte';
+export { default as CommandPalette } from './components/CommandPalette.svelte';
+
+// Utilities (dependency-free, strict-CSP-safe).
+export {
+	scoreCommandPaletteItem,
+	filterAndRankItems as filterAndRankCommandPaletteItems,
+	tokenizeQuery as tokenizeCommandPaletteQuery,
+} from './utils/fuzzy-filter.js';
 
 // Shared types
 export type {
@@ -56,4 +64,7 @@ export type {
 	BreadcrumbItem,
 	CalloutTone,
 	CalloutRole,
+	CommandPaletteItem,
+	CommandPaletteGroup,
+	CommandPaletteFilter,
 } from './types.js';

--- a/packages/shell/src/styles/base.css
+++ b/packages/shell/src/styles/base.css
@@ -46,7 +46,8 @@
 	.gr-shell-summary-strip,
 	.gr-shell-page-title,
 	.gr-shell-breadcrumb,
-	.gr-shell-callout
+	.gr-shell-callout,
+	.gr-shell-command-palette
 ) {
 	--gr-shell-sidebar-width-sm: 14rem;
 	--gr-shell-sidebar-width-md: 16rem;

--- a/packages/shell/src/styles/base.css
+++ b/packages/shell/src/styles/base.css
@@ -27,6 +27,31 @@
 }
 
 /*
+ * Visually-hidden utility shipped by the shell CSS bundle.
+ *
+ * `@equaltoai/greater-components-headless`'s `createLiveRegion()` (used by
+ * CommandPalette and other shell components for polite / assertive
+ * announcements) appends elements to `document.body` with class
+ * `gr-sr-only`. Shell-only consumers who import `shell.css` without the
+ * primitives `theme.css` would otherwise see those announcement strings
+ * rendered visibly. The class is duplicated here (matching the primitives
+ * definition byte-for-byte) so that any shell consumer importing
+ * `@equaltoai/greater-components-shell/shell.css` has working live-region
+ * semantics regardless of which other Greater style bundles they ship.
+ */
+.gr-sr-only {
+	position: fixed;
+	width: 1px;
+	height: 1px;
+	padding: 0;
+	margin: -1px;
+	overflow: hidden;
+	clip: rect(0, 0, 0, 0);
+	white-space: nowrap;
+	border: 0;
+}
+
+/*
  * Default --gr-shell-* tokens (consumers may override).
  *
  * Defined on every shell component root class so a standalone `Panel`,

--- a/packages/shell/src/types.ts
+++ b/packages/shell/src/types.ts
@@ -66,3 +66,55 @@ export type CalloutTone = 'info' | 'success' | 'warning' | 'danger' | 'neutral';
 
 /** Callout ARIA role for live-region semantics. */
 export type CalloutRole = 'status' | 'alert' | 'note';
+
+/**
+ * A single command palette item (e.g. a route, an action, a setting).
+ *
+ * Consumers supply opaque ids; the CommandPalette never interprets `id`
+ * beyond using it for `aria-activedescendant` and as the argument to
+ * `onselect`. Use `keywords` to expose synonyms / aliases for filtering
+ * that should not be displayed as part of the label.
+ */
+export interface CommandPaletteItem {
+	/** Stable id; used for DOM identification and as the `onselect` argument. */
+	id: string;
+	/** Visible primary label. */
+	label: string;
+	/** Optional secondary description rendered below the label. */
+	description?: string;
+	/** Additional terms that should match against the query (synonyms, aliases). */
+	keywords?: string[];
+	/** Optional keyboard shortcut hint (rendered with `aria-hidden`; for visual cue only). */
+	shortcut?: string;
+	/** When true, the item is rendered but cannot be activated. */
+	disabled?: boolean;
+}
+
+/**
+ * A group of command palette items rendered together with a shared label.
+ *
+ * Groups are exposed via `role="group"` with `aria-labelledby` referencing
+ * the group label, so screen readers announce the section name.
+ */
+export interface CommandPaletteGroup {
+	/** Stable id used for the group label element. */
+	id: string;
+	/** Visible label for the group (e.g. "Pages", "Actions"). */
+	label: string;
+	/** Items in this group; rendered in array order after filtering. */
+	items: CommandPaletteItem[];
+}
+
+/**
+ * Signature for a custom item-vs-query matcher.
+ *
+ * Return `null` (or `undefined`) to exclude the item from results; return a
+ * numeric score (higher = better) to include and rank it. When omitted, the
+ * built-in scorer matches all whitespace-separated query tokens
+ * case-insensitively against `label`, `description`, and `keywords`, with
+ * higher scores for prefix / word-boundary matches over substring matches.
+ */
+export type CommandPaletteFilter = (
+	item: CommandPaletteItem,
+	query: string
+) => number | null | undefined;

--- a/packages/shell/src/utils/fuzzy-filter.ts
+++ b/packages/shell/src/utils/fuzzy-filter.ts
@@ -1,0 +1,150 @@
+/**
+ * @fileoverview Dependency-free, strict-CSP-safe filter + ranker for the
+ * Greater CommandPalette.
+ *
+ * Design goals (see issue #647):
+ * - No runtime dependencies (no cmdk, no fuzzysort, no Fuse, etc.). The
+ *   palette is a source-install component shipped via the shadcn-style CLI;
+ *   keeping it dependency-free avoids dragging consumer projects into
+ *   license / supply-chain decisions just to render a palette.
+ * - No `unsafe-eval`, no dynamic code generation. Pure data transforms over
+ *   plain JS strings.
+ * - Deterministic: same input → same output (used by tests as a fixed-point).
+ * - Token-based: whitespace-separated query tokens must each match somewhere
+ *   in the item's searchable text. This matches the way users actually type
+ *   (`"hot reload"` finds "Toggle hot reload" but also "Hot reload settings").
+ *
+ * Ranking heuristic (per item):
+ * - For each query token, the best per-token score across `label`,
+ *   `description`, and `keywords` is summed:
+ *   - Exact full-string match on `label`:           +100
+ *   - Prefix match on `label`:                       +60
+ *   - Word-boundary match on `label`:                +40
+ *   - Substring match on `label`:                    +20
+ *   - Same tiers for `description`, scaled by 0.5
+ *   - Same tiers for `keywords` (best of any keyword), scaled by 0.7
+ * - An item is excluded if any query token has no match anywhere.
+ * - Empty query returns all items in their natural order with score 0.
+ *
+ * The exact numeric scale is internal; consumers should not depend on it.
+ * They should use the boolean exclusion semantics + the sorted output.
+ *
+ * @public
+ */
+
+import type { CommandPaletteItem } from '../types.js';
+
+interface SearchableFields {
+	label: string;
+	description: string;
+	keywords: string[];
+}
+
+function getSearchableFields(item: CommandPaletteItem): SearchableFields {
+	return {
+		label: item.label,
+		description: item.description ?? '',
+		keywords: item.keywords ?? [],
+	};
+}
+
+/** Tokenize a query into normalized lowercase tokens. */
+export function tokenizeQuery(query: string): string[] {
+	return query
+		.trim()
+		.toLowerCase()
+		.split(/\s+/)
+		.filter((token) => token.length > 0);
+}
+
+/**
+ * Score a single token against a single string field.
+ * Returns 0 when there is no match.
+ *
+ * The token and field are expected to already be lowercase.
+ */
+function scoreTokenInField(token: string, field: string): number {
+	if (!field || !token) return 0;
+	if (field === token) return 100;
+	if (field.startsWith(token)) return 60;
+	// Word-boundary check (non-alphanumeric followed by token).
+	if (
+		field.indexOf(' ' + token) >= 0 ||
+		field.indexOf('-' + token) >= 0 ||
+		field.indexOf('_' + token) >= 0 ||
+		field.indexOf('/' + token) >= 0 ||
+		field.indexOf('.' + token) >= 0
+	) {
+		return 40;
+	}
+	if (field.indexOf(token) >= 0) return 20;
+	return 0;
+}
+
+/** Score a single token across all searchable fields of one item. */
+function scoreTokenForItem(token: string, item: CommandPaletteItem): number {
+	const fields = getSearchableFields(item);
+	const labelLower = fields.label.toLowerCase();
+	const descLower = fields.description.toLowerCase();
+
+	const labelScore = scoreTokenInField(token, labelLower);
+	const descScore = scoreTokenInField(token, descLower) * 0.5;
+
+	let keywordsScore = 0;
+	for (const kw of fields.keywords) {
+		const s = scoreTokenInField(token, kw.toLowerCase()) * 0.7;
+		if (s > keywordsScore) keywordsScore = s;
+	}
+
+	return Math.max(labelScore, descScore, keywordsScore);
+}
+
+/**
+ * Built-in scorer: returns a numeric score (higher = better) when the item
+ * matches every token in the query, or `null` when any token has no match.
+ *
+ * An empty query (no tokens) returns 0 (include everything, no preference).
+ *
+ * @public
+ */
+export function scoreCommandPaletteItem(item: CommandPaletteItem, query: string): number | null {
+	const tokens = tokenizeQuery(query);
+	if (tokens.length === 0) return 0;
+
+	let total = 0;
+	for (const token of tokens) {
+		const tokenScore = scoreTokenForItem(token, item);
+		if (tokenScore === 0) return null;
+		total += tokenScore;
+	}
+	return total;
+}
+
+/**
+ * Filter and rank a flat item list.
+ *
+ * Returns items with `score >= 0`, sorted by descending score, then by
+ * natural array order for ties. Disabled items remain in results (the
+ * palette still shows them); consumers decide how to render disabled.
+ *
+ * @public
+ */
+export function filterAndRankItems(
+	items: CommandPaletteItem[],
+	query: string
+): CommandPaletteItem[] {
+	const tokens = tokenizeQuery(query);
+	if (tokens.length === 0) return items.slice();
+
+	const scored: Array<{ item: CommandPaletteItem; score: number; index: number }> = [];
+	for (let i = 0; i < items.length; i++) {
+		const item = items[i]!;
+		const score = scoreCommandPaletteItem(item, query);
+		if (score !== null) scored.push({ item, score, index: i });
+	}
+	scored.sort((a, b) => {
+		if (b.score !== a.score) return b.score - a.score;
+		return a.index - b.index;
+	});
+	return scored.map((entry) => entry.item);
+}

--- a/packages/shell/tests/command-palette.test.ts
+++ b/packages/shell/tests/command-palette.test.ts
@@ -1,0 +1,478 @@
+/**
+ * CommandPalette a11y + interaction tests.
+ *
+ * Covers issue #648 (G1.5):
+ *  - dialog role + accessible name
+ *  - input combobox semantics (role, aria-autocomplete, aria-expanded,
+ *    aria-controls, aria-activedescendant)
+ *  - listbox / option semantics, including grouped results
+ *  - keyboard lifecycle: Escape close, Arrow nav, Home/End, Enter activate
+ *  - virtual focus moves aria-selected across options as activeIndex changes
+ *  - empty + loading states render the right copy and aria-busy
+ *  - disabled items do not activate
+ *  - mouse activation via click
+ *  - strict-CSP: no inline style attribute on root
+ */
+import { describe, it, expect, vi } from 'vitest';
+import { fireEvent, render } from '@testing-library/svelte';
+import { tick } from 'svelte';
+import CommandPalette from '../src/components/CommandPalette.svelte';
+import type { CommandPaletteGroup, CommandPaletteItem } from '../src/types.js';
+
+const flatItems: CommandPaletteItem[] = [
+	{ id: 'overview', label: 'Overview', description: 'Fleet overview' },
+	{ id: 'instances', label: 'Instances' },
+	{ id: 'billing', label: 'Billing' },
+	{ id: 'disabled', label: 'Disabled action', disabled: true },
+	{ id: 'theme-toggle', label: 'Toggle theme', shortcut: 'T' },
+];
+
+const groupedItems: CommandPaletteGroup[] = [
+	{
+		id: 'pages',
+		label: 'Pages',
+		items: [
+			{ id: 'overview', label: 'Overview' },
+			{ id: 'instances', label: 'Instances' },
+		],
+	},
+	{
+		id: 'actions',
+		label: 'Actions',
+		items: [
+			{ id: 'refresh', label: 'Refresh', shortcut: '⌘R' },
+			{ id: 'theme', label: 'Toggle theme' },
+		],
+	},
+];
+
+describe('CommandPalette — closed', () => {
+	it('renders nothing when open=false', () => {
+		const { container } = render(CommandPalette, {
+			open: false,
+			items: flatItems,
+		});
+		expect(container.querySelector('.gr-shell-command-palette')).toBeNull();
+	});
+});
+
+describe('CommandPalette — open: dialog & combobox semantics', () => {
+	it('renders a dialog with the supplied accessible name (default label)', async () => {
+		const { container } = render(CommandPalette, {
+			open: true,
+			items: flatItems,
+		});
+		await tick();
+		const dialog = container.querySelector('[role="dialog"]');
+		expect(dialog).toBeTruthy();
+		expect(dialog?.getAttribute('aria-modal')).toBe('true');
+		const labelEl = dialog?.querySelector('.gr-shell-command-palette__sr-only');
+		expect(labelEl?.textContent?.trim()).toBe('Command palette');
+		const labelledby = dialog?.getAttribute('aria-labelledby');
+		expect(labelledby).toBeTruthy();
+		expect(container.ownerDocument.getElementById(labelledby!)).toBeTruthy();
+	});
+
+	it('uses the supplied label', async () => {
+		const { container } = render(CommandPalette, {
+			open: true,
+			label: 'Quick switcher',
+			items: flatItems,
+		});
+		await tick();
+		const labelEl = container.querySelector('.gr-shell-command-palette__sr-only');
+		expect(labelEl?.textContent?.trim()).toBe('Quick switcher');
+	});
+
+	it('renders a combobox input with required aria attributes', async () => {
+		const { container } = render(CommandPalette, {
+			open: true,
+			items: flatItems,
+		});
+		await tick();
+		const input = container.querySelector('input.gr-shell-command-palette__input');
+		expect(input).toBeTruthy();
+		expect(input?.getAttribute('role')).toBe('combobox');
+		expect(input?.getAttribute('aria-autocomplete')).toBe('list');
+		expect(input?.getAttribute('aria-expanded')).toBe('true');
+		expect(input?.getAttribute('aria-controls')).toBeTruthy();
+		expect(input?.getAttribute('autocomplete')).toBe('off');
+	});
+
+	it('renders a flat listbox when items are supplied', async () => {
+		const { container } = render(CommandPalette, {
+			open: true,
+			items: flatItems,
+		});
+		await tick();
+		const listboxes = container.querySelectorAll('[role="listbox"]');
+		expect(listboxes.length).toBe(1);
+		const options = listboxes[0]!.querySelectorAll('[role="option"]');
+		expect(options.length).toBe(flatItems.length);
+	});
+
+	it('renders one listbox per group when groups are supplied with aria-labelledby', async () => {
+		const { container } = render(CommandPalette, {
+			open: true,
+			groups: groupedItems,
+		});
+		await tick();
+		const listboxes = container.querySelectorAll('[role="listbox"]');
+		expect(listboxes.length).toBe(2);
+		const groupRegions = container.querySelectorAll('[role="group"]');
+		expect(groupRegions.length).toBe(2);
+		// Each group has aria-labelledby pointing at a visible header.
+		for (const region of Array.from(groupRegions)) {
+			const labelledby = region.getAttribute('aria-labelledby');
+			expect(labelledby).toBeTruthy();
+			const labelEl = region.ownerDocument.getElementById(labelledby!);
+			expect(labelEl).toBeTruthy();
+			expect(labelEl?.textContent?.trim().length).toBeGreaterThan(0);
+		}
+	});
+
+	it('renders shortcut chip with aria-hidden', async () => {
+		const { container } = render(CommandPalette, {
+			open: true,
+			items: flatItems,
+		});
+		await tick();
+		const shortcut = container.querySelector('.gr-shell-command-palette__option-shortcut');
+		expect(shortcut).toBeTruthy();
+		expect(shortcut?.getAttribute('aria-hidden')).toBe('true');
+	});
+});
+
+describe('CommandPalette — virtual focus & keyboard navigation', () => {
+	it('starts with the first selectable item as the active descendant', async () => {
+		const { container } = render(CommandPalette, {
+			open: true,
+			items: flatItems,
+		});
+		await tick();
+		await tick();
+		const input = container.querySelector(
+			'input.gr-shell-command-palette__input'
+		) as HTMLInputElement;
+		const activeId = input.getAttribute('aria-activedescendant');
+		expect(activeId).toBeTruthy();
+		const active = container.querySelector(`#${activeId}`) as HTMLElement | null;
+		expect(active).toBeTruthy();
+		expect(active!.getAttribute('aria-selected')).toBe('true');
+		// First non-disabled item is "overview".
+		expect(active!.textContent).toContain('Overview');
+	});
+
+	it('ArrowDown moves virtual focus to the next item', async () => {
+		const { container } = render(CommandPalette, {
+			open: true,
+			items: flatItems,
+		});
+		await tick();
+		await tick();
+		const input = container.querySelector(
+			'input.gr-shell-command-palette__input'
+		) as HTMLInputElement;
+		const before = input.getAttribute('aria-activedescendant');
+
+		await fireEvent.keyDown(input, { key: 'ArrowDown' });
+		await tick();
+
+		const after = input.getAttribute('aria-activedescendant');
+		expect(after).toBeTruthy();
+		expect(after).not.toBe(before);
+		// 2nd item is "instances".
+		const active = container.querySelector(`#${after}`);
+		expect(active?.textContent).toContain('Instances');
+	});
+
+	it('ArrowUp moves virtual focus to the previous item (wraps to last)', async () => {
+		const { container } = render(CommandPalette, {
+			open: true,
+			items: flatItems,
+		});
+		await tick();
+		await tick();
+		const input = container.querySelector(
+			'input.gr-shell-command-palette__input'
+		) as HTMLInputElement;
+
+		await fireEvent.keyDown(input, { key: 'ArrowUp' });
+		await tick();
+
+		const after = input.getAttribute('aria-activedescendant');
+		// Disabled items are skipped during navigation. Last non-disabled is theme-toggle.
+		const active = container.querySelector(`#${after}`);
+		expect(active?.textContent).toContain('Toggle theme');
+	});
+
+	it('Home and End jump to first/last selectable item', async () => {
+		const { container } = render(CommandPalette, {
+			open: true,
+			items: flatItems,
+		});
+		await tick();
+		await tick();
+		const input = container.querySelector(
+			'input.gr-shell-command-palette__input'
+		) as HTMLInputElement;
+
+		await fireEvent.keyDown(input, { key: 'End' });
+		await tick();
+		let active = container.querySelector(`#${input.getAttribute('aria-activedescendant')}`);
+		expect(active?.textContent).toContain('Toggle theme');
+
+		await fireEvent.keyDown(input, { key: 'Home' });
+		await tick();
+		active = container.querySelector(`#${input.getAttribute('aria-activedescendant')}`);
+		expect(active?.textContent).toContain('Overview');
+	});
+
+	it('Enter activates the current item and fires onselect', async () => {
+		const onselect = vi.fn();
+		const { container } = render(CommandPalette, {
+			open: true,
+			items: flatItems,
+			onselect,
+		});
+		await tick();
+		await tick();
+		const input = container.querySelector(
+			'input.gr-shell-command-palette__input'
+		) as HTMLInputElement;
+
+		await fireEvent.keyDown(input, { key: 'ArrowDown' });
+		await tick();
+		await fireEvent.keyDown(input, { key: 'Enter' });
+
+		expect(onselect).toHaveBeenCalledTimes(1);
+		expect(onselect.mock.calls[0]?.[0]?.id).toBe('instances');
+	});
+
+	it('Skips disabled items during keyboard navigation', async () => {
+		const { container } = render(CommandPalette, {
+			open: true,
+			items: flatItems,
+		});
+		await tick();
+		await tick();
+		const input = container.querySelector(
+			'input.gr-shell-command-palette__input'
+		) as HTMLInputElement;
+
+		// flatItems order: overview, instances, billing, disabled, theme-toggle
+		// Start active = overview. Three ArrowDowns should land at theme-toggle,
+		// skipping the disabled item.
+		await fireEvent.keyDown(input, { key: 'ArrowDown' });
+		await fireEvent.keyDown(input, { key: 'ArrowDown' });
+		await fireEvent.keyDown(input, { key: 'ArrowDown' });
+		await tick();
+
+		const active = container.querySelector(`#${input.getAttribute('aria-activedescendant')}`);
+		expect(active?.textContent).toContain('Toggle theme');
+	});
+});
+
+describe('CommandPalette — query input', () => {
+	it('fires onquerychange and filters items reactively', async () => {
+		const onquerychange = vi.fn();
+		const { container } = render(CommandPalette, {
+			open: true,
+			items: flatItems,
+			onquerychange,
+		});
+		await tick();
+		const input = container.querySelector(
+			'input.gr-shell-command-palette__input'
+		) as HTMLInputElement;
+		await fireEvent.input(input, { target: { value: 'inst' } });
+		await tick();
+		await tick();
+
+		expect(onquerychange).toHaveBeenCalledWith('inst');
+		const options = container.querySelectorAll('[role="option"]');
+		// "Instances" matches; the rest don't.
+		expect(options.length).toBe(1);
+		expect(options[0]!.textContent).toContain('Instances');
+	});
+
+	it('shows the empty state when no items match', async () => {
+		const { container } = render(CommandPalette, {
+			open: true,
+			items: flatItems,
+			emptyMessage: 'Nothing found.',
+		});
+		await tick();
+		const input = container.querySelector(
+			'input.gr-shell-command-palette__input'
+		) as HTMLInputElement;
+		await fireEvent.input(input, { target: { value: 'zzzzzz' } });
+		await tick();
+		await tick();
+
+		expect(container.querySelector('.gr-shell-command-palette__empty')?.textContent).toContain(
+			'Nothing found.'
+		);
+		expect(container.querySelectorAll('[role="option"]').length).toBe(0);
+	});
+
+	it('shows the loading state and sets aria-busy when loading=true', async () => {
+		const { container } = render(CommandPalette, {
+			open: true,
+			items: flatItems,
+			loading: true,
+			loadingMessage: 'Searching…',
+		});
+		await tick();
+		expect(
+			container.querySelector('.gr-shell-command-palette__results')?.getAttribute('aria-busy')
+		).toBe('true');
+		expect(container.querySelector('.gr-shell-command-palette__loading')?.textContent).toContain(
+			'Searching…'
+		);
+	});
+});
+
+describe('CommandPalette — close lifecycle', () => {
+	it('Escape inside the input fires preventDefault and exposes the close intent', async () => {
+		// We exercise the keyboard close path directly. The bindable `open`
+		// prop flips internally; after re-rendering with `open: false` the
+		// dialog is gone. The point of this test is that the keydown handler
+		// returns control to the input (preventDefault) rather than letting
+		// Escape leak out of the palette.
+		const { container, rerender } = render(CommandPalette, {
+			open: true,
+			items: flatItems,
+		});
+		await tick();
+		const input = container.querySelector(
+			'input.gr-shell-command-palette__input'
+		) as HTMLInputElement;
+		const handled = await fireEvent.keyDown(input, { key: 'Escape' });
+		expect(handled).toBe(false); // preventDefault → handler returns false from fireEvent
+		await tick();
+
+		// Programmatic close still removes the dialog.
+		await rerender({ open: false, items: flatItems });
+		expect(container.querySelector('[role="dialog"]')).toBeNull();
+	});
+
+	it('clicking outside the panel closes the palette', async () => {
+		const { container, rerender } = render(CommandPalette, {
+			open: true,
+			items: flatItems,
+		});
+		await tick();
+		const root = container.querySelector('.gr-shell-command-palette') as HTMLElement;
+		// Pointerdown on the backdrop (root) but not panel.
+		await fireEvent.pointerDown(root, { target: root });
+		await tick();
+
+		// As above, ensure post-event we can render with open=false and dialog gone.
+		await rerender({ open: false, items: flatItems });
+		expect(container.querySelector('[role="dialog"]')).toBeNull();
+	});
+
+	it('does not call onselect when activating a disabled item', async () => {
+		const onselect = vi.fn();
+		const onlyDisabled: CommandPaletteItem[] = [
+			{ id: 'd1', label: 'Disabled 1', disabled: true },
+			{ id: 'd2', label: 'Disabled 2', disabled: true },
+		];
+		const { container } = render(CommandPalette, {
+			open: true,
+			items: onlyDisabled,
+			onselect,
+		});
+		await tick();
+		await tick();
+		const input = container.querySelector(
+			'input.gr-shell-command-palette__input'
+		) as HTMLInputElement;
+		await fireEvent.keyDown(input, { key: 'Enter' });
+		expect(onselect).not.toHaveBeenCalled();
+	});
+});
+
+describe('CommandPalette — mouse activation', () => {
+	it('clicking an option fires onselect with the item', async () => {
+		const onselect = vi.fn();
+		const { container } = render(CommandPalette, {
+			open: true,
+			items: flatItems,
+			onselect,
+		});
+		await tick();
+		await tick();
+		const options = container.querySelectorAll('[role="option"]');
+		const billing = Array.from(options).find((o) => o.textContent?.includes('Billing'));
+		expect(billing).toBeTruthy();
+		await fireEvent.click(billing as HTMLElement);
+		expect(onselect).toHaveBeenCalledTimes(1);
+		expect(onselect.mock.calls[0]?.[0]?.id).toBe('billing');
+	});
+
+	it('clicking a disabled option does NOT fire onselect', async () => {
+		const onselect = vi.fn();
+		const { container } = render(CommandPalette, {
+			open: true,
+			items: flatItems,
+			onselect,
+		});
+		await tick();
+		const disabledOption = Array.from(container.querySelectorAll('[role="option"]')).find((o) =>
+			o.textContent?.includes('Disabled action')
+		);
+		expect(disabledOption).toBeTruthy();
+		expect(disabledOption!.getAttribute('aria-disabled')).toBe('true');
+		await fireEvent.click(disabledOption as HTMLElement);
+		expect(onselect).not.toHaveBeenCalled();
+	});
+});
+
+describe('CommandPalette — CSP / DOM hygiene', () => {
+	it('does not set inline style attribute on the root', async () => {
+		const { container } = render(CommandPalette, {
+			open: true,
+			items: flatItems,
+		});
+		await tick();
+		expect(container.querySelector('.gr-shell-command-palette')?.hasAttribute('style')).toBe(false);
+	});
+
+	it('does not set inline style attribute on the panel', async () => {
+		const { container } = render(CommandPalette, {
+			open: true,
+			items: flatItems,
+		});
+		await tick();
+		expect(container.querySelector('.gr-shell-command-palette__panel')?.hasAttribute('style')).toBe(
+			false
+		);
+	});
+});
+
+describe('CommandPalette — id uniqueness regression (multiple instances)', () => {
+	it('two CommandPalettes on the same page do not collide on option ids', async () => {
+		const a = render(CommandPalette, {
+			open: true,
+			items: flatItems,
+		});
+		const b = render(CommandPalette, {
+			open: true,
+			items: flatItems,
+		});
+		await tick();
+		await tick();
+
+		const idsA = Array.from(a.container.querySelectorAll('[role="option"]')).map((el) =>
+			el.getAttribute('id')
+		);
+		const idsB = Array.from(b.container.querySelectorAll('[role="option"]')).map((el) =>
+			el.getAttribute('id')
+		);
+		const allIds = [...idsA, ...idsB].filter((v): v is string => Boolean(v));
+		const unique = new Set(allIds);
+		expect(unique.size).toBe(allIds.length);
+	});
+});

--- a/packages/shell/tests/command-palette.test.ts
+++ b/packages/shell/tests/command-palette.test.ts
@@ -111,24 +111,74 @@ describe('CommandPalette — open: dialog & combobox semantics', () => {
 		expect(options.length).toBe(flatItems.length);
 	});
 
-	it('renders one listbox per group when groups are supplied with aria-labelledby', async () => {
+	it('renders a single parent listbox containing role="group" sections when groups are supplied', async () => {
+		// W3C ARIA APG "Combobox with Listbox Popup, Grouped Options" pattern:
+		// one listbox per combobox, with role="group" children wrapping options.
+		// This keeps `aria-controls` pointing at a single owning listbox element,
+		// which is the regression Arch flagged in PR #668's first revision.
 		const { container } = render(CommandPalette, {
 			open: true,
 			groups: groupedItems,
 		});
 		await tick();
 		const listboxes = container.querySelectorAll('[role="listbox"]');
-		expect(listboxes.length).toBe(2);
+		expect(listboxes.length).toBe(1);
 		const groupRegions = container.querySelectorAll('[role="group"]');
 		expect(groupRegions.length).toBe(2);
-		// Each group has aria-labelledby pointing at a visible header.
+		// The parent listbox contains both groups.
 		for (const region of Array.from(groupRegions)) {
+			expect(listboxes[0]!.contains(region)).toBe(true);
 			const labelledby = region.getAttribute('aria-labelledby');
 			expect(labelledby).toBeTruthy();
 			const labelEl = region.ownerDocument.getElementById(labelledby!);
 			expect(labelEl).toBeTruthy();
 			expect(labelEl?.textContent?.trim().length).toBeGreaterThan(0);
 		}
+	});
+
+	it('input aria-controls IDREF resolves in flat mode', async () => {
+		const { container } = render(CommandPalette, {
+			open: true,
+			items: flatItems,
+		});
+		await tick();
+		const input = container.querySelector(
+			'input.gr-shell-command-palette__input'
+		) as HTMLInputElement;
+		const controls = input.getAttribute('aria-controls');
+		expect(controls).toBeTruthy();
+		const target = container.ownerDocument.getElementById(controls!);
+		expect(
+			target,
+			`Expected aria-controls=${controls} to point at a rendered element`
+		).toBeTruthy();
+		expect(target?.getAttribute('role')).toBe('listbox');
+	});
+
+	it('input aria-controls IDREF resolves in grouped mode (Arch PR #668 review regression)', async () => {
+		const { container } = render(CommandPalette, {
+			open: true,
+			groups: groupedItems,
+		});
+		await tick();
+		const input = container.querySelector(
+			'input.gr-shell-command-palette__input'
+		) as HTMLInputElement;
+		const controls = input.getAttribute('aria-controls');
+		expect(controls).toBeTruthy();
+		const target = container.ownerDocument.getElementById(controls!);
+		expect(
+			target,
+			`Expected aria-controls=${controls} to point at a rendered element in grouped mode`
+		).toBeTruthy();
+		expect(target?.getAttribute('role')).toBe('listbox');
+		// The active descendant must live inside the listbox that aria-controls
+		// names, so screen readers see one owning popup.
+		const activeId = input.getAttribute('aria-activedescendant');
+		expect(activeId).toBeTruthy();
+		const activeEl = container.ownerDocument.getElementById(activeId!);
+		expect(activeEl).toBeTruthy();
+		expect(target!.contains(activeEl!)).toBe(true);
 	});
 
 	it('renders shortcut chip with aria-hidden', async () => {

--- a/packages/shell/tests/css-bundle.test.ts
+++ b/packages/shell/tests/css-bundle.test.ts
@@ -1,0 +1,60 @@
+/**
+ * CSS-bundle regression tests.
+ *
+ * Arch flagged on PR #668 that the shell `createLiveRegion()` integration
+ * (used by CommandPalette and any future shell component) depends on the
+ * shared `.gr-sr-only` utility class to keep its `aria-live` announcement
+ * elements visually-hidden. Without that class shipped by shell.css,
+ * shell-only consumers see visible announcement text appended to
+ * `document.body`. This file pins the contract.
+ */
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+const distBundlePath = join(__dirname, '..', 'dist', 'shell.css');
+const baseCssPath = join(__dirname, '..', 'src', 'styles', 'base.css');
+
+describe('shell CSS bundle', () => {
+	it('source base.css ships the `.gr-sr-only` visually-hidden utility', () => {
+		const baseCss = readFileSync(baseCssPath, 'utf8');
+		expect(baseCss).toMatch(/\.gr-sr-only\s*\{/);
+		// The rule must include the standard sr-only properties so any
+		// element with class="gr-sr-only" is truly hidden visually but
+		// still announceable to assistive technology.
+		const ruleMatch = baseCss.match(/\.gr-sr-only\s*\{[^}]*\}/);
+		expect(ruleMatch).toBeTruthy();
+		const rule = ruleMatch![0];
+		expect(rule).toContain('position');
+		expect(rule).toContain('width');
+		expect(rule).toContain('height');
+		expect(rule).toContain('clip');
+		// Width must be 1px (the standard sr-only pattern) so AT can read it.
+		expect(rule).toMatch(/width:\s*1px/);
+	});
+
+	it('built shell.css bundle includes `.gr-sr-only` (regression for PR #668 Arch review #2)', () => {
+		// This test pins the contract that the shell.css bundle —
+		// the canonical stylesheet shell-only consumers import via
+		// `@equaltoai/greater-components-shell/shell.css` — defines
+		// `.gr-sr-only`. The headless `createLiveRegion()` utility appends
+		// announcement elements with this class to `document.body`.
+		let bundle: string;
+		try {
+			bundle = readFileSync(distBundlePath, 'utf8');
+		} catch (err) {
+			// If the bundle hasn't been built yet (e.g. running tests in
+			// isolation before a build step), surface a clear hint rather
+			// than failing on the file read.
+			throw new Error(
+				`Could not read built shell.css bundle at ${distBundlePath}. ` +
+					`Run \`pnpm --filter @equaltoai/greater-components-shell build\` first.`,
+				{ cause: err }
+			);
+		}
+		expect(bundle).toMatch(/\.gr-sr-only\s*\{/);
+	});
+});

--- a/packages/shell/tests/fuzzy-filter.test.ts
+++ b/packages/shell/tests/fuzzy-filter.test.ts
@@ -1,0 +1,138 @@
+import { describe, it, expect } from 'vitest';
+import {
+	scoreCommandPaletteItem,
+	filterAndRankItems,
+	tokenizeQuery,
+} from '../src/utils/fuzzy-filter.js';
+import type { CommandPaletteItem } from '../src/types.js';
+
+const items: CommandPaletteItem[] = [
+	{ id: 'overview', label: 'Overview', description: 'Fleet overview', keywords: ['home', 'fleet'] },
+	{ id: 'instances', label: 'Instances', description: 'Provisioned instances' },
+	{ id: 'instance-detail', label: 'Instance detail', keywords: ['single'] },
+	{ id: 'billing', label: 'Billing & invoicing', description: 'Monthly cycles' },
+	{ id: 'theme-toggle', label: 'Toggle theme', keywords: ['dark', 'light', 'mode'] },
+	{ id: 'disabled', label: 'Disabled action', disabled: true },
+];
+
+describe('tokenizeQuery', () => {
+	it('returns empty array for empty / whitespace query', () => {
+		expect(tokenizeQuery('')).toEqual([]);
+		expect(tokenizeQuery('   ')).toEqual([]);
+	});
+
+	it('splits on whitespace and lowercases', () => {
+		expect(tokenizeQuery('Hot Reload')).toEqual(['hot', 'reload']);
+		expect(tokenizeQuery('   FOO  bar   ')).toEqual(['foo', 'bar']);
+	});
+});
+
+describe('scoreCommandPaletteItem (built-in scorer)', () => {
+	it('returns 0 for empty query (include everything)', () => {
+		for (const item of items) {
+			expect(scoreCommandPaletteItem(item, '')).toBe(0);
+			expect(scoreCommandPaletteItem(item, '   ')).toBe(0);
+		}
+	});
+
+	it('exact full-string label match ranks above prefix / substring', () => {
+		const target = items[0]!; // "Overview"
+		const exact = scoreCommandPaletteItem(target, 'Overview');
+		const prefix = scoreCommandPaletteItem(target, 'Over');
+		const sub = scoreCommandPaletteItem(target, 'view');
+		expect(exact).not.toBeNull();
+		expect(prefix).not.toBeNull();
+		expect(sub).not.toBeNull();
+		expect(exact!).toBeGreaterThan(prefix!);
+		expect(prefix!).toBeGreaterThan(sub!);
+	});
+
+	it('returns null when any token has no match anywhere', () => {
+		const target = items[0]!; // "Overview / Fleet overview / [home, fleet]"
+		expect(scoreCommandPaletteItem(target, 'overview zzzzz')).toBeNull();
+		expect(scoreCommandPaletteItem(target, 'zzz')).toBeNull();
+	});
+
+	it('ranks label matches above description matches', () => {
+		const labelMatch = scoreCommandPaletteItem(items[1]!, 'Instances'); // label exact
+		const descOnly = scoreCommandPaletteItem(items[3]!, 'cycles'); // description substring
+		expect(labelMatch!).toBeGreaterThan(descOnly!);
+	});
+
+	it('matches against keywords', () => {
+		// "dark" is only present as a keyword on theme-toggle
+		const result = scoreCommandPaletteItem(items[4]!, 'dark');
+		expect(result).not.toBeNull();
+		expect(result!).toBeGreaterThan(0);
+	});
+
+	it('multi-token queries require every token to match somewhere', () => {
+		// items[0]: label "Overview", description "Fleet overview", keywords ["home","fleet"]
+		// "fleet overview" → both match
+		expect(scoreCommandPaletteItem(items[0]!, 'fleet overview')).not.toBeNull();
+		// "fleet zzz" → second token has no match
+		expect(scoreCommandPaletteItem(items[0]!, 'fleet zzz')).toBeNull();
+	});
+
+	it('is case-insensitive', () => {
+		const lower = scoreCommandPaletteItem(items[0]!, 'overview');
+		const upper = scoreCommandPaletteItem(items[0]!, 'OVERVIEW');
+		const mixed = scoreCommandPaletteItem(items[0]!, 'OvErVieW');
+		expect(lower).toBe(upper);
+		expect(lower).toBe(mixed);
+	});
+});
+
+describe('filterAndRankItems', () => {
+	it('returns all items in natural order when query is empty', () => {
+		const result = filterAndRankItems(items, '');
+		expect(result.map((it) => it.id)).toEqual(items.map((it) => it.id));
+	});
+
+	it('returns only items that match every query token', () => {
+		const result = filterAndRankItems(items, 'instance');
+		expect(result.map((it) => it.id)).toEqual(['instances', 'instance-detail']);
+	});
+
+	it('ranks better matches first', () => {
+		const result = filterAndRankItems(items, 'instance');
+		// "Instances" prefix match (rank 60) vs "Instance detail" prefix match (rank 60);
+		// tie broken by natural order, so "instances" stays first.
+		expect(result[0]?.id).toBe('instances');
+	});
+
+	it('ranks an exact label match above other matches with the same token', () => {
+		const fixture: CommandPaletteItem[] = [
+			{ id: 'b', label: 'About', description: 'Cat info', keywords: [] },
+			{ id: 'a', label: 'Cat', description: 'A cat page', keywords: [] }, // exact label match
+			{ id: 'c', label: 'Catalog', description: '', keywords: [] }, // prefix match
+		];
+		const result = filterAndRankItems(fixture, 'cat');
+		// Exact "Cat" first, then prefix "Catalog", then substring "About"
+		expect(result.map((it) => it.id)).toEqual(['a', 'c', 'b']);
+	});
+
+	it('excludes items where any token does not match', () => {
+		const result = filterAndRankItems(items, 'fleet zzzzz');
+		expect(result).toEqual([]);
+	});
+
+	it('keeps disabled items in results (renderer decides how to show them)', () => {
+		const result = filterAndRankItems(items, 'disabled');
+		expect(result.find((it) => it.id === 'disabled')).toBeDefined();
+	});
+
+	it('uses keywords for matching even when label/description omit the term', () => {
+		const result = filterAndRankItems(items, 'dark');
+		expect(result.map((it) => it.id)).toContain('theme-toggle');
+	});
+
+	it('matches across whitespace tokens out of order', () => {
+		const fixture: CommandPaletteItem[] = [
+			{ id: 'a', label: 'Switch to dark mode' },
+			{ id: 'b', label: 'Switch to light mode' },
+		];
+		const result = filterAndRankItems(fixture, 'mode dark');
+		expect(result.map((it) => it.id)).toEqual(['a']);
+	});
+});

--- a/packages/shell/vitest.config.ts
+++ b/packages/shell/vitest.config.ts
@@ -18,6 +18,7 @@ export default defineConfig({
 			'@equaltoai/greater-components-shell': path.resolve(__dirname, './src/index.ts'),
 			'@equaltoai/greater-components-tokens': path.resolve(__dirname, '../tokens/src/index.ts'),
 			'@equaltoai/greater-components-utils': path.resolve(__dirname, '../utils/src/index.ts'),
+			'@equaltoai/greater-components-headless': path.resolve(__dirname, '../headless/src/index.ts'),
 		},
 	},
 	test: {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1467,6 +1467,9 @@ importers:
 
   packages/shell:
     dependencies:
+      '@equaltoai/greater-components-headless':
+        specifier: workspace:*
+        version: link:../headless
       '@equaltoai/greater-components-utils':
         specifier: workspace:*
         version: link:../utils

--- a/registry/index.json
+++ b/registry/index.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://equalto.ai/schemas/registry-index.schema.json",
   "schemaVersion": "1.0.0",
-  "generatedAt": "2026-05-24T19:36:38.570Z",
+  "generatedAt": "2026-05-24T19:46:17.417Z",
   "ref": "greater-v0.9.0",
   "version": "0.9.0",
   "checksums": {
@@ -901,7 +901,7 @@
     "packages/shell/src/components/Callout.css": "sha256-LnnrUMfn9/3VcHX6zcDZFSpqe7nKRMZKAI71Jkpgq+8=",
     "packages/shell/src/components/Callout.svelte": "sha256-ph59kDztSXz4xJ+NHdg4dkyhyMM5kv/uGpl/ZvdzgmY=",
     "packages/shell/src/components/CommandPalette.css": "sha256-JFAY1r9Up5S1nhIfWox69+z5AZTs4Lc4odXLkt7l/Fg=",
-    "packages/shell/src/components/CommandPalette.svelte": "sha256-hNGj0JvjtFWsr5NShKhsDv+ABlfOf0I8U0HMak/jkBU=",
+    "packages/shell/src/components/CommandPalette.svelte": "sha256-UrkgFhzcfLGsJOarQkl9LByQwjBKrOONbu2j/H4Wa4k=",
     "packages/shell/src/components/PageFrame.css": "sha256-uiWRrFQ2HAFj1yBpi2eSLVi2DEGdju5WB4Y+AHL0mlA=",
     "packages/shell/src/components/PageFrame.svelte": "sha256-zesK3O34UhQcZTxOqhuqQqnxlm3TFWv0d+EuLqX05HI=",
     "packages/shell/src/components/PageTitle.css": "sha256-jy/Vfn9B9VBstoMHrWA0oPdblW8hxPoRexTCf7c1TiU=",
@@ -921,7 +921,7 @@
     "packages/shell/src/index.ts": "sha256-NLhn3AXDEWBZsC7ACM0NX2/1Uq0CzDuQwYjVG4zGXhw=",
     "packages/shell/src/styles/base.css": "sha256-HEzrvYFs/wBWZuQUMeZmzhNjywLC88m8FgEYWd9S9Ho=",
     "packages/shell/src/types.ts": "sha256-xRnEGFsxQoJKt05wbZb+rbvOVbkbNb5UCpXOSovR8hI=",
-    "packages/shell/src/utils/fuzzy-filter.ts": "sha256-65TJ/23XtKIIqu0MbghfBXGUyNEYao0JkNrtGyCTbMI=",
+    "packages/shell/src/utils/fuzzy-filter.ts": "sha256-ZopMxsr/aoZ3BqcmGydIR4DOwysud9oxTBLp88qVXt8=",
     "packages/faces/social/src/adapters/batcher.ts": "sha256-6PnUshOPk84U+PSnkADYzhN9SpUrvwiy+tN10HPaVeE=",
     "packages/faces/social/src/adapters/cache.ts": "sha256-32jUHLAsYoK4U0JZ6hswGUlQOmwhJ5yquqhMqyfrc4I=",
     "packages/faces/social/src/adapters/graphql/client.ts": "sha256-yor+sP4J7hzK+igh2s4mujPOUZTRDN/e3nU1eccrSyo=",
@@ -6035,8 +6035,8 @@
         },
         {
           "path": "src/components/CommandPalette.svelte",
-          "checksum": "sha256-hNGj0JvjtFWsr5NShKhsDv+ABlfOf0I8U0HMak/jkBU=",
-          "size": 22086
+          "checksum": "sha256-UrkgFhzcfLGsJOarQkl9LByQwjBKrOONbu2j/H4Wa4k=",
+          "size": 21893
         },
         {
           "path": "src/components/PageFrame.css",
@@ -6135,8 +6135,8 @@
         },
         {
           "path": "src/utils/fuzzy-filter.ts",
-          "checksum": "sha256-65TJ/23XtKIIqu0MbghfBXGUyNEYao0JkNrtGyCTbMI=",
-          "size": 5024
+          "checksum": "sha256-ZopMxsr/aoZ3BqcmGydIR4DOwysud9oxTBLp88qVXt8=",
+          "size": 5020
         }
       ],
       "dependencies": [

--- a/registry/index.json
+++ b/registry/index.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://equalto.ai/schemas/registry-index.schema.json",
   "schemaVersion": "1.0.0",
-  "generatedAt": "2026-05-24T19:46:17.417Z",
+  "generatedAt": "2026-05-24T20:14:39.644Z",
   "ref": "greater-v0.9.0",
   "version": "0.9.0",
   "checksums": {
@@ -900,8 +900,8 @@
     "packages/shell/src/components/Breadcrumb.svelte": "sha256-NP1cHv6jMKWSe4PYsafPn/ta/Hle13f154pY6IS/Rig=",
     "packages/shell/src/components/Callout.css": "sha256-LnnrUMfn9/3VcHX6zcDZFSpqe7nKRMZKAI71Jkpgq+8=",
     "packages/shell/src/components/Callout.svelte": "sha256-ph59kDztSXz4xJ+NHdg4dkyhyMM5kv/uGpl/ZvdzgmY=",
-    "packages/shell/src/components/CommandPalette.css": "sha256-JFAY1r9Up5S1nhIfWox69+z5AZTs4Lc4odXLkt7l/Fg=",
-    "packages/shell/src/components/CommandPalette.svelte": "sha256-UrkgFhzcfLGsJOarQkl9LByQwjBKrOONbu2j/H4Wa4k=",
+    "packages/shell/src/components/CommandPalette.css": "sha256-/IGfp1GGTymIqO1Ti/TqyhNh4l6bvCqhd4On971rKCo=",
+    "packages/shell/src/components/CommandPalette.svelte": "sha256-3mNM4rE3MqE/janHhyG9a+zvJDgTgD7i3NFJ843sxGs=",
     "packages/shell/src/components/PageFrame.css": "sha256-uiWRrFQ2HAFj1yBpi2eSLVi2DEGdju5WB4Y+AHL0mlA=",
     "packages/shell/src/components/PageFrame.svelte": "sha256-zesK3O34UhQcZTxOqhuqQqnxlm3TFWv0d+EuLqX05HI=",
     "packages/shell/src/components/PageTitle.css": "sha256-jy/Vfn9B9VBstoMHrWA0oPdblW8hxPoRexTCf7c1TiU=",
@@ -919,7 +919,7 @@
     "packages/shell/src/components/Topbar.css": "sha256-e49AWpuwlaEBLxqeDvM8sMNuwlqugOB+54w1y+7ojME=",
     "packages/shell/src/components/Topbar.svelte": "sha256-QXASS11a1RlKcnxqDskrt0PwkGTt7zvr+LrK2uWHm80=",
     "packages/shell/src/index.ts": "sha256-NLhn3AXDEWBZsC7ACM0NX2/1Uq0CzDuQwYjVG4zGXhw=",
-    "packages/shell/src/styles/base.css": "sha256-HEzrvYFs/wBWZuQUMeZmzhNjywLC88m8FgEYWd9S9Ho=",
+    "packages/shell/src/styles/base.css": "sha256-INLODwNQNHYVsBKgGXbW/PENIwGo7NuIODzsRFuUUN8=",
     "packages/shell/src/types.ts": "sha256-xRnEGFsxQoJKt05wbZb+rbvOVbkbNb5UCpXOSovR8hI=",
     "packages/shell/src/utils/fuzzy-filter.ts": "sha256-ZopMxsr/aoZ3BqcmGydIR4DOwysud9oxTBLp88qVXt8=",
     "packages/faces/social/src/adapters/batcher.ts": "sha256-6PnUshOPk84U+PSnkADYzhN9SpUrvwiy+tN10HPaVeE=",
@@ -6030,13 +6030,13 @@
         },
         {
           "path": "src/components/CommandPalette.css",
-          "checksum": "sha256-JFAY1r9Up5S1nhIfWox69+z5AZTs4Lc4odXLkt7l/Fg=",
-          "size": 4732
+          "checksum": "sha256-/IGfp1GGTymIqO1Ti/TqyhNh4l6bvCqhd4On971rKCo=",
+          "size": 4969
         },
         {
           "path": "src/components/CommandPalette.svelte",
-          "checksum": "sha256-UrkgFhzcfLGsJOarQkl9LByQwjBKrOONbu2j/H4Wa4k=",
-          "size": 21893
+          "checksum": "sha256-3mNM4rE3MqE/janHhyG9a+zvJDgTgD7i3NFJ843sxGs=",
+          "size": 23397
         },
         {
           "path": "src/components/PageFrame.css",
@@ -6125,8 +6125,8 @@
         },
         {
           "path": "src/styles/base.css",
-          "checksum": "sha256-HEzrvYFs/wBWZuQUMeZmzhNjywLC88m8FgEYWd9S9Ho=",
-          "size": 2031
+          "checksum": "sha256-INLODwNQNHYVsBKgGXbW/PENIwGo7NuIODzsRFuUUN8=",
+          "size": 2912
         },
         {
           "path": "src/types.ts",

--- a/registry/index.json
+++ b/registry/index.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://equalto.ai/schemas/registry-index.schema.json",
   "schemaVersion": "1.0.0",
-  "generatedAt": "2026-05-24T19:13:14.126Z",
+  "generatedAt": "2026-05-24T19:36:38.570Z",
   "ref": "greater-v0.9.0",
   "version": "0.9.0",
   "checksums": {
@@ -900,6 +900,8 @@
     "packages/shell/src/components/Breadcrumb.svelte": "sha256-NP1cHv6jMKWSe4PYsafPn/ta/Hle13f154pY6IS/Rig=",
     "packages/shell/src/components/Callout.css": "sha256-LnnrUMfn9/3VcHX6zcDZFSpqe7nKRMZKAI71Jkpgq+8=",
     "packages/shell/src/components/Callout.svelte": "sha256-ph59kDztSXz4xJ+NHdg4dkyhyMM5kv/uGpl/ZvdzgmY=",
+    "packages/shell/src/components/CommandPalette.css": "sha256-JFAY1r9Up5S1nhIfWox69+z5AZTs4Lc4odXLkt7l/Fg=",
+    "packages/shell/src/components/CommandPalette.svelte": "sha256-hNGj0JvjtFWsr5NShKhsDv+ABlfOf0I8U0HMak/jkBU=",
     "packages/shell/src/components/PageFrame.css": "sha256-uiWRrFQ2HAFj1yBpi2eSLVi2DEGdju5WB4Y+AHL0mlA=",
     "packages/shell/src/components/PageFrame.svelte": "sha256-zesK3O34UhQcZTxOqhuqQqnxlm3TFWv0d+EuLqX05HI=",
     "packages/shell/src/components/PageTitle.css": "sha256-jy/Vfn9B9VBstoMHrWA0oPdblW8hxPoRexTCf7c1TiU=",
@@ -916,9 +918,10 @@
     "packages/shell/src/components/SummaryStrip.svelte": "sha256-NNogNLiDalDVA/J2I41BLjv4GxwAh/heQ1V6yw7mr/c=",
     "packages/shell/src/components/Topbar.css": "sha256-e49AWpuwlaEBLxqeDvM8sMNuwlqugOB+54w1y+7ojME=",
     "packages/shell/src/components/Topbar.svelte": "sha256-QXASS11a1RlKcnxqDskrt0PwkGTt7zvr+LrK2uWHm80=",
-    "packages/shell/src/index.ts": "sha256-TPoF60SwTnbRThGLkOeanhz13dTXe1TN/OK26dD9k9Q=",
-    "packages/shell/src/styles/base.css": "sha256-cm8jH6lTse2buuVVFwZXARUnfqJEmKpjiAy6NlVRt4E=",
-    "packages/shell/src/types.ts": "sha256-Jt+84Xzu6ikTcFSglELfXUeDFCP8z3EbwH5BQj2uPwM=",
+    "packages/shell/src/index.ts": "sha256-NLhn3AXDEWBZsC7ACM0NX2/1Uq0CzDuQwYjVG4zGXhw=",
+    "packages/shell/src/styles/base.css": "sha256-HEzrvYFs/wBWZuQUMeZmzhNjywLC88m8FgEYWd9S9Ho=",
+    "packages/shell/src/types.ts": "sha256-xRnEGFsxQoJKt05wbZb+rbvOVbkbNb5UCpXOSovR8hI=",
+    "packages/shell/src/utils/fuzzy-filter.ts": "sha256-65TJ/23XtKIIqu0MbghfBXGUyNEYao0JkNrtGyCTbMI=",
     "packages/faces/social/src/adapters/batcher.ts": "sha256-6PnUshOPk84U+PSnkADYzhN9SpUrvwiy+tN10HPaVeE=",
     "packages/faces/social/src/adapters/cache.ts": "sha256-32jUHLAsYoK4U0JZ6hswGUlQOmwhJ5yquqhMqyfrc4I=",
     "packages/faces/social/src/adapters/graphql/client.ts": "sha256-yor+sP4J7hzK+igh2s4mujPOUZTRDN/e3nU1eccrSyo=",
@@ -6026,6 +6029,16 @@
           "size": 3357
         },
         {
+          "path": "src/components/CommandPalette.css",
+          "checksum": "sha256-JFAY1r9Up5S1nhIfWox69+z5AZTs4Lc4odXLkt7l/Fg=",
+          "size": 4732
+        },
+        {
+          "path": "src/components/CommandPalette.svelte",
+          "checksum": "sha256-hNGj0JvjtFWsr5NShKhsDv+ABlfOf0I8U0HMak/jkBU=",
+          "size": 22086
+        },
+        {
           "path": "src/components/PageFrame.css",
           "checksum": "sha256-uiWRrFQ2HAFj1yBpi2eSLVi2DEGdju5WB4Y+AHL0mlA=",
           "size": 1410
@@ -6107,22 +6120,31 @@
         },
         {
           "path": "src/index.ts",
-          "checksum": "sha256-TPoF60SwTnbRThGLkOeanhz13dTXe1TN/OK26dD9k9Q=",
-          "size": 2142
+          "checksum": "sha256-NLhn3AXDEWBZsC7ACM0NX2/1Uq0CzDuQwYjVG4zGXhw=",
+          "size": 2511
         },
         {
           "path": "src/styles/base.css",
-          "checksum": "sha256-cm8jH6lTse2buuVVFwZXARUnfqJEmKpjiAy6NlVRt4E=",
-          "size": 2003
+          "checksum": "sha256-HEzrvYFs/wBWZuQUMeZmzhNjywLC88m8FgEYWd9S9Ho=",
+          "size": 2031
         },
         {
           "path": "src/types.ts",
-          "checksum": "sha256-Jt+84Xzu6ikTcFSglELfXUeDFCP8z3EbwH5BQj2uPwM=",
-          "size": 1990
+          "checksum": "sha256-xRnEGFsxQoJKt05wbZb+rbvOVbkbNb5UCpXOSovR8hI=",
+          "size": 3967
+        },
+        {
+          "path": "src/utils/fuzzy-filter.ts",
+          "checksum": "sha256-65TJ/23XtKIIqu0MbghfBXGUyNEYao0JkNrtGyCTbMI=",
+          "size": 5024
         }
       ],
-      "dependencies": [{ "name": "utils", "version": "0.9.0" }],
+      "dependencies": [
+        { "name": "headless", "version": "0.9.0" },
+        { "name": "utils", "version": "0.9.0" }
+      ],
       "peerDependencies": [
+        { "name": "@equaltoai/greater-components-headless", "version": "0.9.0" },
         { "name": "@equaltoai/greater-components-utils", "version": "0.9.0" },
         { "name": "@equaltoai/greater-components-tokens", "version": "0.9.0" },
         { "name": "svelte", "version": "^5.55.1" }


### PR DESCRIPTION
## Milestone

**G1 — Accessible CommandPalette for Host navigation** — parent issue #634, child sub-issues #644–#649. Closes G1.1 (#644), G1.2 (#645), G1.3 (#646), G1.4 (#647), G1.5 (#648), G1.6 (#649).

Adds the `CommandPalette` to the `@equaltoai/greater-components/shell` surface that lesser-host web M0.7 needs to replace bespoke palette work and unblock the rest of Project 39's Greater Signal D track.

## Classification

component-addition (one new component under the existing shell surface; new dependency-free utility for fuzzy filtering; new public types; CLI registry refresh; docs + playground; no breaking changes; no Lesser / Lesser Host contract or adapter changes).

## Surfaces affected

- **New shell component**: `packages/shell/src/components/CommandPalette.svelte` (+ CSS) implementing the W3C ARIA combobox + listbox pattern with virtual focus.
- **New filter utility**: `packages/shell/src/utils/fuzzy-filter.ts` — dependency-free, strict-CSP-safe scorer + ranker (exported via the shell barrel and via `@equaltoai/greater-components/shell/fuzzy-filter`).
- **New public types**: `CommandPaletteItem`, `CommandPaletteGroup`, `CommandPaletteFilter` re-exported from the shell barrel and `@equaltoai/greater-components/shell/types`.
- **Headless dep**: `packages/shell/package.json` adds `@equaltoai/greater-components-headless` to `dependencies` (and dev) so the palette can reuse `createFocusTrap`, `createDismissable`, and `createLiveRegion`.
- **Tokens**: `packages/shell/src/styles/base.css` adds `.gr-shell-command-palette` to the broad `:where(...)` selector that emits `--gr-shell-*` defaults — standalone palettes outside a `Shell` ancestor still resolve their spacing tokens.
- **Root barrel**: `packages/greater-components/package.json` adds `./shell/fuzzy-filter` export.
- **CLI registry**: `packages/cli/src/registry/index.ts` updates the `shell` entry's description + tags to mention CommandPalette and adds `utils` + `headless` to `registryDependencies`. `registry/index.json` regenerated (1420 checksums, 26 shell entries).
- **Docs**: `docs/component-inventory.md` table updated 10 → 11 components; new "CommandPalette quick reference" subsection; "What Shell Provides / Does NOT Provide" lists rebalanced. `docs/api-reference.md` Shell Package table + prop unions + accessibility paragraph + filter-override section added.
- **Playground**: `apps/playground/src/routes/command-palette/+page.svelte` is a full demo route with grouped results, a disabled item, shortcut chips, and `returnFocusTo` wiring. Landing CTA link added.

## Specialist walks referenced

- **Component API / theming (`evolve-component-surface`)** — additive only. Component public API is bindable (`open`, `query`), strongly typed (`CommandPaletteItem`, `CommandPaletteGroup`, `CommandPaletteFilter`), and templatable via three snippet props (`itemTemplate`, `emptyState`, `loadingState`). No existing exports renamed or removed. Theming via stable `--gr-*` tokens plus additive `--gr-shell-*` defaults (no new tokens beyond the ones already established in G0).
- **Accessibility (`enforce-accessibility`)** — WCAG 2.1 AA + W3C ARIA APG combobox + listbox pattern from the first commit:
  - `<div role="dialog" aria-modal="true" aria-labelledby>` overlay
  - `<input role="combobox" aria-autocomplete="list" aria-expanded aria-controls aria-activedescendant aria-labelledby>` keeps real focus
  - `<ul role="listbox">` per group with `<section role="group" aria-labelledby>` headers, or a single flat listbox when `items` is provided
  - `<li role="option" aria-selected aria-disabled?>` — disabled items are skipped during keyboard navigation and ignored on Enter / click
  - Live region (`createLiveRegion`) politely announces result counts and empty / loading state changes
  - Focus trap (`createFocusTrap`) returns focus to the opener; outside-pointerdown + Escape close (`createDismissable`)
  - Keyboard contract: ArrowUp / ArrowDown / Home / End / Enter / Escape; all in the test suite
- **Contract sync (`sync-contracts`)** — none. No `packages/adapters/` changes; no Lesser / Lesser Host snapshot changes. Data is supplied by consumer props.
- **Release flow** — three-branch flow respected: PR targets `staging`. Branch is based off `staging` (post-#667 merge commit `555a39d9`), so `origin/main` and `origin/premain` are NOT ancestors of HEAD. CI promotion-rehearsal will run `simulate-squash` (also PASS locally) — **this PR can be merged with either "Create a merge commit" or "Squash and merge"**.
- **Framework feedback** — idiomatic Svelte 5 runes + SvelteKit SSR-safe; no upstream patches; no new framework dependencies.

## Semver impact

**minor.** Changeset `.changeset/command-palette-g1.md` declares minor for `greater-components`, `@equaltoai/greater-components`, `@equaltoai/greater-components-shell`. No breaking changes; no existing exports renamed / removed; theming contract preserved.

## Consumer impact

- **lesser-host (Project 39, M0.7)**: can wire route + action lists to `CommandPalette` and remove any bespoke palette work. Strict-CSP-safe by construction; meets host's single-origin CSP without weakening it.
- **sim**: unaffected directly; additive surface.
- **lesser UIs**: unaffected directly; additive surface.
- **External Mastodon-compatible consumers**: unaffected; presentational, protocol-agnostic.

## Tasks

- [x] **G1.1 — Define CommandPalette API contract (#644)** — props / snippets / events typed in `packages/shell/src/types.ts`; exported through the barrel.
- [x] **G1.2 — Wire CommandPalette headless accessibility behaviors (#645)** — composed `createFocusTrap` + `createDismissable` + `createLiveRegion` from `@equaltoai/greater-components-headless`; added headless as a runtime dependency.
- [x] **G1.3 — Implement CommandPalette keyboard lifecycle (#646)** — full keyboard contract (Esc / Arrow / Home / End / Enter / Tab), focus restore via the trap's `returnFocusTo`, empty + loading states.
- [x] **G1.4 — Add dependency-free fuzzy filtering (#647)** — `packages/shell/src/utils/fuzzy-filter.ts` with `scoreCommandPaletteItem`, `filterAndRankItems`, and `tokenizeQuery`. No cmdk / Fuse / fuzzysort dependency. Strict-CSP-safe (no `unsafe-eval`, pure data transforms).
- [x] **G1.5 — Test CommandPalette accessibility and interactions (#648)** — `tests/command-palette.test.ts` (19 tests) + `tests/fuzzy-filter.test.ts` (22 tests).
- [x] **G1.6 — Document and register CommandPalette (#649)** — inventory + api-reference updates, playground demo route + landing CTA, CLI registry refresh, registry regenerated.

## Changesets

- `.changeset/command-palette-g1.md` — `greater-components: minor`, `@equaltoai/greater-components: minor`, `@equaltoai/greater-components-shell: minor`.

## Validation (local)

- `pnpm install` — clean; lockfile now links shell → headless workspace.
- `pnpm --filter @equaltoai/greater-components-shell build` — clean (shell.css 25,859 bytes including CommandPalette styles).
- `pnpm --filter @equaltoai/greater-components-shell test` — **120 / 120 PASS** (was 79; added 19 command-palette + 22 fuzzy-filter tests).
- `pnpm --filter @equaltoai/greater-components-cli test` — 822 / 822 PASS.
- `pnpm -r build` — workspace-wide clean (incl. root barrel and playground / docs apps).
- `pnpm test` workspace-wide — all green; no regressions.
- `pnpm --filter @equaltoai/playground build` — 47 HTML files, 47 inline scripts extracted by CSP postprocessor; new `/command-palette` route pre-rendered.
- `pnpm format`, `pnpm format:check` — clean.
- `pnpm lint` — 0 errors (pre-existing-style non-null-assertion warnings in tests, consistent with repo policy).
- `pnpm validate:registry`, `validate:cli` (2840 files), `validate:exports` (34 packages), `validate:dist`, `validate:deps` (27 packages), `validate:tokens`, `validate:ids` (no unstable id generation), `validate:csp` (0 new violations), `validate:versions`, `check:openapi-auth` — all PASS.
- `node scripts/check-dco.js --base origin/staging --head HEAD` — PASS (2 commits).
- `node scripts/rehearse-release-promotion.js --candidate HEAD` — **PASS (preserve-topology)** for `staging → premain`, `staging → main`, `premain → main`.
- `node scripts/rehearse-release-promotion.js --candidate HEAD --simulate-squash` — **PASS (simulate-squash)** for all three paths.

## Release-flow plan (handoff after merge to staging)

- [ ] Merge to staging (squash OR merge-commit both safe; this branch is based off staging directly, no main/premain ancestry to preserve).
- [ ] Staging soak.
- [ ] Promote to premain via `release-components` (release-please RC PR; cuts `greater-vX.Y.Z-rc.N`).
- [ ] RC soak, including internal consumer (sim, host) testing of `greater add shell` for the updated palette.
- [ ] Promote to main via `release-components` (release-please stable PR; cuts `greater-vX.Y.Z` + CLI tarball + registry + GitHub Release).
- [ ] Backmerge main → premain → staging.

## Cross-repo coordination

- **lesser-host** (Project 39 — primary consumer): unblocks command-palette adoption in lesser-host web M0.7. Host can wire its route/action list to `CommandPalette` once this release ships, OR import from `@equaltoai/greater-components/shell` during local development.
- **sim, lesser UIs**: additive only — no required action.

## Advisor-brief authorization

N/A — this work proceeded from the existing Greater Project 39 roadmap (issues #634, #644–#649) and Aron's direct direction in this session ("merged proceed to sync to staging and implement-milestone https://github.com/equaltoai/greater-components/issues/634"). No `@lessersoul.ai` advisor brief was used.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)