### PR TITLE
feat(host-platform): add operator timelines and stack matrix (#636)

### DIFF
--- a/.changeset/host-platform-g3.md
+++ b/.changeset/host-platform-g3.md
@@ -1,0 +1,29 @@
+---
+'greater-components': minor
+'@equaltoai/greater-components': minor
+'@equaltoai/greater-components-host-platform': minor
+---
+
+Add three operator-console components to `@equaltoai/greater-components/host-platform`: `ProvisioningTimeline`, `ReleaseTimeline`, `StackMatrix`. G3 milestone for lesser-host web M2 (Greater Project 39 Signal D, parent #636).
+
+All three are presentational only — consumers supply already-shaped data. No Lesser / Lesser Host adapter or contract changes (deferred to a later sync-contracts-gated PR if/when Host publishes provisioning / release / stack APIs).
+
+Highlights:
+
+- **ProvisioningTimeline** — `<section aria-labelledby>` + semantic `<ol>` of `ProvisioningStep`s. Each step exposes status (`pending` / `active` / `success` / `failure` / `skipped`) via icon glyph + visible text label (never color-only). The active step carries `aria-current="step"`. Optional `liveLog` snippet is wrapped in a constrained `<section role="log" aria-live="polite" aria-atomic="false" aria-relevant="additions">` so AT users hear only NEW log lines on each update rather than the entire backlog. `liveLogPoliteness` configurable to `'assertive'` (urgent failures) or `'off'` (visible-only).
+
+- **ReleaseTimeline** — `<section aria-labelledby>` + semantic `<ol>` of `ReleaseTimelineItem`s. Each release exposes channel via `aria-label`, dates via `<time datetime>`, and numeric adoption as a nested `role="meter"` with `[0, 1]` range and composed `aria-valuetext` (e.g. `"Adoption: 42%"`). String adoption (`"42 of 100 instances"`) renders as static text — no fake meter range. Default `formatDate` uses `Intl.DateTimeFormat`; `formatAdoption` and `formatDate` are both overridable.
+
+- **StackMatrix** — real `<table>` with `<caption>` (visually-hidden by default but available to AT), `<th scope="col">` column headers, `<th scope="row">` row headers, and `aria-sort` on the currently-sorted column. Sortable columns render their headers as `<button>` elements (browser-native keyboard contract); consumers receive the column id via `onsort` and re-supply `rows` in the desired order. Drift indicators (`in-sync` ● / `pending` ◌ / `drifted` ⚠ / `unknown` ?) are non-color-only. Per-row actions are wrapped in `<div role="group">` with a row-specific accessible name.
+
+Type contracts added: `ProvisioningStep`, `ProvisioningStepStatus`, `ProvisioningLogPoliteness`, `ReleaseChannel`, `ReleaseStatus`, `ReleaseTimelineItem`, `ReleaseAdoptionFormatter`, `StackMatrixDrift`, `StackMatrixColumn`, `StackMatrixCell`, `StackMatrixRow`, `StackMatrixSortDirection`.
+
+Wiring:
+
+- `packages/host-platform/src/index.ts` exports the three new components and all twelve new types.
+- `packages/host-platform/package.json` adds `./ProvisioningTimeline`, `./ReleaseTimeline`, `./StackMatrix` subpath exports.
+- `packages/host-platform/src/styles/base.css` extends the box-sizing + `--gr-host-platform-*` token-defaults `:where(...)` selector to cover the new component root classes.
+- CLI registry (`packages/cli/src/registry/index.ts`): updated `host-platform` description + tags to mention the new components.
+- `registry/index.json` regenerated.
+
+No existing exports are renamed or removed. No new runtime dependencies. Strict-CSP safe: no inline event handlers, no `style` attributes set at runtime.

--- a/apps/playground/src/routes/host-platform/+page.svelte
+++ b/apps/playground/src/routes/host-platform/+page.svelte
@@ -14,8 +14,131 @@ components. Only static stylesheets and class-driven width steps.
 		FleetCard,
 		CostGauge,
 		ActivitySparkline,
+		ProvisioningTimeline,
+		ReleaseTimeline,
+		StackMatrix,
+	} from '@equaltoai/greater-components-host-platform';
+	import type {
+		ProvisioningStep,
+		ReleaseTimelineItem,
+		StackMatrixColumn,
+		StackMatrixRow,
+		StackMatrixSortDirection,
 	} from '@equaltoai/greater-components-host-platform';
 	import '@equaltoai/greater-components-host-platform/host-platform.css';
+
+	// G3 — operator components
+	const provisioningSteps: ProvisioningStep[] = [
+		{
+			id: 'allocate',
+			label: 'Allocate compute',
+			status: 'success',
+			timestamp: '2026-05-24T15:00:00Z',
+			meta: '38s',
+		},
+		{
+			id: 'install',
+			label: 'Install Lesser',
+			status: 'success',
+			timestamp: '2026-05-24T15:00:38Z',
+			meta: '1m12s',
+		},
+		{
+			id: 'migrate',
+			label: 'Run migrations',
+			status: 'active',
+			description: 'Applying schema CSR-035 + x402 grant indexes…',
+		},
+		{ id: 'seed', label: 'Seed default data', status: 'pending' },
+		{ id: 'verify', label: 'Verify health checks', status: 'pending' },
+	];
+
+	const releases: ReleaseTimelineItem[] = [
+		{
+			id: 'lesser-v1412',
+			version: 'v1.4.12',
+			channel: 'stable',
+			date: '2026-05-22T00:00:00Z',
+			status: 'shipped',
+			adoption: 0.82,
+			description: 'Stable release — rate-limit headers + 429 responses.',
+		},
+		{
+			id: 'lesser-v1500rc1',
+			version: 'v1.5.0-rc.1',
+			channel: 'beta',
+			date: '2026-05-23T00:00:00Z',
+			status: 'in-progress',
+			adoption: 0.05,
+			description: 'Early-access channel; metrics endpoints stabilizing.',
+		},
+		{
+			id: 'lesser-v1411',
+			version: 'v1.4.11',
+			channel: 'stable',
+			date: '2026-05-18T00:00:00Z',
+			status: 'rolled-back',
+			adoption: 0,
+			description: 'Pulled after CSR-041 OpenAPI gap discovered.',
+		},
+	];
+
+	const stackColumns: StackMatrixColumn[] = [
+		{ id: 'lesser', label: 'Lesser', sortable: true },
+		{ id: 'host', label: 'Lesser Host', sortable: true },
+		{ id: 'body', label: 'Body', sortable: false },
+	];
+
+	let stackRows = $state<StackMatrixRow[]>([
+		{
+			id: 'r-lesser-example',
+			label: 'lesser.example',
+			subLabel: 'us-east-1',
+			cells: {
+				lesser: { value: 'v1.4.12', drift: 'in-sync' },
+				host: { value: 'v0.4.5', drift: 'pending' },
+				body: { value: 'v0.2.1', drift: 'in-sync' },
+			},
+		},
+		{
+			id: 'r-lesser-staging',
+			label: 'lesser.staging',
+			subLabel: 'us-west-2',
+			cells: {
+				lesser: { value: 'v1.4.10', drift: 'drifted' },
+				host: { value: 'v0.4.5', drift: 'in-sync' },
+				body: { value: 'v0.2.0', drift: 'drifted' },
+			},
+		},
+		{
+			id: 'r-lesser-scratch',
+			label: 'lesser.scratch',
+			subLabel: 'eu-central-1',
+			cells: {
+				lesser: { value: 'v1.4.12', drift: 'in-sync' },
+				host: { value: 'v0.4.4', drift: 'drifted' },
+				body: { value: 'unknown', drift: 'unknown' },
+			},
+		},
+	]);
+
+	let stackSortBy = $state<string | undefined>('lesser');
+	let stackSortDirection = $state<StackMatrixSortDirection>('ascending');
+
+	function handleStackSort(columnId: string) {
+		if (stackSortBy === columnId) {
+			stackSortDirection = stackSortDirection === 'ascending' ? 'descending' : 'ascending';
+		} else {
+			stackSortBy = columnId;
+			stackSortDirection = 'ascending';
+		}
+		const direction = stackSortDirection === 'ascending' ? 1 : -1;
+		stackRows = [...stackRows].sort((a, b) => {
+			const av = a.cells[columnId]?.value ?? '';
+			const bv = b.cells[columnId]?.value ?? '';
+			return av.localeCompare(bv) * direction;
+		});
+	}
 </script>
 
 <svelte:head>
@@ -159,6 +282,45 @@ components. Only static stylesheets and class-driven width steps.
 				/>
 			</div>
 		</div>
+	</section>
+
+	<section>
+		<h2>ProvisioningTimeline</h2>
+		<ProvisioningTimeline
+			label="lesser.example provisioning"
+			steps={provisioningSteps}
+			liveLogLabel="Live provisioning log"
+		>
+			{#snippet liveLog()}
+				<pre>
+15:00:00 [allocate] requesting compute node…
+15:00:38 [allocate] node provisioned (1 × t3.medium)
+15:00:38 [install] downloading Lesser v1.4.12 container…
+15:01:50 [install] container started
+15:01:51 [migrate] applying schema CSR-035…</pre>
+			{/snippet}
+		</ProvisioningTimeline>
+	</section>
+
+	<section>
+		<h2>ReleaseTimeline</h2>
+		<ReleaseTimeline label="Lesser release history" {releases} />
+	</section>
+
+	<section>
+		<h2>StackMatrix</h2>
+		<StackMatrix
+			caption="Lesser fleet stack versions"
+			columns={stackColumns}
+			rows={stackRows}
+			sortBy={stackSortBy}
+			sortDirection={stackSortDirection}
+			onsort={handleStackSort}
+		>
+			{#snippet rowActions(row)}
+				<button type="button">Inspect {row.label}</button>
+			{/snippet}
+		</StackMatrix>
 	</section>
 </div>
 

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -1522,13 +1522,16 @@ Hosted-platform data-display components for managed-instance dashboards
 (lesser-host web, sim, operator consoles). Strict-CSP safe, Svelte 5 runes,
 WCAG 2.1 AA; status communication is never color-only.
 
-**Components (3):**
+**Components (6):**
 
-| Component           | Element                                 | Required props     | Snippets / slots                      |
-| ------------------- | --------------------------------------- | ------------------ | ------------------------------------- |
-| `FleetCard`         | `<section>` with auto `aria-labelledby` | `name`             | `icon`, `cost`, `activity`, `actions` |
-| `CostGauge`         | `<div role="meter">`                    | `current`, `limit` | `extra`                               |
-| `ActivitySparkline` | `<svg role="img">` (or `aria-hidden`)   | `data`             | —                                     |
+| Component              | Element                                                                      | Required props               | Snippets / slots                                     |
+| ---------------------- | ---------------------------------------------------------------------------- | ---------------------------- | ---------------------------------------------------- |
+| `FleetCard`            | `<section>` with auto `aria-labelledby`                                      | `name`                       | `icon`, `cost`, `activity`, `actions`                |
+| `CostGauge`            | `<div role="meter">` (or `role="img"` for invalid ranges)                    | `current`, `limit`           | `extra`                                              |
+| `ActivitySparkline`    | `<svg role="img">` (or `aria-hidden`)                                        | `data`                       | —                                                    |
+| `ProvisioningTimeline` | `<section>` + `<ol>` with `aria-current="step"`                              | `label`, `steps`             | `liveLog`                                            |
+| `ReleaseTimeline`      | `<section>` + `<ol>` with `<time datetime>` + nested `role="meter"` adoption | `label`, `releases`          | `itemActions(release)`                               |
+| `StackMatrix`          | `<table>` with `<caption>`, `<th scope>`, `aria-sort`                        | `caption`, `columns`, `rows` | `cellRenderer(cell, row, column)`, `rowActions(row)` |
 
 **Key prop unions** (from `@equaltoai/greater-components/host-platform/types`):
 
@@ -1539,6 +1542,18 @@ WCAG 2.1 AA; status communication is never color-only.
 - `CostGaugeThresholds = { warning?: number; danger?: number }` (ratios in `[0, 1]`)
 - `CostValueFormatter = (value: number, currency: string | undefined) => string`
 - `ActivitySparklineTone = 'default' | 'success' | 'warning' | 'danger' | 'info'`
+- `ProvisioningStepStatus = 'pending' | 'active' | 'success' | 'failure' | 'skipped'`
+- `ProvisioningLogPoliteness = 'off' | 'polite' | 'assertive'`
+- `ProvisioningStep = { id: string; label: string; description?: string; status?: ProvisioningStepStatus; timestamp?: string; meta?: string }`
+- `ReleaseStatus = 'shipped' | 'in-progress' | 'rolled-back' | 'planned'`
+- `ReleaseChannel = string` (conventionally `'stable'` / `'beta'`)
+- `ReleaseTimelineItem = { id: string; version: string; channel: ReleaseChannel; date: Date | string; status?: ReleaseStatus; adoption?: number | string; description?: string; href?: string }`
+- `ReleaseAdoptionFormatter = (adoption: number | string | undefined) => string | undefined`
+- `StackMatrixDrift = 'in-sync' | 'pending' | 'drifted' | 'unknown'`
+- `StackMatrixColumn = { id: string; label: string; sortable?: boolean }`
+- `StackMatrixCell = { value: string; drift?: StackMatrixDrift; description?: string }`
+- `StackMatrixRow = { id: string; label: string; subLabel?: string; cells: Record<string, StackMatrixCell> }`
+- `StackMatrixSortDirection = 'ascending' | 'descending' | 'none'`
 
 **Accessibility:**
 
@@ -1552,6 +1567,23 @@ WCAG 2.1 AA; status communication is never color-only.
 - `ActivitySparkline` defaults to informative — `<svg role="img" aria-labelledby
 aria-describedby>` with real `<title>` / optional `<desc>` children. Opt
   into `decorative={true}` only when a textual equivalent exists adjacent.
+- `ProvisioningTimeline` renders a semantic `<ol>` of steps with
+  `aria-current="step"` on the active step. The optional live-log slot is
+  wrapped in `<section role="log" aria-live="polite" aria-atomic="false"
+aria-relevant="additions">` so AT users hear only NEW log lines, not the
+  whole backlog on each update. `liveLogPoliteness` configurable to
+  `'assertive'` (urgent failures) or `'off'` (visible-only).
+- `ReleaseTimeline` exposes channel via `aria-label`, dates via `<time
+datetime>`, and numeric adoption as a nested `role="meter"` with `[0, 1]`
+  range and composed `aria-valuetext` (e.g. `"Adoption: 42%"`). String
+  adoption renders as static text (no fake meter range).
+- `StackMatrix` is a real `<table>` with `<caption>` (visually-hidden by
+  default), `<th scope="col">` column headers, `<th scope="row">` row
+  headers, and `aria-sort` on the currently-sorted column. Sortable column
+  headers render as `<button>` elements with the keyboard contract natively
+  handled by the browser; consumers receive the column id via `onsort`
+  and re-supply `rows` in the desired order. Per-row actions are wrapped
+  in `<div role="group">` with a row-specific accessible name.
 - All ids are unique across multiple instances via `useStableId`.
 
 **Strict CSP:**
@@ -1607,7 +1639,7 @@ The package exports three dependency-free utilities, also available via
 greater add host-platform
 ```
 
-This copies the 3 components, their CSS, types, formatters, sparkline-path
+This copies the 6 components, their CSS, types, formatters, sparkline-path
 utility, and the barrel into the consumer's `$lib/greater/host-platform`
 directory. The CLI registry validates per-file checksums on install.
 

--- a/docs/component-inventory.md
+++ b/docs/component-inventory.md
@@ -1411,11 +1411,11 @@ Minimum host wiring:
 
 ### Package Scope
 
-This package provides **3 hosted-platform data-display components** designed for
-managed-instance dashboards (lesser-host web, sim, operator consoles). It is
-intentionally separate from `shell` and `faces/*`: `shell` is the generic
-app-shell surface, `faces/*` are protocol-aware Fediverse UI suites, and
-`host-platform` is the **operator / platform console surface**.
+This package provides **6 hosted-platform data-display and operator components**
+designed for managed-instance dashboards (lesser-host web, sim, operator
+consoles). It is intentionally separate from `shell` and `faces/*`: `shell`
+is the generic app-shell surface, `faces/*` are protocol-aware Fediverse UI
+suites, and `host-platform` is the **operator / platform console surface**.
 
 **What Host-platform Provides:**
 
@@ -1427,34 +1427,65 @@ app-shell surface, `faces/*` are protocol-aware Fediverse UI suites, and
 - `ActivitySparkline` — inline SVG trend with explicit `<title>` / `<desc>`
   for informative usage, or `aria-hidden` decorative mode when a textual
   equivalent exists nearby
+- `ProvisioningTimeline` — ordered timeline of provisioning steps with
+  `aria-current="step"` on the active step, status icon glyph + text label,
+  and an optional constrained live-log region (`role="log"` + polite/
+  assertive `aria-live`)
+- `ReleaseTimeline` — two-channel release history with accessible dates
+  (`<time datetime>`), status icon + text, and adoption metric rendered as
+  a valid `role="meter"` when numeric (0–1) or static text otherwise
+- `StackMatrix` — semantic `<table>` of stack / version drift with optional
+  sortable headers (`aria-sort`), non-color-only drift indicators, and a
+  per-row CTA slot
 
 **What Host-platform Does NOT Provide:**
 
 ❌ NO data fetching (presentational; bring your own adapters)
-❌ NO Lesser Host adapter (consumer passes already-shaped data; contract sync deferred per #635)
-❌ NO chart library (sparkline is the only data-viz primitive)
-❌ NO billing / invoice surfaces (out of scope for G2; deferred to a future hosted-platform milestone)
+❌ NO Lesser Host adapter (consumer passes already-shaped data; contract sync deferred per #635 / #636)
+❌ NO chart library (sparkline is the only data-viz primitive; richer visualization belongs in a future dedicated package or a consumer-vendored chart lib)
+❌ NO billing / invoice surfaces (out of scope; deferred to a future hosted-platform milestone)
 
-### All 3 Components
+### All 6 Components
 
-| Component             | Element                                 | Required props     | Snippets / slots                      |
-| --------------------- | --------------------------------------- | ------------------ | ------------------------------------- |
-| **FleetCard**         | `<section>` with auto `aria-labelledby` | `name`             | `icon`, `cost`, `activity`, `actions` |
-| **CostGauge**         | `<div role="meter">`                    | `current`, `limit` | `extra`                               |
-| **ActivitySparkline** | `<svg role="img">` (or `aria-hidden`)   | `data`             | —                                     |
+| Component                | Element                                                                      | Required props               | Snippets / slots                                     |
+| ------------------------ | ---------------------------------------------------------------------------- | ---------------------------- | ---------------------------------------------------- |
+| **FleetCard**            | `<section>` with auto `aria-labelledby`                                      | `name`                       | `icon`, `cost`, `activity`, `actions`                |
+| **CostGauge**            | `<div role="meter">` (or `role="img"` for invalid ranges)                    | `current`, `limit`           | `extra`                                              |
+| **ActivitySparkline**    | `<svg role="img">` (or `aria-hidden`)                                        | `data`                       | —                                                    |
+| **ProvisioningTimeline** | `<section>` + `<ol>` with `aria-current="step"`                              | `label`, `steps`             | `liveLog`                                            |
+| **ReleaseTimeline**      | `<section>` + `<ol>` with `<time datetime>` + nested `role="meter"` adoption | `label`, `releases`          | `itemActions(release)`                               |
+| **StackMatrix**          | `<table>` with `<caption>`, `<thead>`, `<th scope>`, `aria-sort`             | `caption`, `columns`, `rows` | `cellRenderer(cell, row, column)`, `rowActions(row)` |
 
 ### Accessibility guarantees
 
-- **Status is never color-only.** Every `FleetCardStatus` and `CostGaugeStatus`
-  ships an icon glyph + visible text label inside the badge / readout in
-  addition to any color tint.
-- **CostGauge uses `role="meter"`** with `aria-valuenow`, `aria-valuemin`,
-  `aria-valuemax`, and `aria-valuetext` so AT announces the precise numeric
-  value (e.g. "$42.50 of $100.00") rather than a coarse percentage.
+- **Status is never color-only.** Every `FleetCardStatus`, `CostGaugeStatus`,
+  `ProvisioningStepStatus`, `ReleaseStatus`, and `StackMatrixDrift` ships
+  an icon glyph + visible text label inside the badge / readout in addition
+  to any color tint.
+- **CostGauge uses `role="meter"`** with clamped `aria-valuenow` into a
+  valid `[aria-valuemin, aria-valuemax]` range. When the consumer-supplied
+  limit makes the range invalid (`limit <= 0` or non-finite), the gauge
+  falls back to `role="img"` with a composed `aria-labelledby` so AT users
+  still receive the current / limit values without violating the meter
+  contract.
 - **ActivitySparkline defaults to informative.** When `decorative === false`
   (the default), the SVG has `role="img"` + `<title>` + optional `<desc>`.
   Consumers opt into `decorative={true}` only when a textual equivalent
   exists adjacent.
+- **ProvisioningTimeline** marks the active step with `aria-current="step"`.
+  The optional live-log region uses `role="log"` with `aria-live="polite"`
+  (default; configurable to `assertive` or `off`), `aria-atomic="false"`,
+  and `aria-relevant="additions"` so AT users hear only NEW log lines
+  rather than the entire backlog on each update.
+- **ReleaseTimeline** exposes channel via `aria-label`, dates via
+  `<time datetime>`, and numeric adoption as a `role="meter"` with a
+  valid `[0, 1]` range and composed `aria-valuetext` (e.g. `"Adoption: 42%"`).
+  String adoption renders as static text (no fake meter range).
+- **StackMatrix** is a real `<table>` with `<caption>` (visually-hidden by
+  default but available to AT), `<th scope="col">` column headers,
+  `<th scope="row">` row headers, and `aria-sort` on the currently-sorted
+  column. Per-row actions live inside `<div role="group">` with a
+  row-specific accessible name.
 - **All ids unique across multiple instances** via `useStableId`.
 - **Strict CSP safe.** No inline event handlers; no `style` attributes set
   at runtime. The CostGauge fill width is driven by a `data-ratio`

--- a/packages/cli/src/registry/index.ts
+++ b/packages/cli/src/registry/index.ts
@@ -219,12 +219,21 @@ export const componentRegistry: Record<string, ComponentMetadata> = {
 		name: 'host-platform',
 		type: 'shared',
 		description:
-			'Hosted-platform data-display components (FleetCard, CostGauge, ActivitySparkline) for managed-instance dashboards (lesser-host, sim, operator consoles)',
+			'Hosted-platform data-display + operator components (FleetCard, CostGauge, ActivitySparkline, ProvisioningTimeline, ReleaseTimeline, StackMatrix) for managed-instance dashboards (lesser-host, sim, operator consoles)',
 		files: [{ path: 'greater/host-platform/index.ts', content: '', type: 'component' }],
 		dependencies: [],
 		devDependencies: [],
 		registryDependencies: ['tokens', 'utils'],
-		tags: ['core', 'host-platform', 'data-display', 'meter', 'sparkline'],
+		tags: [
+			'core',
+			'host-platform',
+			'data-display',
+			'meter',
+			'sparkline',
+			'timeline',
+			'matrix',
+			'operator',
+		],
 		version: '1.0.0',
 	},
 

--- a/packages/host-platform/package.json
+++ b/packages/host-platform/package.json
@@ -35,6 +35,21 @@
       "svelte": "./dist/components/ActivitySparkline.svelte",
       "import": "./dist/components/ActivitySparkline.svelte"
     },
+    "./ProvisioningTimeline": {
+      "types": "./dist/components/ProvisioningTimeline.svelte.d.ts",
+      "svelte": "./dist/components/ProvisioningTimeline.svelte",
+      "import": "./dist/components/ProvisioningTimeline.svelte"
+    },
+    "./ReleaseTimeline": {
+      "types": "./dist/components/ReleaseTimeline.svelte.d.ts",
+      "svelte": "./dist/components/ReleaseTimeline.svelte",
+      "import": "./dist/components/ReleaseTimeline.svelte"
+    },
+    "./StackMatrix": {
+      "types": "./dist/components/StackMatrix.svelte.d.ts",
+      "svelte": "./dist/components/StackMatrix.svelte",
+      "import": "./dist/components/StackMatrix.svelte"
+    },
     "./components/*.svelte": {
       "types": "./dist/components/*.svelte.d.ts",
       "svelte": "./dist/components/*.svelte",

--- a/packages/host-platform/src/components/ProvisioningTimeline.css
+++ b/packages/host-platform/src/components/ProvisioningTimeline.css
@@ -1,0 +1,191 @@
+.gr-host-platform-provisioning-timeline {
+	display: flex;
+	flex-direction: column;
+	gap: var(--gr-host-platform-gap-md);
+	min-width: 0;
+}
+
+.gr-host-platform-provisioning-timeline__empty {
+	padding: var(--gr-host-platform-gap-md) var(--gr-host-platform-gutter);
+	color: var(--gr-semantic-foreground-tertiary, var(--gr-color-gray-500, #6b7280));
+	background: var(--gr-semantic-background-secondary, var(--gr-color-gray-50, #f9fafb));
+	border: 1px dashed var(--gr-semantic-border-subtle, var(--gr-color-gray-200, #e5e7eb));
+	border-radius: var(--gr-host-platform-radius);
+	font-size: 0.875rem;
+}
+
+.gr-host-platform-provisioning-timeline__list {
+	margin: 0;
+	padding: 0;
+	list-style: none;
+	display: flex;
+	flex-direction: column;
+}
+
+.gr-host-platform-provisioning-timeline__step {
+	display: grid;
+	grid-template-columns: 1.5rem 1fr;
+	gap: var(--gr-host-platform-gap-md);
+	padding: 0;
+	min-width: 0;
+}
+
+.gr-host-platform-provisioning-timeline__rail {
+	display: flex;
+	flex-direction: column;
+	align-items: center;
+	min-height: 1.5rem;
+}
+
+.gr-host-platform-provisioning-timeline__marker {
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	width: 1.5rem;
+	height: 1.5rem;
+	border-radius: 999px;
+	background: var(--gr-semantic-background-secondary, var(--gr-color-gray-100, #f3f4f6));
+	border: 1px solid var(--gr-semantic-border-subtle, var(--gr-color-gray-200, #e5e7eb));
+	color: var(--gr-semantic-foreground-primary, var(--gr-color-gray-900, #111827));
+	font-size: 0.75rem;
+	font-weight: 700;
+	flex-shrink: 0;
+}
+
+.gr-host-platform-provisioning-timeline__line {
+	width: 1px;
+	flex: 1 1 auto;
+	background: var(--gr-semantic-border-subtle, var(--gr-color-gray-200, #e5e7eb));
+	margin-block: 0.25rem;
+	min-height: 1rem;
+}
+
+.gr-host-platform-provisioning-timeline__body {
+	padding-bottom: var(--gr-host-platform-gap-md);
+	min-width: 0;
+}
+
+.gr-host-platform-provisioning-timeline__step:last-child
+	.gr-host-platform-provisioning-timeline__body {
+	padding-bottom: 0;
+}
+
+.gr-host-platform-provisioning-timeline__header {
+	display: flex;
+	flex-wrap: wrap;
+	align-items: center;
+	gap: var(--gr-host-platform-gap-sm);
+	min-width: 0;
+}
+
+.gr-host-platform-provisioning-timeline__label {
+	font-weight: 600;
+	color: var(--gr-semantic-foreground-primary, var(--gr-color-gray-900, #111827));
+	min-width: 0;
+}
+
+.gr-host-platform-provisioning-timeline__status {
+	display: inline-flex;
+	align-items: center;
+	gap: 0.25rem;
+	padding: 0.0625rem 0.5rem;
+	border-radius: 999px;
+	font-size: 0.75rem;
+	font-weight: 600;
+	border: 1px solid transparent;
+	flex-shrink: 0;
+}
+
+.gr-host-platform-provisioning-timeline__step--status-pending
+	.gr-host-platform-provisioning-timeline__status {
+	background: var(--gr-semantic-background-secondary, var(--gr-color-gray-100, #f3f4f6));
+	color: var(--gr-semantic-foreground-secondary, var(--gr-color-gray-700, #374151));
+	border-color: var(--gr-semantic-border-subtle, var(--gr-color-gray-200, #e5e7eb));
+}
+.gr-host-platform-provisioning-timeline__step--status-active
+	.gr-host-platform-provisioning-timeline__status {
+	background: var(--gr-color-info-50, #eff6ff);
+	color: var(--gr-color-info-900, #1e3a8a);
+	border-color: var(--gr-color-info-300, #93c5fd);
+}
+.gr-host-platform-provisioning-timeline__step--status-active
+	.gr-host-platform-provisioning-timeline__marker {
+	background: var(--gr-color-info-100, #dbeafe);
+	color: var(--gr-color-info-700, #1d4ed8);
+	border-color: var(--gr-color-info-300, #93c5fd);
+}
+.gr-host-platform-provisioning-timeline__step--status-success
+	.gr-host-platform-provisioning-timeline__status {
+	background: var(--gr-color-success-50, #f0fdf4);
+	color: var(--gr-color-success-900, #14532d);
+	border-color: var(--gr-color-success-300, #86efac);
+}
+.gr-host-platform-provisioning-timeline__step--status-success
+	.gr-host-platform-provisioning-timeline__marker {
+	background: var(--gr-color-success-100, #dcfce7);
+	color: var(--gr-color-success-700, #15803d);
+	border-color: var(--gr-color-success-300, #86efac);
+}
+.gr-host-platform-provisioning-timeline__step--status-failure
+	.gr-host-platform-provisioning-timeline__status {
+	background: var(--gr-color-error-50, #fef2f2);
+	color: var(--gr-color-error-900, #7f1d1d);
+	border-color: var(--gr-color-error-300, #fca5a5);
+}
+.gr-host-platform-provisioning-timeline__step--status-failure
+	.gr-host-platform-provisioning-timeline__marker {
+	background: var(--gr-color-error-100, #fee2e2);
+	color: var(--gr-color-error-700, #b91c1c);
+	border-color: var(--gr-color-error-300, #fca5a5);
+}
+.gr-host-platform-provisioning-timeline__step--status-skipped
+	.gr-host-platform-provisioning-timeline__status {
+	background: var(--gr-semantic-background-secondary, var(--gr-color-gray-100, #f3f4f6));
+	color: var(--gr-semantic-foreground-tertiary, var(--gr-color-gray-500, #6b7280));
+	border-color: var(--gr-semantic-border-subtle, var(--gr-color-gray-200, #e5e7eb));
+}
+
+.gr-host-platform-provisioning-timeline__description {
+	margin: 0.25rem 0 0;
+	font-size: 0.875rem;
+	color: var(--gr-semantic-foreground-secondary, var(--gr-color-gray-700, #374151));
+}
+
+.gr-host-platform-provisioning-timeline__meta {
+	margin: 0.25rem 0 0;
+	display: flex;
+	flex-wrap: wrap;
+	gap: var(--gr-host-platform-gap-sm);
+	font-size: 0.75rem;
+	color: var(--gr-semantic-foreground-tertiary, var(--gr-color-gray-500, #6b7280));
+}
+
+.gr-host-platform-provisioning-timeline__time {
+	font-family: var(--gr-typography-fontFamily-mono, ui-monospace, SFMono-Regular, Menlo, monospace);
+}
+
+.gr-host-platform-provisioning-timeline__log {
+	display: flex;
+	flex-direction: column;
+	gap: 0.25rem;
+	background: var(--gr-semantic-background-secondary, var(--gr-color-gray-50, #f9fafb));
+	border: 1px solid var(--gr-semantic-border-subtle, var(--gr-color-gray-200, #e5e7eb));
+	border-radius: var(--gr-host-platform-radius);
+	padding: var(--gr-host-platform-gap-sm) var(--gr-host-platform-gap-md);
+}
+
+.gr-host-platform-provisioning-timeline__log-label {
+	margin: 0;
+	font-size: 0.8125rem;
+	font-weight: 600;
+	color: var(--gr-semantic-foreground-secondary, var(--gr-color-gray-700, #374151));
+}
+
+.gr-host-platform-provisioning-timeline__log-body {
+	font-family: var(--gr-typography-fontFamily-mono, ui-monospace, SFMono-Regular, Menlo, monospace);
+	font-size: 0.8125rem;
+	line-height: 1.4;
+	max-height: 12rem;
+	overflow-y: auto;
+	color: var(--gr-semantic-foreground-primary, var(--gr-color-gray-900, #111827));
+}

--- a/packages/host-platform/src/components/ProvisioningTimeline.svelte
+++ b/packages/host-platform/src/components/ProvisioningTimeline.svelte
@@ -186,20 +186,48 @@ runtime style writes. All styling via stable `--gr-*` tokens.
 	{/if}
 
 	{#if liveLog}
-		<section
-			class="gr-host-platform-provisioning-timeline__log"
-			role="log"
-			aria-live={liveLogPoliteness === 'off' ? undefined : liveLogPoliteness}
-			aria-atomic="false"
-			aria-relevant="additions"
-			aria-labelledby={logLabelId}
-		>
-			<h3 id={logLabelId} class="gr-host-platform-provisioning-timeline__log-label">
-				{liveLogLabel}
-			</h3>
-			<div class="gr-host-platform-provisioning-timeline__log-body">
-				{@render liveLog()}
-			</div>
-		</section>
+		<!--
+			When `liveLogPoliteness === 'off'`, we MUST drop `role="log"`
+			entirely — not just `aria-live`. `role="log"` has implicit polite
+			live-region semantics in screen readers; merely omitting `aria-live`
+			leaves the role's implicit announcements in place. Arch flagged this
+			in PR #670 review. For the off-case we render a plain `<section
+			aria-labelledby>` so the consumer's log still appears visibly but
+			never announces to AT.
+
+			Polite / assertive paths keep `role="log"` and the matching
+			`aria-live`, with `aria-atomic="false"` + `aria-relevant="additions"`
+			so AT users hear only NEW lines, not the entire backlog on each
+			update.
+		-->
+		{#if liveLogPoliteness === 'off'}
+			<section
+				class="gr-host-platform-provisioning-timeline__log gr-host-platform-provisioning-timeline__log--quiet"
+				aria-labelledby={logLabelId}
+			>
+				<h3 id={logLabelId} class="gr-host-platform-provisioning-timeline__log-label">
+					{liveLogLabel}
+				</h3>
+				<div class="gr-host-platform-provisioning-timeline__log-body">
+					{@render liveLog()}
+				</div>
+			</section>
+		{:else}
+			<section
+				class="gr-host-platform-provisioning-timeline__log"
+				role="log"
+				aria-live={liveLogPoliteness}
+				aria-atomic="false"
+				aria-relevant="additions"
+				aria-labelledby={logLabelId}
+			>
+				<h3 id={logLabelId} class="gr-host-platform-provisioning-timeline__log-label">
+					{liveLogLabel}
+				</h3>
+				<div class="gr-host-platform-provisioning-timeline__log-body">
+					{@render liveLog()}
+				</div>
+			</section>
+		{/if}
 	{/if}
 </section>

--- a/packages/host-platform/src/components/ProvisioningTimeline.svelte
+++ b/packages/host-platform/src/components/ProvisioningTimeline.svelte
@@ -1,0 +1,205 @@
+<!--
+@component
+ProvisioningTimeline — ordered timeline of provisioning job steps for
+hosted-platform operator consoles.
+
+Renders an `<ol>` (semantic ordered list) inside a `<section
+aria-labelledby>` landmark. Each step is an `<li>` with status icon
+glyph + visible text label (never color-only), description, optional
+timestamp, and optional metadata. The *active* step (status='active')
+also carries `aria-current="step"` so AT users hear which step is in
+progress.
+
+When the consumer supplies a `liveLog` snippet, the component wraps it
+in a constrained `<section role="log" aria-live aria-atomic="false"
+aria-labelledby>` region so only NEW log lines announce — never the
+full backlog. `liveLogPoliteness` defaults to `'polite'`; set to
+`'off'` for visible-only logs.
+
+Strict-CSP safe: no inline event handlers, no `style` attributes, no
+runtime style writes. All styling via stable `--gr-*` tokens.
+
+@example
+```svelte
+<ProvisioningTimeline
+	label="lesser.example provisioning"
+	steps={[
+		{ id: 'allocate', label: 'Allocate compute', status: 'success', timestamp: '2026-05-24T15:00:00Z' },
+		{ id: 'install',  label: 'Install Lesser',   status: 'active' },
+		{ id: 'migrate',  label: 'Run migrations',   status: 'pending' },
+	]}
+>
+	{#snippet liveLog()}
+		<pre>15:01:02 [allocate] node provisioned…
+15:01:34 [install] downloading container…</pre>
+	{/snippet}
+</ProvisioningTimeline>
+```
+-->
+<script lang="ts">
+	import type { HTMLAttributes } from 'svelte/elements';
+	import type { Snippet } from 'svelte';
+	import { useStableId } from '@equaltoai/greater-components-utils';
+	import type {
+		ProvisioningLogPoliteness,
+		ProvisioningStep,
+		ProvisioningStepStatus,
+	} from '../types.js';
+
+	interface Props extends Omit<HTMLAttributes<HTMLElement>, 'aria-label'> {
+		/** Required accessible name for the timeline region. @public */
+		label: string;
+
+		/** Ordered steps (renders in array order). @public */
+		steps: ProvisioningStep[];
+
+		/**
+		 * Constrained live-log slot. When provided, the component wraps the
+		 * rendered content in a `<section role="log">` with `aria-live` so
+		 * new log lines announce politely. The consumer is responsible for
+		 * APPENDING new content (the live region announces incremental
+		 * changes; full re-renders are noisy).
+		 * @public
+		 */
+		liveLog?: Snippet;
+
+		/**
+		 * Accessible name for the live-log region. Defaults to
+		 * `'Live provisioning log'`. Strongly recommended to override when
+		 * multiple timelines coexist on a page.
+		 * @public
+		 */
+		liveLogLabel?: string;
+
+		/**
+		 * ARIA politeness for the live-log region. `'off'` disables
+		 * announcements while keeping the visible log. Defaults to `'polite'`.
+		 * @public
+		 */
+		liveLogPoliteness?: ProvisioningLogPoliteness;
+
+		/** Message rendered when `steps.length === 0`. @public */
+		emptyMessage?: string;
+
+		/** Additional CSS classes. @public */
+		class?: string;
+	}
+
+	let {
+		label,
+		steps,
+		liveLog,
+		liveLogLabel = 'Live provisioning log',
+		liveLogPoliteness = 'polite',
+		emptyMessage = 'No provisioning steps yet.',
+		class: className = '',
+		style: _style,
+		...restProps
+	}: Props = $props();
+
+	const stableId = useStableId('host-prov-timeline');
+	const labelId = $derived(stableId.value ? `${stableId.value}-label` : undefined);
+	const logLabelId = $derived(stableId.value ? `${stableId.value}-log-label` : undefined);
+
+	const statusInfo = $derived.by(() => {
+		const map: Record<ProvisioningStepStatus, { icon: string; label: string }> = {
+			pending: { icon: '○', label: 'Pending' },
+			active: { icon: '◌', label: 'In progress' },
+			success: { icon: '✓', label: 'Completed' },
+			failure: { icon: '✕', label: 'Failed' },
+			skipped: { icon: '—', label: 'Skipped' },
+		};
+		return map;
+	});
+
+	const rootClass = $derived(() =>
+		['gr-host-platform-provisioning-timeline', className].filter(Boolean).join(' ')
+	);
+
+	const hasSteps = $derived(steps.length > 0);
+</script>
+
+<section class={rootClass()} aria-labelledby={labelId} {...restProps}>
+	<h2 id={labelId} class="gr-sr-only">{label}</h2>
+
+	{#if !hasSteps}
+		<div class="gr-host-platform-provisioning-timeline__empty" role="status">
+			{emptyMessage}
+		</div>
+	{:else}
+		<ol class="gr-host-platform-provisioning-timeline__list">
+			{#each steps as step, index (step.id)}
+				{@const status = step.status ?? 'pending'}
+				{@const info = statusInfo[status]}
+				<li
+					id={stableId.value ? `${stableId.value}-step-${step.id}` : undefined}
+					class={[
+						'gr-host-platform-provisioning-timeline__step',
+						`gr-host-platform-provisioning-timeline__step--status-${status}`,
+					].join(' ')}
+					aria-current={status === 'active' ? 'step' : undefined}
+				>
+					<span class="gr-host-platform-provisioning-timeline__rail" aria-hidden="true">
+						<span class="gr-host-platform-provisioning-timeline__marker">{info.icon}</span>
+						{#if index < steps.length - 1}
+							<span class="gr-host-platform-provisioning-timeline__line"></span>
+						{/if}
+					</span>
+					<div class="gr-host-platform-provisioning-timeline__body">
+						<div class="gr-host-platform-provisioning-timeline__header">
+							<span class="gr-host-platform-provisioning-timeline__label">{step.label}</span>
+							<span
+								class="gr-host-platform-provisioning-timeline__status"
+								aria-label={`Status: ${info.label}`}
+							>
+								<span class="gr-host-platform-provisioning-timeline__status-text">
+									{info.label}
+								</span>
+							</span>
+						</div>
+						{#if step.description}
+							<p class="gr-host-platform-provisioning-timeline__description">
+								{step.description}
+							</p>
+						{/if}
+						{#if step.timestamp || step.meta}
+							<p class="gr-host-platform-provisioning-timeline__meta">
+								{#if step.timestamp}
+									<time
+										class="gr-host-platform-provisioning-timeline__time"
+										datetime={step.timestamp}
+									>
+										{step.timestamp}
+									</time>
+								{/if}
+								{#if step.meta}
+									<span class="gr-host-platform-provisioning-timeline__meta-text">
+										{step.meta}
+									</span>
+								{/if}
+							</p>
+						{/if}
+					</div>
+				</li>
+			{/each}
+		</ol>
+	{/if}
+
+	{#if liveLog}
+		<section
+			class="gr-host-platform-provisioning-timeline__log"
+			role="log"
+			aria-live={liveLogPoliteness === 'off' ? undefined : liveLogPoliteness}
+			aria-atomic="false"
+			aria-relevant="additions"
+			aria-labelledby={logLabelId}
+		>
+			<h3 id={logLabelId} class="gr-host-platform-provisioning-timeline__log-label">
+				{liveLogLabel}
+			</h3>
+			<div class="gr-host-platform-provisioning-timeline__log-body">
+				{@render liveLog()}
+			</div>
+		</section>
+	{/if}
+</section>

--- a/packages/host-platform/src/components/ReleaseTimeline.css
+++ b/packages/host-platform/src/components/ReleaseTimeline.css
@@ -1,0 +1,175 @@
+.gr-host-platform-release-timeline {
+	display: flex;
+	flex-direction: column;
+	gap: var(--gr-host-platform-gap-md);
+	min-width: 0;
+}
+
+.gr-host-platform-release-timeline__empty {
+	padding: var(--gr-host-platform-gap-md) var(--gr-host-platform-gutter);
+	color: var(--gr-semantic-foreground-tertiary, var(--gr-color-gray-500, #6b7280));
+	background: var(--gr-semantic-background-secondary, var(--gr-color-gray-50, #f9fafb));
+	border: 1px dashed var(--gr-semantic-border-subtle, var(--gr-color-gray-200, #e5e7eb));
+	border-radius: var(--gr-host-platform-radius);
+	font-size: 0.875rem;
+}
+
+.gr-host-platform-release-timeline__list {
+	margin: 0;
+	padding: 0;
+	list-style: none;
+	display: flex;
+	flex-direction: column;
+}
+
+.gr-host-platform-release-timeline__release {
+	display: grid;
+	grid-template-columns: 1.5rem 1fr;
+	gap: var(--gr-host-platform-gap-md);
+	padding-bottom: var(--gr-host-platform-gap-md);
+	min-width: 0;
+}
+.gr-host-platform-release-timeline__release:last-child {
+	padding-bottom: 0;
+}
+
+.gr-host-platform-release-timeline__rail {
+	display: flex;
+	flex-direction: column;
+	align-items: center;
+}
+
+.gr-host-platform-release-timeline__marker {
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	width: 1.5rem;
+	height: 1.5rem;
+	border-radius: 999px;
+	background: var(--gr-semantic-background-secondary, var(--gr-color-gray-100, #f3f4f6));
+	border: 1px solid var(--gr-semantic-border-subtle, var(--gr-color-gray-200, #e5e7eb));
+	color: var(--gr-semantic-foreground-primary, var(--gr-color-gray-900, #111827));
+	font-size: 0.75rem;
+	font-weight: 700;
+}
+
+.gr-host-platform-release-timeline__body {
+	min-width: 0;
+}
+
+.gr-host-platform-release-timeline__header {
+	display: flex;
+	flex-wrap: wrap;
+	align-items: center;
+	gap: var(--gr-host-platform-gap-sm);
+	min-width: 0;
+}
+
+.gr-host-platform-release-timeline__version {
+	font-weight: 600;
+	font-family: var(--gr-typography-fontFamily-mono, ui-monospace, SFMono-Regular, Menlo, monospace);
+}
+
+.gr-host-platform-release-timeline__channel {
+	display: inline-flex;
+	align-items: center;
+	padding: 0.0625rem 0.5rem;
+	border-radius: 999px;
+	font-size: 0.6875rem;
+	font-weight: 700;
+	letter-spacing: 0.05em;
+	text-transform: uppercase;
+	background: var(--gr-semantic-background-secondary, var(--gr-color-gray-100, #f3f4f6));
+	color: var(--gr-semantic-foreground-secondary, var(--gr-color-gray-700, #374151));
+	border: 1px solid var(--gr-semantic-border-subtle, var(--gr-color-gray-200, #e5e7eb));
+}
+.gr-host-platform-release-timeline__release--channel-stable
+	.gr-host-platform-release-timeline__channel {
+	background: var(--gr-color-success-100, #dcfce7);
+	color: var(--gr-color-success-900, #14532d);
+	border-color: var(--gr-color-success-300, #86efac);
+}
+.gr-host-platform-release-timeline__release--channel-beta
+	.gr-host-platform-release-timeline__channel {
+	background: var(--gr-color-warning-100, #fef3c7);
+	color: var(--gr-color-warning-900, #78350f);
+	border-color: var(--gr-color-warning-300, #fcd34d);
+}
+
+.gr-host-platform-release-timeline__status {
+	display: inline-flex;
+	align-items: center;
+	padding: 0.0625rem 0.5rem;
+	border-radius: 999px;
+	font-size: 0.75rem;
+	font-weight: 600;
+	border: 1px solid transparent;
+}
+.gr-host-platform-release-timeline__release--status-shipped
+	.gr-host-platform-release-timeline__status,
+.gr-host-platform-release-timeline__release--status-shipped
+	.gr-host-platform-release-timeline__marker {
+	background: var(--gr-color-success-50, #f0fdf4);
+	color: var(--gr-color-success-900, #14532d);
+	border-color: var(--gr-color-success-300, #86efac);
+}
+.gr-host-platform-release-timeline__release--status-in-progress
+	.gr-host-platform-release-timeline__status,
+.gr-host-platform-release-timeline__release--status-in-progress
+	.gr-host-platform-release-timeline__marker {
+	background: var(--gr-color-info-50, #eff6ff);
+	color: var(--gr-color-info-900, #1e3a8a);
+	border-color: var(--gr-color-info-300, #93c5fd);
+}
+.gr-host-platform-release-timeline__release--status-rolled-back
+	.gr-host-platform-release-timeline__status,
+.gr-host-platform-release-timeline__release--status-rolled-back
+	.gr-host-platform-release-timeline__marker {
+	background: var(--gr-color-error-50, #fef2f2);
+	color: var(--gr-color-error-900, #7f1d1d);
+	border-color: var(--gr-color-error-300, #fca5a5);
+}
+.gr-host-platform-release-timeline__release--status-planned
+	.gr-host-platform-release-timeline__status,
+.gr-host-platform-release-timeline__release--status-planned
+	.gr-host-platform-release-timeline__marker {
+	background: var(--gr-semantic-background-secondary, var(--gr-color-gray-100, #f3f4f6));
+	color: var(--gr-semantic-foreground-secondary, var(--gr-color-gray-700, #374151));
+	border-color: var(--gr-semantic-border-subtle, var(--gr-color-gray-200, #e5e7eb));
+}
+
+.gr-host-platform-release-timeline__date {
+	font-size: 0.8125rem;
+	color: var(--gr-semantic-foreground-tertiary, var(--gr-color-gray-500, #6b7280));
+	font-family: var(--gr-typography-fontFamily-mono, ui-monospace, SFMono-Regular, Menlo, monospace);
+	margin-inline-start: auto;
+}
+
+.gr-host-platform-release-timeline__description {
+	margin: 0.25rem 0 0;
+	font-size: 0.875rem;
+	color: var(--gr-semantic-foreground-secondary, var(--gr-color-gray-700, #374151));
+}
+
+.gr-host-platform-release-timeline__adoption,
+.gr-host-platform-release-timeline__adoption-static {
+	margin: 0.375rem 0 0;
+	font-size: 0.8125rem;
+	color: var(--gr-semantic-foreground-secondary, var(--gr-color-gray-700, #374151));
+}
+
+.gr-host-platform-release-timeline__actions {
+	margin-top: 0.5rem;
+	display: flex;
+	flex-wrap: wrap;
+	gap: var(--gr-host-platform-gap-sm);
+	align-items: center;
+}
+
+.gr-host-platform-release-timeline__link {
+	font-size: 0.8125rem;
+	color: var(--gr-color-primary-700, #1d4ed8);
+}
+.gr-host-platform-release-timeline__link:hover {
+	text-decoration: underline;
+}

--- a/packages/host-platform/src/components/ReleaseTimeline.svelte
+++ b/packages/host-platform/src/components/ReleaseTimeline.svelte
@@ -1,0 +1,235 @@
+<!--
+@component
+ReleaseTimeline — two-channel release-history timeline.
+
+Renders an `<ol>` (semantic ordered list) inside a `<section
+aria-labelledby>` landmark. Each release is an `<li>` with channel
+badge, version, accessible date, status icon glyph + text label
+(never color-only), and optional adoption percentage / count.
+
+Two-channel presentation: when consumers want stable + beta side by
+side, they pass `releases` containing items with distinct `channel`
+fields. The component renders the items in their supplied order
+(release-newest-first is conventional) and visually distinguishes
+channels via classes. No date sorting / grouping is performed; the
+component is presentational only.
+
+Adoption metric:
+- Numeric values in `[0, 1]` are formatted as `"XX%"` and exposed via
+  `aria-valuetext` semantics on a `role="meter"` element inside each
+  release (with a valid range [0, 1] — see CostGauge's contract
+  for the meter-validity rules this also follows).
+- String adoption values render as-is (e.g. `"42 of 100 instances"`).
+
+Strict-CSP safe: no inline event handlers, no `style` attributes, no
+runtime style writes. All styling via stable `--gr-*` tokens.
+
+@example
+```svelte
+<ReleaseTimeline
+	label="Lesser release history"
+	releases={[
+		{ id: 'v1412', version: 'v1.4.12', channel: 'stable', date: '2026-05-22',
+		  status: 'shipped', adoption: 0.82 },
+		{ id: 'v1500rc1', version: 'v1.5.0-rc.1', channel: 'beta', date: '2026-05-23',
+		  status: 'in-progress', adoption: 0.05 },
+	]}
+/>
+```
+-->
+<script lang="ts">
+	import type { HTMLAttributes } from 'svelte/elements';
+	import type { Snippet } from 'svelte';
+	import { useStableId } from '@equaltoai/greater-components-utils';
+	import type { ReleaseAdoptionFormatter, ReleaseStatus, ReleaseTimelineItem } from '../types.js';
+
+	interface Props extends Omit<HTMLAttributes<HTMLElement>, 'aria-label'> {
+		/** Required accessible name for the timeline region. @public */
+		label: string;
+
+		/** Required release list (rendered in array order). @public */
+		releases: ReleaseTimelineItem[];
+
+		/**
+		 * Custom date formatter. Receives the raw `date` (Date or ISO string)
+		 * and returns a visible string. Defaults to `Intl.DateTimeFormat`
+		 * with `'en-US'` locale + medium date style.
+		 * @public
+		 */
+		formatDate?: (date: Date | string) => string;
+
+		/**
+		 * Custom adoption formatter. Receives the raw `adoption` and returns
+		 * a visible string. When omitted, numeric adoption is formatted as
+		 * `XX%` and string adoption is rendered as-is.
+		 * @public
+		 */
+		formatAdoption?: ReleaseAdoptionFormatter;
+
+		/** Optional locale for the default date formatter. Defaults to `'en-US'`. @public */
+		locale?: string;
+
+		/** Message rendered when `releases.length === 0`. @public */
+		emptyMessage?: string;
+
+		/** Additional CSS classes. @public */
+		class?: string;
+
+		/** Optional trailing action snippet rendered per item (e.g. release notes link). @public */
+		itemActions?: Snippet<[ReleaseTimelineItem]>;
+	}
+
+	let {
+		label,
+		releases,
+		formatDate,
+		formatAdoption,
+		locale = 'en-US',
+		emptyMessage = 'No releases recorded yet.',
+		class: className = '',
+		itemActions,
+		style: _style,
+		...restProps
+	}: Props = $props();
+
+	const stableId = useStableId('host-release-timeline');
+	const labelId = $derived(stableId.value ? `${stableId.value}-label` : undefined);
+
+	const statusInfo = $derived.by(() => {
+		const map: Record<ReleaseStatus, { icon: string; label: string }> = {
+			shipped: { icon: '✓', label: 'Shipped' },
+			'in-progress': { icon: '◌', label: 'Rolling out' },
+			'rolled-back': { icon: '↺', label: 'Rolled back' },
+			planned: { icon: '○', label: 'Planned' },
+		};
+		return map;
+	});
+
+	function defaultFormatDate(d: Date | string): string {
+		const date = typeof d === 'string' ? new Date(d) : d;
+		if (Number.isNaN(date.getTime())) return typeof d === 'string' ? d : '';
+		try {
+			return new Intl.DateTimeFormat(locale, { dateStyle: 'medium' }).format(date);
+		} catch {
+			return date.toISOString().slice(0, 10);
+		}
+	}
+
+	function dateIsoAttr(d: Date | string): string | undefined {
+		const date = typeof d === 'string' ? new Date(d) : d;
+		if (Number.isNaN(date.getTime())) return typeof d === 'string' ? d : undefined;
+		return date.toISOString();
+	}
+
+	function defaultFormatAdoption(value: number | string | undefined): string | undefined {
+		if (value === undefined) return undefined;
+		if (typeof value === 'string') return value;
+		if (!Number.isFinite(value)) return undefined;
+		const clamped = Math.max(0, Math.min(1, value));
+		return `${Math.round(clamped * 100)}%`;
+	}
+
+	function numericAdoption(value: number | string | undefined): number | null {
+		if (typeof value !== 'number') return null;
+		if (!Number.isFinite(value)) return null;
+		return Math.max(0, Math.min(1, value));
+	}
+
+	const rootClass = $derived(() =>
+		['gr-host-platform-release-timeline', className].filter(Boolean).join(' ')
+	);
+
+	const hasReleases = $derived(releases.length > 0);
+</script>
+
+<section class={rootClass()} aria-labelledby={labelId} {...restProps}>
+	<h2 id={labelId} class="gr-sr-only">{label}</h2>
+
+	{#if !hasReleases}
+		<div class="gr-host-platform-release-timeline__empty" role="status">
+			{emptyMessage}
+		</div>
+	{:else}
+		<ol class="gr-host-platform-release-timeline__list">
+			{#each releases as release (release.id)}
+				{@const status = release.status ?? 'shipped'}
+				{@const info = statusInfo[status]}
+				{@const visibleDate = (formatDate ?? defaultFormatDate)(release.date)}
+				{@const isoDate = dateIsoAttr(release.date)}
+				{@const adoptionText = (formatAdoption ?? defaultFormatAdoption)(release.adoption)}
+				{@const adoptionRatio = numericAdoption(release.adoption)}
+				<li
+					id={stableId.value ? `${stableId.value}-rel-${release.id}` : undefined}
+					class={[
+						'gr-host-platform-release-timeline__release',
+						`gr-host-platform-release-timeline__release--status-${status}`,
+						`gr-host-platform-release-timeline__release--channel-${release.channel}`,
+					].join(' ')}
+				>
+					<span class="gr-host-platform-release-timeline__rail" aria-hidden="true">
+						<span class="gr-host-platform-release-timeline__marker">{info.icon}</span>
+					</span>
+					<div class="gr-host-platform-release-timeline__body">
+						<div class="gr-host-platform-release-timeline__header">
+							<span class="gr-host-platform-release-timeline__version">{release.version}</span>
+							<span
+								class="gr-host-platform-release-timeline__channel"
+								aria-label={`Channel: ${release.channel}`}
+							>
+								{release.channel}
+							</span>
+							<span
+								class="gr-host-platform-release-timeline__status"
+								aria-label={`Status: ${info.label}`}
+							>
+								<span class="gr-host-platform-release-timeline__status-text">{info.label}</span>
+							</span>
+							<time class="gr-host-platform-release-timeline__date" datetime={isoDate ?? undefined}>
+								{visibleDate}
+							</time>
+						</div>
+						{#if release.description}
+							<p class="gr-host-platform-release-timeline__description">{release.description}</p>
+						{/if}
+						{#if adoptionText !== undefined}
+							{#if adoptionRatio !== null}
+								<div
+									class="gr-host-platform-release-timeline__adoption"
+									role="meter"
+									aria-valuemin={0}
+									aria-valuemax={1}
+									aria-valuenow={adoptionRatio}
+									aria-valuetext={`Adoption: ${adoptionText}`}
+								>
+									<span class="gr-sr-only">Adoption: {adoptionText}</span>
+									<span class="gr-host-platform-release-timeline__adoption-text" aria-hidden="true">
+										Adoption: {adoptionText}
+									</span>
+								</div>
+							{:else}
+								<p class="gr-host-platform-release-timeline__adoption-static">
+									<span class="gr-sr-only">Adoption: </span>
+									{adoptionText}
+								</p>
+							{/if}
+						{/if}
+						{#if release.href || itemActions}
+							<div class="gr-host-platform-release-timeline__actions" role="group">
+								{#if release.href}
+									<a
+										class="gr-host-platform-release-timeline__link"
+										href={release.href}
+										aria-label={`Release notes for ${release.version}`}
+									>
+										Release notes
+									</a>
+								{/if}
+								{#if itemActions}{@render itemActions(release)}{/if}
+							</div>
+						{/if}
+					</div>
+				</li>
+			{/each}
+		</ol>
+	{/if}
+</section>

--- a/packages/host-platform/src/components/ReleaseTimeline.svelte
+++ b/packages/host-platform/src/components/ReleaseTimeline.svelte
@@ -105,11 +105,36 @@ runtime style writes. All styling via stable `--gr-*` tokens.
 		return map;
 	});
 
+	/**
+	 * True when the input string represents a date that should be interpreted
+	 * as a calendar day rather than a precise instant — e.g. a bare
+	 * `'2026-05-22'` or any ISO string at UTC midnight (`...T00:00:00Z`).
+	 *
+	 * Calendar-day inputs MUST be formatted in UTC; otherwise `Intl.DateTimeFormat`
+	 * applies the viewer's local timezone offset and renders the previous day
+	 * in any timezone west of UTC (US, Pacific, much of the Americas). Arch
+	 * flagged this regression on PR #670 — releases dated `'2026-05-22T00:00:00Z'`
+	 * rendered as "May 21" in US timezones.
+	 */
+	function isCalendarDayString(d: string): boolean {
+		// Bare `YYYY-MM-DD`.
+		if (/^\d{4}-\d{2}-\d{2}$/.test(d)) return true;
+		// ISO 8601 at UTC midnight (`...T00:00:00Z` or `...T00:00:00.000Z`).
+		if (/^\d{4}-\d{2}-\d{2}T00:00:00(?:\.0+)?Z$/.test(d)) return true;
+		return false;
+	}
+
 	function defaultFormatDate(d: Date | string): string {
+		const isCalendarDay = typeof d === 'string' && isCalendarDayString(d);
 		const date = typeof d === 'string' ? new Date(d) : d;
 		if (Number.isNaN(date.getTime())) return typeof d === 'string' ? d : '';
 		try {
-			return new Intl.DateTimeFormat(locale, { dateStyle: 'medium' }).format(date);
+			return new Intl.DateTimeFormat(locale, {
+				dateStyle: 'medium',
+				// For calendar-day inputs, format in UTC so we render the same
+				// day the consumer typed (no local-timezone shift).
+				timeZone: isCalendarDay ? 'UTC' : undefined,
+			}).format(date);
 		} catch {
 			return date.toISOString().slice(0, 10);
 		}
@@ -193,23 +218,36 @@ runtime style writes. All styling via stable `--gr-*` tokens.
 						{/if}
 						{#if adoptionText !== undefined}
 							{#if adoptionRatio !== null}
+								{@const adoptionLabelId = stableId.value
+									? `${stableId.value}-rel-${release.id}-adoption-label`
+									: undefined}
+								<!--
+									The adoption meter MUST have an accessible name. We use
+									`aria-labelledby` pointing at the visible adoption text
+									(rather than aria-label) so the visible text and the
+									announced name stay in sync.  aria-valuetext carries the
+									numeric value; aria-labelledby carries the "what is this
+									meter measuring" semantic.
+								-->
 								<div
 									class="gr-host-platform-release-timeline__adoption"
 									role="meter"
+									aria-labelledby={adoptionLabelId}
 									aria-valuemin={0}
 									aria-valuemax={1}
 									aria-valuenow={adoptionRatio}
 									aria-valuetext={`Adoption: ${adoptionText}`}
 								>
-									<span class="gr-sr-only">Adoption: {adoptionText}</span>
-									<span class="gr-host-platform-release-timeline__adoption-text" aria-hidden="true">
+									<span
+										id={adoptionLabelId}
+										class="gr-host-platform-release-timeline__adoption-text"
+									>
 										Adoption: {adoptionText}
 									</span>
 								</div>
 							{:else}
 								<p class="gr-host-platform-release-timeline__adoption-static">
-									<span class="gr-sr-only">Adoption: </span>
-									{adoptionText}
+									Adoption: {adoptionText}
 								</p>
 							{/if}
 						{/if}

--- a/packages/host-platform/src/components/StackMatrix.css
+++ b/packages/host-platform/src/components/StackMatrix.css
@@ -1,0 +1,155 @@
+.gr-host-platform-stack-matrix {
+	overflow-x: auto;
+	min-width: 0;
+}
+
+.gr-host-platform-stack-matrix__table {
+	width: 100%;
+	border-collapse: collapse;
+	font-size: 0.875rem;
+	background: var(--gr-semantic-background-surface, var(--gr-color-base-white, #fff));
+	color: var(--gr-semantic-foreground-primary, var(--gr-color-gray-900, #111827));
+}
+
+.gr-host-platform-stack-matrix__caption {
+	text-align: start;
+	caption-side: top;
+	padding: 0 0 var(--gr-host-platform-gap-sm);
+	font-weight: 600;
+	color: var(--gr-semantic-foreground-secondary, var(--gr-color-gray-700, #374151));
+}
+
+.gr-host-platform-stack-matrix__col-header,
+.gr-host-platform-stack-matrix__row-header,
+.gr-host-platform-stack-matrix__actions-header,
+.gr-host-platform-stack-matrix__row-header-col {
+	text-align: start;
+	font-weight: 600;
+	padding: 0.5rem var(--gr-host-platform-gap-md);
+	background: var(--gr-semantic-background-secondary, var(--gr-color-gray-50, #f9fafb));
+	border-bottom: 1px solid var(--gr-semantic-border-subtle, var(--gr-color-gray-200, #e5e7eb));
+	color: var(--gr-semantic-foreground-secondary, var(--gr-color-gray-700, #374151));
+	white-space: nowrap;
+}
+
+.gr-host-platform-stack-matrix__col-header--sortable {
+	padding: 0;
+}
+
+.gr-host-platform-stack-matrix__sort-button {
+	all: unset;
+	display: inline-flex;
+	align-items: center;
+	gap: 0.25rem;
+	width: 100%;
+	padding: 0.5rem var(--gr-host-platform-gap-md);
+	cursor: pointer;
+	font-weight: inherit;
+	color: inherit;
+}
+.gr-host-platform-stack-matrix__sort-button:hover {
+	background: var(--gr-semantic-background-tertiary, var(--gr-color-gray-100, #f3f4f6));
+}
+.gr-host-platform-stack-matrix__sort-button:focus-visible {
+	outline: 2px solid var(--gr-semantic-border-focus, var(--gr-color-primary-600, #2563eb));
+	outline-offset: -2px;
+}
+
+.gr-host-platform-stack-matrix__sort-indicator {
+	font-size: 0.6875rem;
+	color: var(--gr-semantic-foreground-tertiary, var(--gr-color-gray-500, #6b7280));
+}
+
+.gr-host-platform-stack-matrix__row {
+	border-bottom: 1px solid var(--gr-semantic-border-subtle, var(--gr-color-gray-200, #e5e7eb));
+}
+.gr-host-platform-stack-matrix__row:last-child {
+	border-bottom: none;
+}
+
+.gr-host-platform-stack-matrix__row-header {
+	background: var(--gr-semantic-background-surface, var(--gr-color-base-white, #fff));
+	border-right: 1px solid var(--gr-semantic-border-subtle, var(--gr-color-gray-200, #e5e7eb));
+	min-width: 12rem;
+}
+
+.gr-host-platform-stack-matrix__row-label {
+	display: block;
+	font-weight: 600;
+	color: var(--gr-semantic-foreground-primary, var(--gr-color-gray-900, #111827));
+}
+
+.gr-host-platform-stack-matrix__row-sublabel {
+	display: block;
+	font-size: 0.75rem;
+	font-weight: normal;
+	color: var(--gr-semantic-foreground-tertiary, var(--gr-color-gray-500, #6b7280));
+	font-family: var(--gr-typography-fontFamily-mono, ui-monospace, SFMono-Regular, Menlo, monospace);
+}
+
+.gr-host-platform-stack-matrix__cell {
+	padding: 0.5rem var(--gr-host-platform-gap-md);
+	vertical-align: middle;
+	font-family: var(--gr-typography-fontFamily-mono, ui-monospace, SFMono-Regular, Menlo, monospace);
+}
+
+.gr-host-platform-stack-matrix__cell-value {
+	display: inline-flex;
+	align-items: center;
+	gap: 0.375rem;
+	padding: 0.125rem 0.5rem;
+	border-radius: 999px;
+	font-size: 0.8125rem;
+	border: 1px solid transparent;
+	font-family: var(--gr-typography-fontFamily-mono, ui-monospace, SFMono-Regular, Menlo, monospace);
+}
+
+.gr-host-platform-stack-matrix__cell-value--drift-in-sync {
+	background: var(--gr-color-success-50, #f0fdf4);
+	color: var(--gr-color-success-900, #14532d);
+	border-color: var(--gr-color-success-300, #86efac);
+}
+.gr-host-platform-stack-matrix__cell-value--drift-pending {
+	background: var(--gr-color-info-50, #eff6ff);
+	color: var(--gr-color-info-900, #1e3a8a);
+	border-color: var(--gr-color-info-300, #93c5fd);
+}
+.gr-host-platform-stack-matrix__cell-value--drift-drifted {
+	background: var(--gr-color-warning-50, #fffbeb);
+	color: var(--gr-color-warning-900, #78350f);
+	border-color: var(--gr-color-warning-300, #fcd34d);
+}
+.gr-host-platform-stack-matrix__cell-value--drift-unknown {
+	background: var(--gr-semantic-background-secondary, var(--gr-color-gray-100, #f3f4f6));
+	color: var(--gr-semantic-foreground-secondary, var(--gr-color-gray-700, #374151));
+	border-color: var(--gr-semantic-border-subtle, var(--gr-color-gray-200, #e5e7eb));
+}
+
+.gr-host-platform-stack-matrix__drift-icon {
+	font-size: 0.6875rem;
+	font-weight: 700;
+	line-height: 1;
+}
+
+.gr-host-platform-stack-matrix__actions-cell {
+	padding: 0.5rem var(--gr-host-platform-gap-md);
+	text-align: end;
+	vertical-align: middle;
+}
+
+.gr-host-platform-stack-matrix__actions {
+	display: inline-flex;
+	flex-wrap: wrap;
+	gap: var(--gr-host-platform-gap-sm);
+	align-items: center;
+}
+
+.gr-host-platform-stack-matrix__empty-row {
+	border-bottom: none;
+}
+
+.gr-host-platform-stack-matrix__empty {
+	padding: var(--gr-host-platform-gap-lg) var(--gr-host-platform-gutter);
+	color: var(--gr-semantic-foreground-tertiary, var(--gr-color-gray-500, #6b7280));
+	text-align: center;
+}

--- a/packages/host-platform/src/components/StackMatrix.svelte
+++ b/packages/host-platform/src/components/StackMatrix.svelte
@@ -1,0 +1,293 @@
+<!--
+@component
+StackMatrix — semantic table view of stack / version drift across rows.
+
+Renders a real `<table>` with `<caption>` (visually-hidden by default
+but available to AT), `<thead>` / `<tbody>` / `<th scope="col" |
+"row">`. Drift state on each cell is communicated by an icon glyph +
+text label (never color-only) inside the cell.
+
+Sortable columns:
+- When a column has `sortable: true`, its header `<th>` renders a
+  `<button>` that emits the `onsort(columnId)` callback. The component
+  reflects the consumer-supplied `sortBy` + `sortDirection` via
+  `aria-sort` on the matching `<th>`.
+- The component is presentation-only — it does not sort data internally.
+  Consumers manage the sort state and reorder `rows` in response to the
+  `onsort` callback.
+
+Per-row CTA slot:
+- `rowActions` snippet receives the current `StackMatrixRow` and renders
+  inside a `<td>` at the end of each row (wrapped in `<div role="group">`
+  with an accessible name).
+
+Strict-CSP safe: no inline event handlers (Svelte's compiled
+`on*` handlers attach after hydration); no `style` attributes set at
+runtime; styling via stable `--gr-*` tokens.
+
+@example
+```svelte
+<StackMatrix
+	caption="Lesser fleet stack versions"
+	columns={[
+		{ id: 'lesser', label: 'Lesser', sortable: true },
+		{ id: 'host',   label: 'Lesser Host', sortable: true },
+	]}
+	rows={[
+		{ id: 'r1', label: 'lesser.example', subLabel: 'us-east-1',
+		  cells: {
+		    lesser: { value: 'v1.4.12', drift: 'in-sync' },
+		    host:   { value: 'v0.4.5',  drift: 'pending' },
+		  } },
+	]}
+	sortBy="lesser"
+	sortDirection="ascending"
+	onsort={(id) => …}
+>
+	{#snippet rowActions(row)}<button type="button">Manage</button>{/snippet}
+</StackMatrix>
+```
+-->
+<script lang="ts">
+	import type { HTMLAttributes } from 'svelte/elements';
+	import type { Snippet } from 'svelte';
+	import { useStableId } from '@equaltoai/greater-components-utils';
+	import type {
+		StackMatrixCell,
+		StackMatrixColumn,
+		StackMatrixDrift,
+		StackMatrixRow,
+		StackMatrixSortDirection,
+	} from '../types.js';
+
+	interface Props extends HTMLAttributes<HTMLDivElement> {
+		/** Required accessible caption for the table. May be visually hidden. @public */
+		caption: string;
+
+		/**
+		 * When true, the caption is rendered as `<caption class="gr-sr-only">`
+		 * (still announced to AT). Default `true` to keep the visual surface
+		 * compact for dashboard layouts.
+		 * @public
+		 */
+		captionHidden?: boolean;
+
+		/** Column definitions in left-to-right render order. @public */
+		columns: StackMatrixColumn[];
+
+		/** Rows in display order. @public */
+		rows: StackMatrixRow[];
+
+		/** Id of the currently-sorted column. @public */
+		sortBy?: string;
+
+		/** Current sort direction. Defaults to `'none'` (no aria-sort active). @public */
+		sortDirection?: StackMatrixSortDirection;
+
+		/**
+		 * Called when a sortable column header is activated. Consumers manage
+		 * sort state externally and re-supply `rows` in the desired order.
+		 * @public
+		 */
+		onsort?: (columnId: string) => void;
+
+		/** Empty-state message when `rows.length === 0`. @public */
+		emptyMessage?: string;
+
+		/** Accessible name for the per-row actions cell group. @public */
+		rowActionsLabel?: string;
+
+		/** Additional CSS classes on the wrapper. @public */
+		class?: string;
+
+		/** Optional custom cell renderer. @public */
+		cellRenderer?: Snippet<[StackMatrixCell, StackMatrixRow, StackMatrixColumn]>;
+
+		/** Per-row actions slot. @public */
+		rowActions?: Snippet<[StackMatrixRow]>;
+	}
+
+	let {
+		caption,
+		captionHidden = true,
+		columns,
+		rows,
+		sortBy,
+		sortDirection = 'none',
+		onsort,
+		emptyMessage = 'No rows to display.',
+		rowActionsLabel = 'Row actions',
+		class: className = '',
+		cellRenderer,
+		rowActions,
+		style: _style,
+		...restProps
+	}: Props = $props();
+
+	const stableId = useStableId('host-stack-matrix');
+
+	const driftInfo = $derived.by(() => {
+		const map: Record<StackMatrixDrift, { icon: string; label: string }> = {
+			'in-sync': { icon: '●', label: 'In sync' },
+			pending: { icon: '◌', label: 'Update pending' },
+			drifted: { icon: '⚠', label: 'Drifted' },
+			unknown: { icon: '?', label: 'Unknown drift state' },
+		};
+		return map;
+	});
+
+	function ariaSortFor(columnId: string): StackMatrixSortDirection | undefined {
+		if (columnId !== sortBy) return undefined;
+		return sortDirection;
+	}
+
+	function handleHeaderClick(column: StackMatrixColumn) {
+		if (!column.sortable) return;
+		onsort?.(column.id);
+	}
+
+	function handleHeaderKeydown(event: KeyboardEvent, column: StackMatrixColumn) {
+		// Native <button> handles Enter/Space; this is here purely for the
+		// rare case a consumer styles the button so that activating it
+		// requires explicit key handling. The default browser behavior is
+		// already correct.
+		if (event.key === 'Enter' || event.key === ' ') {
+			if (!column.sortable) return;
+			event.preventDefault();
+			onsort?.(column.id);
+		}
+	}
+
+	const rootClass = $derived(() =>
+		['gr-host-platform-stack-matrix', className].filter(Boolean).join(' ')
+	);
+
+	const hasRows = $derived(rows.length > 0);
+	const hasRowActions = $derived(!!rowActions);
+</script>
+
+<div class={rootClass()} {...restProps}>
+	<table class="gr-host-platform-stack-matrix__table">
+		<caption
+			class={['gr-host-platform-stack-matrix__caption', captionHidden && 'gr-sr-only']
+				.filter(Boolean)
+				.join(' ')}
+		>
+			{caption}
+		</caption>
+		<thead>
+			<tr>
+				<th scope="col" class="gr-host-platform-stack-matrix__row-header-col">
+					<span class="gr-sr-only">Row</span>
+				</th>
+				{#each columns as column (column.id)}
+					{@const ariaSort = ariaSortFor(column.id)}
+					<th
+						scope="col"
+						class={[
+							'gr-host-platform-stack-matrix__col-header',
+							column.sortable && 'gr-host-platform-stack-matrix__col-header--sortable',
+						]
+							.filter(Boolean)
+							.join(' ')}
+						aria-sort={ariaSort}
+					>
+						{#if column.sortable}
+							<button
+								type="button"
+								class="gr-host-platform-stack-matrix__sort-button"
+								onclick={() => handleHeaderClick(column)}
+								onkeydown={(event) => handleHeaderKeydown(event, column)}
+							>
+								<span>{column.label}</span>
+								<span class="gr-host-platform-stack-matrix__sort-indicator" aria-hidden="true">
+									{#if ariaSort === 'ascending'}
+										▲
+									{:else if ariaSort === 'descending'}
+										▼
+									{:else}
+										↕
+									{/if}
+								</span>
+							</button>
+						{:else}
+							{column.label}
+						{/if}
+					</th>
+				{/each}
+				{#if hasRowActions}
+					<th scope="col" class="gr-host-platform-stack-matrix__actions-header">
+						<span class="gr-sr-only">{rowActionsLabel}</span>
+					</th>
+				{/if}
+			</tr>
+		</thead>
+		<tbody>
+			{#if !hasRows}
+				<tr class="gr-host-platform-stack-matrix__empty-row">
+					<td
+						colspan={columns.length + 1 + (hasRowActions ? 1 : 0)}
+						class="gr-host-platform-stack-matrix__empty"
+					>
+						{emptyMessage}
+					</td>
+				</tr>
+			{:else}
+				{#each rows as row (row.id)}
+					<tr
+						id={stableId.value ? `${stableId.value}-row-${row.id}` : undefined}
+						class="gr-host-platform-stack-matrix__row"
+					>
+						<th scope="row" class="gr-host-platform-stack-matrix__row-header">
+							<span class="gr-host-platform-stack-matrix__row-label">{row.label}</span>
+							{#if row.subLabel}
+								<span class="gr-host-platform-stack-matrix__row-sublabel">{row.subLabel}</span>
+							{/if}
+						</th>
+						{#each columns as column (column.id)}
+							{@const cell = row.cells[column.id]}
+							<td class="gr-host-platform-stack-matrix__cell">
+								{#if cell === undefined}
+									<span class="gr-sr-only">No data</span>
+									<span aria-hidden="true">—</span>
+								{:else if cellRenderer}
+									{@render cellRenderer(cell, row, column)}
+								{:else}
+									{@const drift = cell.drift ?? 'in-sync'}
+									{@const info = driftInfo[drift]}
+									<span
+										class={[
+											'gr-host-platform-stack-matrix__cell-value',
+											`gr-host-platform-stack-matrix__cell-value--drift-${drift}`,
+										].join(' ')}
+									>
+										<span class="gr-host-platform-stack-matrix__drift-icon" aria-hidden="true"
+											>{info.icon}</span
+										>
+										<span class="gr-host-platform-stack-matrix__cell-text">
+											{cell.value}
+										</span>
+										<span class="gr-sr-only">
+											{cell.description ?? info.label}
+										</span>
+									</span>
+								{/if}
+							</td>
+						{/each}
+						{#if hasRowActions}
+							<td class="gr-host-platform-stack-matrix__actions-cell">
+								<div
+									class="gr-host-platform-stack-matrix__actions"
+									role="group"
+									aria-label={`${rowActionsLabel}: ${row.label}`}
+								>
+									{@render rowActions?.(row)}
+								</div>
+							</td>
+						{/if}
+					</tr>
+				{/each}
+			{/if}
+		</tbody>
+	</table>
+</div>

--- a/packages/host-platform/src/index.ts
+++ b/packages/host-platform/src/index.ts
@@ -27,6 +27,9 @@ export type { ComponentProps } from 'svelte';
 export { default as FleetCard } from './components/FleetCard.svelte';
 export { default as CostGauge } from './components/CostGauge.svelte';
 export { default as ActivitySparkline } from './components/ActivitySparkline.svelte';
+export { default as ProvisioningTimeline } from './components/ProvisioningTimeline.svelte';
+export { default as ReleaseTimeline } from './components/ReleaseTimeline.svelte';
+export { default as StackMatrix } from './components/StackMatrix.svelte';
 
 // Utilities (dependency-free, strict-CSP-safe)
 export { formatCost, formatCostGaugeText, computeRatio } from './utils/formatters.js';
@@ -42,4 +45,16 @@ export type {
 	CostGaugeThresholds,
 	CostValueFormatter,
 	ActivitySparklineTone,
+	ProvisioningStep,
+	ProvisioningStepStatus,
+	ProvisioningLogPoliteness,
+	ReleaseChannel,
+	ReleaseStatus,
+	ReleaseTimelineItem,
+	ReleaseAdoptionFormatter,
+	StackMatrixDrift,
+	StackMatrixColumn,
+	StackMatrixCell,
+	StackMatrixRow,
+	StackMatrixSortDirection,
 } from './types.js';

--- a/packages/host-platform/src/styles/base.css
+++ b/packages/host-platform/src/styles/base.css
@@ -7,13 +7,19 @@
 
 .gr-host-platform-fleet-card,
 .gr-host-platform-cost-gauge,
-.gr-host-platform-activity-sparkline {
+.gr-host-platform-activity-sparkline,
+.gr-host-platform-provisioning-timeline,
+.gr-host-platform-release-timeline,
+.gr-host-platform-stack-matrix {
 	box-sizing: border-box;
 }
 
 .gr-host-platform-fleet-card *,
 .gr-host-platform-cost-gauge *,
-.gr-host-platform-activity-sparkline * {
+.gr-host-platform-activity-sparkline *,
+.gr-host-platform-provisioning-timeline *,
+.gr-host-platform-release-timeline *,
+.gr-host-platform-stack-matrix * {
 	box-sizing: border-box;
 }
 
@@ -43,7 +49,10 @@
 :where(
 	.gr-host-platform-fleet-card,
 	.gr-host-platform-cost-gauge,
-	.gr-host-platform-activity-sparkline
+	.gr-host-platform-activity-sparkline,
+	.gr-host-platform-provisioning-timeline,
+	.gr-host-platform-release-timeline,
+	.gr-host-platform-stack-matrix
 ) {
 	--gr-host-platform-gutter: 1rem;
 	--gr-host-platform-gap-sm: 0.5rem;

--- a/packages/host-platform/src/types.ts
+++ b/packages/host-platform/src/types.ts
@@ -46,3 +46,162 @@ export type CostValueFormatter = (value: number, currency: string | undefined) =
 
 /** Tone for the sparkline stroke. Non-color-only — accompany with `label`. */
 export type ActivitySparklineTone = 'default' | 'success' | 'warning' | 'danger' | 'info';
+
+/* ============================================================================
+ * G3 — Operator timelines and stack matrix
+ * ==========================================================================*/
+
+/**
+ * Status of a single step in a `ProvisioningTimeline`.
+ *
+ * Drives both the rendered icon glyph (●/◌/✓/⚠/—) and the accessible label;
+ * status is never communicated by color alone.
+ *
+ * @public
+ */
+export type ProvisioningStepStatus = 'pending' | 'active' | 'success' | 'failure' | 'skipped';
+
+/**
+ * A single step in a `ProvisioningTimeline`.
+ *
+ * @public
+ */
+export interface ProvisioningStep {
+	/** Stable id; used for the DOM list-item id and as the row key. */
+	id: string;
+	/** Visible primary label (e.g. "Allocate compute"). */
+	label: string;
+	/** Optional supporting description rendered below the label. */
+	description?: string;
+	/** Status — drives icon + text. Defaults to `'pending'` when omitted. */
+	status?: ProvisioningStepStatus;
+	/** Optional ISO timestamp string rendered as the step's time anchor. */
+	timestamp?: string;
+	/** Optional short metadata (e.g. job duration, region). */
+	meta?: string;
+}
+
+/**
+ * ARIA politeness for the constrained live-log region. `'off'` disables
+ * announcements; the visible log still renders.
+ *
+ * @public
+ */
+export type ProvisioningLogPoliteness = 'off' | 'polite' | 'assertive';
+
+/**
+ * Two-channel release timeline release channel.
+ *
+ * Conventionally `'stable'` and `'beta'`, but consumers may use any strings
+ * (e.g. `'stable'` vs `'rc'`). The `ReleaseTimeline` groups items by channel
+ * and presents them as two visually-distinct streams.
+ *
+ * @public
+ */
+export type ReleaseChannel = string;
+
+/**
+ * Status of a release. Drives icon + accessible label.
+ *
+ * @public
+ */
+export type ReleaseStatus = 'shipped' | 'in-progress' | 'rolled-back' | 'planned';
+
+/**
+ * A single release entry rendered by `ReleaseTimeline`.
+ *
+ * @public
+ */
+export interface ReleaseTimelineItem {
+	/** Stable id; used for the DOM list-item id and as the row key. */
+	id: string;
+	/** Version label (e.g. `'v1.4.12'`). */
+	version: string;
+	/** Channel this release belongs to (e.g. `'stable'`). */
+	channel: ReleaseChannel;
+	/** Date of the release. May be a `Date` or an ISO string. */
+	date: Date | string;
+	/** Status — drives icon + text. Defaults to `'shipped'` when omitted. */
+	status?: ReleaseStatus;
+	/**
+	 * Adoption metric: a number in `[0, 1]` (a ratio) or a free-form string
+	 * (e.g. `'42 of 100 instances'`). When numeric, the component formats
+	 * it as a percentage and exposes an accessible value-text.
+	 */
+	adoption?: number | string;
+	/** Optional secondary description. */
+	description?: string;
+	/** Optional changelog / release-notes URL. */
+	href?: string;
+}
+
+/**
+ * Formatter for a release's adoption metric. Receives the raw `adoption`
+ * (number in [0,1] or string) and returns a visible string. When omitted,
+ * numeric adoption is formatted as `XX%`.
+ *
+ * @public
+ */
+export type ReleaseAdoptionFormatter = (
+	adoption: number | string | undefined
+) => string | undefined;
+
+/**
+ * Drift state of a stack-matrix cell, paired with an icon glyph + text label
+ * so the indicator is never color-only.
+ *
+ * @public
+ */
+export type StackMatrixDrift = 'in-sync' | 'pending' | 'drifted' | 'unknown';
+
+/**
+ * Column definition for `StackMatrix`.
+ *
+ * @public
+ */
+export interface StackMatrixColumn {
+	/** Stable id used as the lookup key into each row's `cells` map. */
+	id: string;
+	/** Visible column header. */
+	label: string;
+	/** When true, the header renders as a sort-trigger `<button>` and
+	 *  `aria-sort` reflects the current sort state. */
+	sortable?: boolean;
+}
+
+/**
+ * A single cell in a `StackMatrix` row. Either a string (rendered as text)
+ * or a structured value with drift status.
+ *
+ * @public
+ */
+export interface StackMatrixCell {
+	/** Visible cell value (e.g. `'v1.4.12'`). */
+	value: string;
+	/** Drift state — drives icon + accessible label. */
+	drift?: StackMatrixDrift;
+	/**
+	 * Optional accessible description override. When omitted, the cell's
+	 * accessible content is `value` + (` (drift state)` if drift !== `'in-sync'`).
+	 */
+	description?: string;
+}
+
+/**
+ * A row in `StackMatrix`. The `cells` map keys MUST match column ids.
+ *
+ * @public
+ */
+export interface StackMatrixRow {
+	/** Stable id used for the DOM row id and as the row key. */
+	id: string;
+	/** Row header label rendered in the first cell with `<th scope="row">`. */
+	label: string;
+	/** Optional secondary row header (e.g. region). */
+	subLabel?: string;
+	/** Map of column id → cell. */
+	cells: Record<string, StackMatrixCell>;
+}
+
+/** Sort direction state used by `StackMatrix`. */
+export type StackMatrixSortDirection = 'ascending' | 'descending' | 'none';

--- a/packages/host-platform/tests/provisioning-timeline.test.ts
+++ b/packages/host-platform/tests/provisioning-timeline.test.ts
@@ -1,0 +1,184 @@
+import { describe, it, expect } from 'vitest';
+import { render } from '@testing-library/svelte';
+import { createRawSnippet } from 'svelte';
+import ProvisioningTimeline from '../src/components/ProvisioningTimeline.svelte';
+import type { ProvisioningStep } from '../src/types.js';
+
+function snippetOf(html: string) {
+	return createRawSnippet(() => ({ render: () => html }));
+}
+
+const baseSteps: ProvisioningStep[] = [
+	{
+		id: 'allocate',
+		label: 'Allocate compute',
+		status: 'success',
+		timestamp: '2026-05-24T15:00:00Z',
+	},
+	{ id: 'install', label: 'Install Lesser', status: 'active' },
+	{ id: 'migrate', label: 'Run migrations', status: 'pending' },
+];
+
+describe('ProvisioningTimeline', () => {
+	it('renders as <section aria-labelledby> with the supplied accessible name', () => {
+		const { container } = render(ProvisioningTimeline, {
+			label: 'lesser.example provisioning',
+			steps: baseSteps,
+		});
+		const section = container.querySelector('section.gr-host-platform-provisioning-timeline');
+		expect(section).toBeTruthy();
+		const labelledby = section?.getAttribute('aria-labelledby');
+		expect(labelledby).toBeTruthy();
+		expect(container.ownerDocument.getElementById(labelledby!)?.textContent).toBe(
+			'lesser.example provisioning'
+		);
+	});
+
+	it('renders steps as a semantic <ol>', () => {
+		const { container } = render(ProvisioningTimeline, {
+			label: 'p',
+			steps: baseSteps,
+		});
+		const list = container.querySelector('ol.gr-host-platform-provisioning-timeline__list');
+		expect(list).toBeTruthy();
+		const items = list?.querySelectorAll('li');
+		expect(items?.length).toBe(3);
+	});
+
+	it.each([
+		['pending', 'Pending'],
+		['active', 'In progress'],
+		['success', 'Completed'],
+		['failure', 'Failed'],
+		['skipped', 'Skipped'],
+	])('communicates status %s with text label (%s) — never color-only', (status, expectedLabel) => {
+		const steps: ProvisioningStep[] = [{ id: 's', label: 'Step', status: status as never }];
+		const { container } = render(ProvisioningTimeline, { label: 'p', steps });
+		const stepEl = container.querySelector(
+			`.gr-host-platform-provisioning-timeline__step--status-${status}`
+		);
+		expect(stepEl).toBeTruthy();
+		const badge = stepEl?.querySelector('.gr-host-platform-provisioning-timeline__status');
+		expect(badge?.getAttribute('aria-label')).toBe(`Status: ${expectedLabel}`);
+		expect(
+			badge?.querySelector('.gr-host-platform-provisioning-timeline__status-text')?.textContent
+		).toBe(expectedLabel);
+	});
+
+	it('sets aria-current="step" on the active step only', () => {
+		const { container } = render(ProvisioningTimeline, {
+			label: 'p',
+			steps: baseSteps,
+		});
+		const currentItems = container.querySelectorAll('[aria-current="step"]');
+		expect(currentItems.length).toBe(1);
+		expect(currentItems[0]?.textContent).toContain('Install Lesser');
+	});
+
+	it('renders the empty state with role="status" when no steps are supplied', () => {
+		const { container } = render(ProvisioningTimeline, {
+			label: 'p',
+			steps: [],
+			emptyMessage: 'Nothing scheduled.',
+		});
+		expect(container.querySelector('ol')).toBeNull();
+		const empty = container.querySelector('.gr-host-platform-provisioning-timeline__empty');
+		expect(empty?.getAttribute('role')).toBe('status');
+		expect(empty?.textContent?.trim()).toBe('Nothing scheduled.');
+	});
+
+	it('wraps the liveLog snippet in a role="log" region with aria-live=polite by default', () => {
+		const { container } = render(ProvisioningTimeline, {
+			label: 'p',
+			steps: baseSteps,
+			liveLog: snippetOf('<pre data-test="log">15:01:02 [allocate] node provisioned…</pre>'),
+		});
+		const log = container.querySelector('section.gr-host-platform-provisioning-timeline__log');
+		expect(log).toBeTruthy();
+		expect(log?.getAttribute('role')).toBe('log');
+		expect(log?.getAttribute('aria-live')).toBe('polite');
+		expect(log?.getAttribute('aria-atomic')).toBe('false');
+		expect(log?.getAttribute('aria-relevant')).toBe('additions');
+		// Log content is rendered inside the region.
+		expect(log?.querySelector('[data-test="log"]')).toBeTruthy();
+		// Region has its own accessible name.
+		const labelledby = log?.getAttribute('aria-labelledby');
+		expect(labelledby).toBeTruthy();
+		expect(container.ownerDocument.getElementById(labelledby!)?.textContent).toBe(
+			'Live provisioning log'
+		);
+	});
+
+	it('honors liveLogLabel + liveLogPoliteness="assertive"', () => {
+		const { container } = render(ProvisioningTimeline, {
+			label: 'p',
+			steps: baseSteps,
+			liveLog: snippetOf('<div data-test="log"></div>'),
+			liveLogLabel: 'Build output',
+			liveLogPoliteness: 'assertive',
+		});
+		const log = container.querySelector('section.gr-host-platform-provisioning-timeline__log');
+		expect(log?.getAttribute('aria-live')).toBe('assertive');
+		const labelledby = log?.getAttribute('aria-labelledby');
+		expect(container.ownerDocument.getElementById(labelledby!)?.textContent).toBe('Build output');
+	});
+
+	it('drops aria-live when liveLogPoliteness="off" (visible log but no announcements)', () => {
+		const { container } = render(ProvisioningTimeline, {
+			label: 'p',
+			steps: baseSteps,
+			liveLog: snippetOf('<div data-test="log"></div>'),
+			liveLogPoliteness: 'off',
+		});
+		const log = container.querySelector('section.gr-host-platform-provisioning-timeline__log');
+		expect(log).toBeTruthy();
+		expect(log?.hasAttribute('aria-live')).toBe(false);
+		expect(log?.querySelector('[data-test="log"]')).toBeTruthy();
+	});
+
+	it('does not render the log region when liveLog snippet is omitted', () => {
+		const { container } = render(ProvisioningTimeline, {
+			label: 'p',
+			steps: baseSteps,
+		});
+		expect(container.querySelector('[role="log"]')).toBeNull();
+	});
+
+	it('renders a <time datetime> for steps with a timestamp', () => {
+		const { container } = render(ProvisioningTimeline, {
+			label: 'p',
+			steps: [
+				{
+					id: 's',
+					label: 'Step',
+					status: 'success',
+					timestamp: '2026-05-24T15:00:00Z',
+				},
+			],
+		});
+		const time = container.querySelector('time.gr-host-platform-provisioning-timeline__time');
+		expect(time?.getAttribute('datetime')).toBe('2026-05-24T15:00:00Z');
+	});
+
+	it('does not set inline style attribute on any rendered element', () => {
+		const { container } = render(ProvisioningTimeline, {
+			label: 'p',
+			steps: baseSteps,
+			liveLog: snippetOf('<div data-test="log"></div>'),
+		});
+		container.querySelectorAll('[style]').forEach((el) => {
+			expect(el.tagName, `${el.tagName} should not have style attribute`).toBe('NEVER');
+		});
+		expect(container.querySelectorAll('[style]').length).toBe(0);
+	});
+
+	it('produces unique step ids across multiple timeline instances', () => {
+		const a = render(ProvisioningTimeline, { label: 'a', steps: baseSteps });
+		const b = render(ProvisioningTimeline, { label: 'b', steps: baseSteps });
+		const aId = a.container.querySelector('li')?.getAttribute('id');
+		const bId = b.container.querySelector('li')?.getAttribute('id');
+		expect(aId).toBeTruthy();
+		expect(bId).toBeTruthy();
+		expect(aId).not.toBe(bId);
+	});
+});

--- a/packages/host-platform/tests/provisioning-timeline.test.ts
+++ b/packages/host-platform/tests/provisioning-timeline.test.ts
@@ -123,17 +123,37 @@ describe('ProvisioningTimeline', () => {
 		expect(container.ownerDocument.getElementById(labelledby!)?.textContent).toBe('Build output');
 	});
 
-	it('drops aria-live when liveLogPoliteness="off" (visible log but no announcements)', () => {
+	it('drops role="log" entirely when liveLogPoliteness="off" (Arch PR #670 review regression)', () => {
+		// `role="log"` has implicit polite live-region semantics in screen
+		// readers — merely omitting `aria-live` does NOT disable announcements.
+		// When the consumer opts into liveLogPoliteness="off", the log MUST
+		// render without role="log" so AT users see no announcements at all.
 		const { container } = render(ProvisioningTimeline, {
 			label: 'p',
 			steps: baseSteps,
 			liveLog: snippetOf('<div data-test="log"></div>'),
 			liveLogPoliteness: 'off',
 		});
+		// No role="log" anywhere in the rendered output.
+		expect(container.querySelector('[role="log"]')).toBeNull();
+		// The visible log region still renders (consumer's content is visible
+		// to sighted users), but with no live semantics.
 		const log = container.querySelector('section.gr-host-platform-provisioning-timeline__log');
 		expect(log).toBeTruthy();
 		expect(log?.hasAttribute('aria-live')).toBe(false);
+		expect(log?.hasAttribute('aria-atomic')).toBe(false);
+		expect(log?.hasAttribute('aria-relevant')).toBe(false);
+		expect(log?.classList.contains('gr-host-platform-provisioning-timeline__log--quiet')).toBe(
+			true
+		);
 		expect(log?.querySelector('[data-test="log"]')).toBeTruthy();
+		// The section still has an accessible name pointing at the visible
+		// log heading.
+		const labelledby = log?.getAttribute('aria-labelledby');
+		expect(labelledby).toBeTruthy();
+		expect(container.ownerDocument.getElementById(labelledby!)?.textContent).toBe(
+			'Live provisioning log'
+		);
 	});
 
 	it('does not render the log region when liveLog snippet is omitted', () => {

--- a/packages/host-platform/tests/release-timeline.test.ts
+++ b/packages/host-platform/tests/release-timeline.test.ts
@@ -1,0 +1,235 @@
+import { describe, it, expect } from 'vitest';
+import { render } from '@testing-library/svelte';
+import ReleaseTimeline from '../src/components/ReleaseTimeline.svelte';
+import type { ReleaseTimelineItem } from '../src/types.js';
+
+const baseReleases: ReleaseTimelineItem[] = [
+	{
+		id: 'v1412',
+		version: 'v1.4.12',
+		channel: 'stable',
+		date: '2026-05-22T00:00:00Z',
+		status: 'shipped',
+		adoption: 0.82,
+	},
+	{
+		id: 'v1500rc1',
+		version: 'v1.5.0-rc.1',
+		channel: 'beta',
+		date: '2026-05-23T00:00:00Z',
+		status: 'in-progress',
+		adoption: 0.05,
+	},
+];
+
+describe('ReleaseTimeline', () => {
+	it('renders as <section aria-labelledby> with the supplied accessible name', () => {
+		const { container } = render(ReleaseTimeline, {
+			label: 'Lesser release history',
+			releases: baseReleases,
+		});
+		const section = container.querySelector('section.gr-host-platform-release-timeline');
+		expect(section).toBeTruthy();
+		const labelledby = section?.getAttribute('aria-labelledby');
+		expect(labelledby).toBeTruthy();
+		expect(container.ownerDocument.getElementById(labelledby!)?.textContent).toBe(
+			'Lesser release history'
+		);
+	});
+
+	it('renders releases as a semantic <ol>', () => {
+		const { container } = render(ReleaseTimeline, {
+			label: 'r',
+			releases: baseReleases,
+		});
+		const list = container.querySelector('ol.gr-host-platform-release-timeline__list');
+		expect(list).toBeTruthy();
+		const items = list?.querySelectorAll('li');
+		expect(items?.length).toBe(2);
+	});
+
+	it.each([
+		['shipped', 'Shipped'],
+		['in-progress', 'Rolling out'],
+		['rolled-back', 'Rolled back'],
+		['planned', 'Planned'],
+	])('communicates status %s with text label (%s) — never color-only', (status, expectedLabel) => {
+		const { container } = render(ReleaseTimeline, {
+			label: 'r',
+			releases: [
+				{
+					id: 's',
+					version: 'v1.0.0',
+					channel: 'stable',
+					date: '2026-05-22',
+					status: status as never,
+				},
+			],
+		});
+		const badge = container.querySelector('.gr-host-platform-release-timeline__status');
+		expect(badge?.getAttribute('aria-label')).toBe(`Status: ${expectedLabel}`);
+		expect(badge?.textContent?.trim()).toBe(expectedLabel);
+	});
+
+	it('exposes the channel via aria-label (non-color-only)', () => {
+		const { container } = render(ReleaseTimeline, {
+			label: 'r',
+			releases: baseReleases,
+		});
+		const channels = container.querySelectorAll('.gr-host-platform-release-timeline__channel');
+		expect(channels.length).toBe(2);
+		expect(channels[0]?.getAttribute('aria-label')).toBe('Channel: stable');
+		expect(channels[1]?.getAttribute('aria-label')).toBe('Channel: beta');
+	});
+
+	it('renders <time datetime> with ISO date and visible formatted date', () => {
+		const { container } = render(ReleaseTimeline, {
+			label: 'r',
+			releases: [
+				{
+					id: 'r1',
+					version: 'v1.0.0',
+					channel: 'stable',
+					date: '2026-05-22T00:00:00Z',
+					status: 'shipped',
+				},
+			],
+		});
+		const time = container.querySelector('time.gr-host-platform-release-timeline__date');
+		const dt = time?.getAttribute('datetime');
+		expect(dt).toBeTruthy();
+		expect(dt).toContain('2026-05-22');
+		// Visible date renders something non-empty (Intl.DateTimeFormat may render
+		// locale-specific output; we just assert it's there).
+		expect(time?.textContent?.trim().length).toBeGreaterThan(0);
+	});
+
+	it('honors formatDate prop for custom date rendering', () => {
+		const { container } = render(ReleaseTimeline, {
+			label: 'r',
+			releases: [
+				{
+					id: 'r1',
+					version: 'v1.0.0',
+					channel: 'stable',
+					date: '2026-05-22T00:00:00Z',
+					status: 'shipped',
+				},
+			],
+			formatDate: (d) => (typeof d === 'string' ? `[${d}]` : `[${d.toISOString()}]`),
+		});
+		const time = container.querySelector('time');
+		expect(time?.textContent?.trim()).toBe('[2026-05-22T00:00:00Z]');
+	});
+
+	it('renders numeric adoption as a role="meter" with valid range and aria-valuetext', () => {
+		const { container } = render(ReleaseTimeline, {
+			label: 'r',
+			releases: [
+				{
+					id: 'r1',
+					version: 'v1.0.0',
+					channel: 'stable',
+					date: '2026-05-22',
+					status: 'shipped',
+					adoption: 0.42,
+				},
+			],
+		});
+		const meter = container.querySelector('[role="meter"]');
+		expect(meter).toBeTruthy();
+		const min = Number(meter?.getAttribute('aria-valuemin'));
+		const max = Number(meter?.getAttribute('aria-valuemax'));
+		const now = Number(meter?.getAttribute('aria-valuenow'));
+		expect(min).toBe(0);
+		expect(max).toBe(1);
+		expect(now).toBeCloseTo(0.42, 5);
+		expect(meter?.getAttribute('aria-valuetext')).toBe('Adoption: 42%');
+	});
+
+	it('clamps numeric adoption above 1.0 into [0,1] for the meter', () => {
+		const { container } = render(ReleaseTimeline, {
+			label: 'r',
+			releases: [
+				{
+					id: 'r1',
+					version: 'v1.0.0',
+					channel: 'stable',
+					date: '2026-05-22',
+					status: 'shipped',
+					adoption: 2.5, // intentional overrun
+				},
+			],
+		});
+		const meter = container.querySelector('[role="meter"]');
+		const now = Number(meter?.getAttribute('aria-valuenow'));
+		expect(now).toBe(1);
+		expect(meter?.getAttribute('aria-valuetext')).toBe('Adoption: 100%');
+	});
+
+	it('renders string adoption as text (no meter, no fake range)', () => {
+		const { container } = render(ReleaseTimeline, {
+			label: 'r',
+			releases: [
+				{
+					id: 'r1',
+					version: 'v1.0.0',
+					channel: 'stable',
+					date: '2026-05-22',
+					status: 'shipped',
+					adoption: '42 of 100 instances',
+				},
+			],
+		});
+		expect(container.querySelector('[role="meter"]')).toBeNull();
+		const text = container.querySelector('.gr-host-platform-release-timeline__adoption-static');
+		expect(text?.textContent).toContain('42 of 100 instances');
+	});
+
+	it('renders the release-notes link with accessible label when href is supplied', () => {
+		const { container } = render(ReleaseTimeline, {
+			label: 'r',
+			releases: [
+				{
+					id: 'r1',
+					version: 'v1.0.0',
+					channel: 'stable',
+					date: '2026-05-22',
+					status: 'shipped',
+					href: 'https://example.com/v1.0.0',
+				},
+			],
+		});
+		const link = container.querySelector('a.gr-host-platform-release-timeline__link');
+		expect(link?.getAttribute('aria-label')).toBe('Release notes for v1.0.0');
+	});
+
+	it('renders the empty state with role="status" when no releases are supplied', () => {
+		const { container } = render(ReleaseTimeline, {
+			label: 'r',
+			releases: [],
+			emptyMessage: 'No releases yet.',
+		});
+		const empty = container.querySelector('.gr-host-platform-release-timeline__empty');
+		expect(empty?.getAttribute('role')).toBe('status');
+		expect(empty?.textContent?.trim()).toBe('No releases yet.');
+	});
+
+	it('does not set inline style attribute on any rendered element', () => {
+		const { container } = render(ReleaseTimeline, {
+			label: 'r',
+			releases: baseReleases,
+		});
+		expect(container.querySelectorAll('[style]').length).toBe(0);
+	});
+
+	it('produces unique release item ids across multiple timeline instances', () => {
+		const a = render(ReleaseTimeline, { label: 'a', releases: baseReleases });
+		const b = render(ReleaseTimeline, { label: 'b', releases: baseReleases });
+		const aId = a.container.querySelector('li')?.getAttribute('id');
+		const bId = b.container.querySelector('li')?.getAttribute('id');
+		expect(aId).toBeTruthy();
+		expect(bId).toBeTruthy();
+		expect(aId).not.toBe(bId);
+	});
+});

--- a/packages/host-platform/tests/release-timeline.test.ts
+++ b/packages/host-platform/tests/release-timeline.test.ts
@@ -104,6 +104,67 @@ describe('ReleaseTimeline', () => {
 		expect(time?.textContent?.trim().length).toBeGreaterThan(0);
 	});
 
+	it('formats UTC-midnight and date-only release dates without timezone shift (Arch PR #670 review regression)', () => {
+		// `new Date('2026-05-22T00:00:00Z')` parses as UTC midnight; the default
+		// Intl.DateTimeFormat applies the viewer's local timezone, which renders
+		// the previous day in any zone west of UTC (US, Pacific, etc.). For
+		// calendar-day inputs (`YYYY-MM-DD` or `...T00:00:00Z`) we must format
+		// in UTC so the visible date matches what the consumer typed.
+		//
+		// We assert the date contains "22" (the day component) regardless of
+		// locale, and explicitly does NOT shift to "21".
+		const { container } = render(ReleaseTimeline, {
+			label: 'r',
+			releases: [
+				{
+					id: 'utc-midnight',
+					version: 'v1.0.0',
+					channel: 'stable',
+					date: '2026-05-22T00:00:00Z',
+					status: 'shipped',
+				},
+				{
+					id: 'date-only',
+					version: 'v1.0.1',
+					channel: 'stable',
+					date: '2026-05-23',
+					status: 'shipped',
+				},
+			],
+		});
+		const times = container.querySelectorAll('time.gr-host-platform-release-timeline__date');
+		const text1 = times[0]?.textContent?.trim() ?? '';
+		const text2 = times[1]?.textContent?.trim() ?? '';
+		expect(text1).toContain('22');
+		expect(text1).not.toContain('21');
+		expect(text2).toContain('23');
+		expect(text2).not.toContain('22');
+	});
+
+	it('preserves non-midnight timestamps in viewer-local timezone (existing behavior)', () => {
+		// Inputs with explicit non-midnight times remain instant-in-time
+		// semantics and may legitimately shift across day boundaries based on
+		// viewer timezone. This test pins that the calendar-day detection is
+		// narrow — it only kicks in for the unambiguous date-only cases.
+		const { container } = render(ReleaseTimeline, {
+			label: 'r',
+			releases: [
+				{
+					id: 'midday',
+					version: 'v1.0.0',
+					channel: 'stable',
+					date: '2026-05-22T14:30:00Z',
+					status: 'shipped',
+				},
+			],
+		});
+		const time = container.querySelector('time');
+		// Just assert the time renders something non-empty — exact date depends
+		// on viewer timezone, which is the correct semantics for an explicit
+		// instant.
+		expect(time?.textContent?.trim().length).toBeGreaterThan(0);
+	});
+
 	it('honors formatDate prop for custom date rendering', () => {
 		const { container } = render(ReleaseTimeline, {
 			label: 'r',
@@ -145,6 +206,36 @@ describe('ReleaseTimeline', () => {
 		expect(max).toBe(1);
 		expect(now).toBeCloseTo(0.42, 5);
 		expect(meter?.getAttribute('aria-valuetext')).toBe('Adoption: 42%');
+	});
+
+	it('adoption meter has an accessible name via aria-labelledby (Arch PR #670 review regression)', () => {
+		// Every `role="meter"` MUST have an accessible name. Previously we set
+		// aria-valuetext + aria-valuenow but left the meter unnamed, so screen
+		// readers announced only the value with no semantic anchor.
+		const { container } = render(ReleaseTimeline, {
+			label: 'r',
+			releases: [
+				{
+					id: 'r1',
+					version: 'v1.0.0',
+					channel: 'stable',
+					date: '2026-05-22',
+					status: 'shipped',
+					adoption: 0.42,
+				},
+			],
+		});
+		const meter = container.querySelector('[role="meter"]');
+		expect(meter).toBeTruthy();
+		const labelledby = meter?.getAttribute('aria-labelledby');
+		expect(labelledby, 'meter must have aria-labelledby').toBeTruthy();
+		const labelEl = container.ownerDocument.getElementById(labelledby!);
+		expect(labelEl, 'aria-labelledby must resolve to a real element').toBeTruthy();
+		expect(labelEl?.textContent).toContain('Adoption');
+		expect(labelEl?.textContent).toContain('42%');
+		// Should NOT also have aria-label (precedence pitfall — labelledby wins,
+		// but emitting both is ambiguous and triggers spec warnings).
+		expect(meter?.hasAttribute('aria-label')).toBe(false);
 	});
 
 	it('clamps numeric adoption above 1.0 into [0,1] for the meter', () => {

--- a/packages/host-platform/tests/stack-matrix.test.ts
+++ b/packages/host-platform/tests/stack-matrix.test.ts
@@ -1,0 +1,220 @@
+import { describe, it, expect, vi } from 'vitest';
+import { fireEvent, render } from '@testing-library/svelte';
+import { createRawSnippet } from 'svelte';
+import StackMatrix from '../src/components/StackMatrix.svelte';
+import type { StackMatrixColumn, StackMatrixRow } from '../src/types.js';
+
+function snippetOf(html: string) {
+	return createRawSnippet(() => ({ render: () => html }));
+}
+
+const columns: StackMatrixColumn[] = [
+	{ id: 'lesser', label: 'Lesser', sortable: true },
+	{ id: 'host', label: 'Lesser Host', sortable: true },
+	{ id: 'body', label: 'Body', sortable: false },
+];
+
+const rows: StackMatrixRow[] = [
+	{
+		id: 'r1',
+		label: 'lesser.example',
+		subLabel: 'us-east-1',
+		cells: {
+			lesser: { value: 'v1.4.12', drift: 'in-sync' },
+			host: { value: 'v0.4.5', drift: 'pending' },
+			body: { value: 'v0.2.1', drift: 'in-sync' },
+		},
+	},
+	{
+		id: 'r2',
+		label: 'lesser.staging',
+		subLabel: 'us-west-2',
+		cells: {
+			lesser: { value: 'v1.4.10', drift: 'drifted' },
+			host: { value: 'v0.4.5', drift: 'in-sync' },
+			body: { value: 'v0.2.0', drift: 'drifted' },
+		},
+	},
+];
+
+describe('StackMatrix', () => {
+	it('renders a real <table> with <caption>, <thead>, and <tbody>', () => {
+		const { container } = render(StackMatrix, {
+			caption: 'Lesser fleet stack versions',
+			columns,
+			rows,
+		});
+		const table = container.querySelector('table.gr-host-platform-stack-matrix__table');
+		expect(table).toBeTruthy();
+		expect(table?.querySelector('caption')).toBeTruthy();
+		expect(table?.querySelector('thead')).toBeTruthy();
+		expect(table?.querySelector('tbody')).toBeTruthy();
+	});
+
+	it('keeps the caption available to AT even when visually hidden (default)', () => {
+		const { container } = render(StackMatrix, {
+			caption: 'Lesser fleet stack versions',
+			columns,
+			rows,
+		});
+		const caption = container.querySelector('caption');
+		expect(caption?.classList.contains('gr-sr-only')).toBe(true);
+		expect(caption?.textContent?.trim()).toBe('Lesser fleet stack versions');
+	});
+
+	it('renders a column header per column with scope="col"', () => {
+		const { container } = render(StackMatrix, {
+			caption: 'c',
+			columns,
+			rows,
+		});
+		// First col header is the row-header placeholder, then one per column.
+		const colHeaders = container.querySelectorAll('thead th[scope="col"]');
+		// 1 row-header-col + 3 columns
+		expect(colHeaders.length).toBe(1 + columns.length);
+	});
+
+	it('renders a row header per row with scope="row"', () => {
+		const { container } = render(StackMatrix, {
+			caption: 'c',
+			columns,
+			rows,
+		});
+		const rowHeaders = container.querySelectorAll('tbody th[scope="row"]');
+		expect(rowHeaders.length).toBe(rows.length);
+		expect(rowHeaders[0]?.textContent).toContain('lesser.example');
+		expect(rowHeaders[0]?.textContent).toContain('us-east-1');
+	});
+
+	it('emits onsort when a sortable header button is clicked', async () => {
+		const onsort = vi.fn();
+		const { container } = render(StackMatrix, {
+			caption: 'c',
+			columns,
+			rows,
+			onsort,
+		});
+		const sortBtn = container.querySelector(
+			'.gr-host-platform-stack-matrix__col-header--sortable .gr-host-platform-stack-matrix__sort-button'
+		);
+		expect(sortBtn).toBeTruthy();
+		await fireEvent.click(sortBtn!);
+		expect(onsort).toHaveBeenCalledTimes(1);
+		expect(onsort.mock.calls[0]?.[0]).toBe('lesser');
+	});
+
+	it('does NOT emit onsort for non-sortable columns (no button rendered)', async () => {
+		const onsort = vi.fn();
+		const { container } = render(StackMatrix, {
+			caption: 'c',
+			columns,
+			rows,
+			onsort,
+		});
+		// "Body" column is not sortable; ensure no sort-button exists for it.
+		const headers = Array.from(container.querySelectorAll('thead th[scope="col"]'));
+		const bodyHeader = headers.find((h) => h.textContent?.includes('Body'));
+		expect(bodyHeader).toBeTruthy();
+		expect(bodyHeader?.querySelector('.gr-host-platform-stack-matrix__sort-button')).toBeNull();
+	});
+
+	it('reflects sortBy / sortDirection via aria-sort on the matching header only', () => {
+		const { container } = render(StackMatrix, {
+			caption: 'c',
+			columns,
+			rows,
+			sortBy: 'lesser',
+			sortDirection: 'descending',
+		});
+		const sorted = container.querySelectorAll('th[aria-sort]');
+		expect(sorted.length).toBe(1);
+		expect(sorted[0]?.getAttribute('aria-sort')).toBe('descending');
+		expect(sorted[0]?.textContent).toContain('Lesser');
+	});
+
+	it.each([
+		['in-sync', 'In sync'],
+		['pending', 'Update pending'],
+		['drifted', 'Drifted'],
+		['unknown', 'Unknown drift state'],
+	])(
+		'communicates drift state %s with text label (%s) — never color-only',
+		(drift, expectedLabel) => {
+			const { container } = render(StackMatrix, {
+				caption: 'c',
+				columns: [{ id: 'col', label: 'Col' }],
+				rows: [
+					{
+						id: 'r',
+						label: 'row',
+						cells: { col: { value: 'v', drift: drift as never } },
+					},
+				],
+			});
+			const cellValue = container.querySelector(
+				`.gr-host-platform-stack-matrix__cell-value--drift-${drift}`
+			);
+			expect(cellValue).toBeTruthy();
+			// The sr-only descriptor carries the drift label.
+			expect(cellValue?.textContent).toContain(expectedLabel);
+		}
+	);
+
+	it('renders rowActions inside a role="group" with row-specific accessible name', () => {
+		const { container } = render(StackMatrix, {
+			caption: 'c',
+			columns,
+			rows,
+			rowActions: snippetOf('<button type="button" data-test="action">Manage</button>'),
+		});
+		const groups = container.querySelectorAll('.gr-host-platform-stack-matrix__actions');
+		expect(groups.length).toBe(rows.length);
+		expect(groups[0]?.getAttribute('role')).toBe('group');
+		expect(groups[0]?.getAttribute('aria-label')).toBe('Row actions: lesser.example');
+		expect(groups[0]?.querySelector('[data-test="action"]')).toBeTruthy();
+	});
+
+	it('omits the actions column entirely when rowActions snippet is not provided', () => {
+		const { container } = render(StackMatrix, {
+			caption: 'c',
+			columns,
+			rows,
+		});
+		expect(container.querySelector('.gr-host-platform-stack-matrix__actions')).toBeNull();
+		expect(container.querySelector('.gr-host-platform-stack-matrix__actions-header')).toBeNull();
+	});
+
+	it('renders an empty-state row spanning all columns when rows.length === 0', () => {
+		const { container } = render(StackMatrix, {
+			caption: 'c',
+			columns,
+			rows: [],
+			emptyMessage: 'Nothing yet.',
+		});
+		const empty = container.querySelector('.gr-host-platform-stack-matrix__empty');
+		expect(empty?.textContent?.trim()).toBe('Nothing yet.');
+		// colspan covers row-header + columns + (0 actions cols here).
+		expect(empty?.getAttribute('colspan')).toBe(String(columns.length + 1));
+	});
+
+	it('does not set inline style attribute on any rendered element', () => {
+		const { container } = render(StackMatrix, {
+			caption: 'c',
+			columns,
+			rows,
+			sortBy: 'lesser',
+			sortDirection: 'ascending',
+		});
+		expect(container.querySelectorAll('[style]').length).toBe(0);
+	});
+
+	it('produces unique row ids across multiple matrix instances', () => {
+		const a = render(StackMatrix, { caption: 'a', columns, rows });
+		const b = render(StackMatrix, { caption: 'b', columns, rows });
+		const idA = a.container.querySelector('tbody tr')?.getAttribute('id');
+		const idB = b.container.querySelector('tbody tr')?.getAttribute('id');
+		expect(idA).toBeTruthy();
+		expect(idB).toBeTruthy();
+		expect(idA).not.toBe(idB);
+	});
+});

--- a/registry/index.json
+++ b/registry/index.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://equalto.ai/schemas/registry-index.schema.json",
   "schemaVersion": "1.0.0",
-  "generatedAt": "2026-05-24T21:22:41.641Z",
+  "generatedAt": "2026-05-24T21:48:48.877Z",
   "ref": "greater-v0.9.0",
   "version": "0.9.0",
   "checksums": {
@@ -928,9 +928,15 @@
     "packages/host-platform/src/components/CostGauge.svelte": "sha256-MXGntskauXYINmg68F8Sa6ST/Kd14e5+Ff3/I+vD/wY=",
     "packages/host-platform/src/components/FleetCard.css": "sha256-rslZpcvYjpViDEP6F08QV9gGDTgCmiqYiQ95zuX2wXQ=",
     "packages/host-platform/src/components/FleetCard.svelte": "sha256-vVyr8nmE+E/utrZzaXWP0cbHuRXKofAo3R8J7X00yJ4=",
-    "packages/host-platform/src/index.ts": "sha256-iaKrAZ1nPtEbnw9jRTc59X/8afo9CsJJDy9538tzS30=",
-    "packages/host-platform/src/styles/base.css": "sha256-EvtaDGp/SuADtSnRc9VOl1ZNydpnyBQT4rw5zMATmTg=",
-    "packages/host-platform/src/types.ts": "sha256-EnkMzghFTrT2Gk3nk8DQqzn58xGPeYTY4ZJ0dIbM4/o=",
+    "packages/host-platform/src/components/ProvisioningTimeline.css": "sha256-rphEj1C3PlOup0baAgJyDSkSiZmzvMX2JhOBlpGj+J4=",
+    "packages/host-platform/src/components/ProvisioningTimeline.svelte": "sha256-DnbAeiSTqQ0/M9p7MNthklTAUcRSR6FdxA6cG232oL8=",
+    "packages/host-platform/src/components/ReleaseTimeline.css": "sha256-UCzT8op2KiKophHU40Bcfv80iMmv22DjWH2nMAxfLNY=",
+    "packages/host-platform/src/components/ReleaseTimeline.svelte": "sha256-EgdPZ4WJhFlmSnragw/HU5jY3aA2CTVtNIRBlvT76cY=",
+    "packages/host-platform/src/components/StackMatrix.css": "sha256-K59j8igR3hBFO2cFyaq3Rp0Dkjypg3+DM4wLCSWN9cY=",
+    "packages/host-platform/src/components/StackMatrix.svelte": "sha256-aMruAWkbvQmTTEXLd8Yp5kQdHegwLoj64//o2q5UGPo=",
+    "packages/host-platform/src/index.ts": "sha256-hFXD84EuQLU6bKXPyTkFUwxOewMy8fkcwkVzbRpAsTg=",
+    "packages/host-platform/src/styles/base.css": "sha256-razMHs+WCheiXksb3g4y90O42WAyMruExK9MiNmJbhc=",
+    "packages/host-platform/src/types.ts": "sha256-9wKDSQaj3aQ9OXIqdTbYM6O6sGbAxfpwa0I1119yBLg=",
     "packages/host-platform/src/utils/formatters.ts": "sha256-kkUGG/4k60g54llCi+xp5RmnYrg8TuFqMiKgdgd01cE=",
     "packages/host-platform/src/utils/sparkline.ts": "sha256-w8R8uqcnpPo2QK8crNVtabB10ChInLNOdNeQ6HxNUCM=",
     "packages/faces/social/src/adapters/batcher.ts": "sha256-6PnUshOPk84U+PSnkADYzhN9SpUrvwiy+tN10HPaVeE=",
@@ -6199,19 +6205,49 @@
           "size": 7366
         },
         {
+          "path": "src/components/ProvisioningTimeline.css",
+          "checksum": "sha256-rphEj1C3PlOup0baAgJyDSkSiZmzvMX2JhOBlpGj+J4=",
+          "size": 6355
+        },
+        {
+          "path": "src/components/ProvisioningTimeline.svelte",
+          "checksum": "sha256-DnbAeiSTqQ0/M9p7MNthklTAUcRSR6FdxA6cG232oL8=",
+          "size": 6658
+        },
+        {
+          "path": "src/components/ReleaseTimeline.css",
+          "checksum": "sha256-UCzT8op2KiKophHU40Bcfv80iMmv22DjWH2nMAxfLNY=",
+          "size": 5801
+        },
+        {
+          "path": "src/components/ReleaseTimeline.svelte",
+          "checksum": "sha256-EgdPZ4WJhFlmSnragw/HU5jY3aA2CTVtNIRBlvT76cY=",
+          "size": 8358
+        },
+        {
+          "path": "src/components/StackMatrix.css",
+          "checksum": "sha256-K59j8igR3hBFO2cFyaq3Rp0Dkjypg3+DM4wLCSWN9cY=",
+          "size": 5005
+        },
+        {
+          "path": "src/components/StackMatrix.svelte",
+          "checksum": "sha256-aMruAWkbvQmTTEXLd8Yp5kQdHegwLoj64//o2q5UGPo=",
+          "size": 8863
+        },
+        {
           "path": "src/index.ts",
-          "checksum": "sha256-iaKrAZ1nPtEbnw9jRTc59X/8afo9CsJJDy9538tzS30=",
-          "size": 1730
+          "checksum": "sha256-hFXD84EuQLU6bKXPyTkFUwxOewMy8fkcwkVzbRpAsTg=",
+          "size": 2233
         },
         {
           "path": "src/styles/base.css",
-          "checksum": "sha256-EvtaDGp/SuADtSnRc9VOl1ZNydpnyBQT4rw5zMATmTg=",
-          "size": 1441
+          "checksum": "sha256-razMHs+WCheiXksb3g4y90O42WAyMruExK9MiNmJbhc=",
+          "size": 1777
         },
         {
           "path": "src/types.ts",
-          "checksum": "sha256-EnkMzghFTrT2Gk3nk8DQqzn58xGPeYTY4ZJ0dIbM4/o=",
-          "size": 1512
+          "checksum": "sha256-9wKDSQaj3aQ9OXIqdTbYM6O6sGbAxfpwa0I1119yBLg=",
+          "size": 6274
         },
         {
           "path": "src/utils/formatters.ts",

--- a/registry/index.json
+++ b/registry/index.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://equalto.ai/schemas/registry-index.schema.json",
   "schemaVersion": "1.0.0",
-  "generatedAt": "2026-05-24T21:48:48.877Z",
+  "generatedAt": "2026-05-24T22:35:12.018Z",
   "ref": "greater-v0.9.0",
   "version": "0.9.0",
   "checksums": {
@@ -929,9 +929,9 @@
     "packages/host-platform/src/components/FleetCard.css": "sha256-rslZpcvYjpViDEP6F08QV9gGDTgCmiqYiQ95zuX2wXQ=",
     "packages/host-platform/src/components/FleetCard.svelte": "sha256-vVyr8nmE+E/utrZzaXWP0cbHuRXKofAo3R8J7X00yJ4=",
     "packages/host-platform/src/components/ProvisioningTimeline.css": "sha256-rphEj1C3PlOup0baAgJyDSkSiZmzvMX2JhOBlpGj+J4=",
-    "packages/host-platform/src/components/ProvisioningTimeline.svelte": "sha256-DnbAeiSTqQ0/M9p7MNthklTAUcRSR6FdxA6cG232oL8=",
+    "packages/host-platform/src/components/ProvisioningTimeline.svelte": "sha256-p5Vnk8hHwe/VUaYsZwZ33+Q9IG42UuzZLo8vAa5tCdw=",
     "packages/host-platform/src/components/ReleaseTimeline.css": "sha256-UCzT8op2KiKophHU40Bcfv80iMmv22DjWH2nMAxfLNY=",
-    "packages/host-platform/src/components/ReleaseTimeline.svelte": "sha256-EgdPZ4WJhFlmSnragw/HU5jY3aA2CTVtNIRBlvT76cY=",
+    "packages/host-platform/src/components/ReleaseTimeline.svelte": "sha256-L8/Bx4pTa5DDE6kB8uxozkRjkMtDXqpLPUss8LR54/Y=",
     "packages/host-platform/src/components/StackMatrix.css": "sha256-K59j8igR3hBFO2cFyaq3Rp0Dkjypg3+DM4wLCSWN9cY=",
     "packages/host-platform/src/components/StackMatrix.svelte": "sha256-aMruAWkbvQmTTEXLd8Yp5kQdHegwLoj64//o2q5UGPo=",
     "packages/host-platform/src/index.ts": "sha256-hFXD84EuQLU6bKXPyTkFUwxOewMy8fkcwkVzbRpAsTg=",
@@ -6211,8 +6211,8 @@
         },
         {
           "path": "src/components/ProvisioningTimeline.svelte",
-          "checksum": "sha256-DnbAeiSTqQ0/M9p7MNthklTAUcRSR6FdxA6cG232oL8=",
-          "size": 6658
+          "checksum": "sha256-p5Vnk8hHwe/VUaYsZwZ33+Q9IG42UuzZLo8vAa5tCdw=",
+          "size": 7742
         },
         {
           "path": "src/components/ReleaseTimeline.css",
@@ -6221,8 +6221,8 @@
         },
         {
           "path": "src/components/ReleaseTimeline.svelte",
-          "checksum": "sha256-EgdPZ4WJhFlmSnragw/HU5jY3aA2CTVtNIRBlvT76cY=",
-          "size": 8358
+          "checksum": "sha256-L8/Bx4pTa5DDE6kB8uxozkRjkMtDXqpLPUss8LR54/Y=",
+          "size": 9974
         },
         {
           "path": "src/components/StackMatrix.css",


### PR DESCRIPTION
## Milestone

**G3 — Operator timelines and stack matrix for Host M2** — parent issue #636, child sub-issues #656–#660. Closes G3.1 (#656), G3.2 (#657), G3.3 (#658), G3.4 (#659), G3.5 (#660).

Adds three operator-console components to the existing `@equaltoai/greater-components/host-platform` surface for the lesser-host web M2 rollout (Greater Project 39 Signal D).

## Classification

component-addition (three additive components in the existing package, twelve new public types, CLI registry refresh, docs + playground extension; no breaking changes; no Lesser / Lesser Host contract or adapter changes).

## Surfaces affected

- **New components in `packages/host-platform/src/components/`**:
  - `ProvisioningTimeline.svelte` + `.css` — ordered job-steps timeline with constrained live-log region
  - `ReleaseTimeline.svelte` + `.css` — two-channel release history with adoption metric
  - `StackMatrix.svelte` + `.css` — semantic `<table>` of stack drift with sort + row actions
- **Twelve new public types** added to `packages/host-platform/src/types.ts`: `ProvisioningStep`, `ProvisioningStepStatus`, `ProvisioningLogPoliteness`, `ReleaseChannel`, `ReleaseStatus`, `ReleaseTimelineItem`, `ReleaseAdoptionFormatter`, `StackMatrixDrift`, `StackMatrixColumn`, `StackMatrixCell`, `StackMatrixRow`, `StackMatrixSortDirection`.
- **Barrel**: `packages/host-platform/src/index.ts` exports the three components and all twelve types.
- **Package.json**: three new subpath exports (`./ProvisioningTimeline`, `./ReleaseTimeline`, `./StackMatrix`).
- **base.css**: `:where(...)` selectors extended to include the new component root classes for box-sizing and `--gr-host-platform-*` token defaults.
- **CLI registry**: `packages/cli/src/registry/index.ts` updates `host-platform` description + tags.
- **registry/index.json**: regenerated (1437 checksums, +6 over G2).
- **Docs**: `docs/component-inventory.md` and `docs/api-reference.md` Host-platform sections grown from 3 to 6 components, with expanded accessibility narrative and twelve new prop unions documented.
- **Playground**: `apps/playground/src/routes/host-platform/+page.svelte` extended with three new sections at the bottom of the demo page (ProvisioningTimeline with live log, ReleaseTimeline with three releases, StackMatrix with working client-side sort).

## Specialist walks referenced

- **Component API / theming** (`evolve-component-surface` walk):
  - Additive only — no existing exports renamed or removed.
  - Twelve new typed contracts; all components Svelte 5 runes with strongly-typed `$props()` interfaces.
  - Theming via existing stable `--gr-*` semantic tokens plus the already-additive `--gr-host-platform-*` tokens added in G2 (no new tokens this milestone).
- **Accessibility** (`enforce-accessibility` walk):
  - **Status is never color-only.** Every `ProvisioningStepStatus` (pending ○ / active ◌ / success ✓ / failure ✕ / skipped —), `ReleaseStatus` (shipped ✓ / in-progress ◌ / rolled-back ↺ / planned ○), and `StackMatrixDrift` (in-sync ● / pending ◌ / drifted ⚠ / unknown ?) renders an icon glyph plus a visible text label.
  - **ProvisioningTimeline**: `<section aria-labelledby>` + semantic `<ol>`. Active step carries `aria-current="step"`. Optional live-log slot wraps in `<section role="log" aria-live="polite" aria-atomic="false" aria-relevant="additions">` so AT users hear only NEW lines on each update — not the whole backlog. `liveLogPoliteness` configurable to `assertive` (urgent failures) or `off` (visible-only).
  - **ReleaseTimeline**: channel exposed via `aria-label`, dates via `<time datetime>`, numeric adoption as nested `role="meter"` with `[0, 1]` range + composed `aria-valuetext` (e.g. `"Adoption: 42%"`). Overrun ratios are clamped (same discipline as CostGauge in G2). String adoption renders as static text — no fake meter range.
  - **StackMatrix**: real `<table>` with `<caption>` (visually-hidden by default but available to AT), `<th scope="col">` column headers, `<th scope="row">` row headers, and `aria-sort` on the currently-sorted column only. Sortable column headers render as `<button>` elements (browser-native keyboard contract). Per-row actions wrapped in `<div role="group">` with row-specific accessible name.
  - All ids unique across multiple instances via `useStableId`.
- **Strict CSP** — no inline event handlers, no `style` attributes set at runtime. Sortable headers use real `<button onclick>` (compiled to addEventListener); no inline handlers.
- **Contract sync** — none. No `packages/adapters/` changes; no Lesser / Lesser Host snapshot changes. Consumers supply already-shaped data per #636 guardrails.
- **Release flow** — three-branch flow respected: PR targets `staging`. Branch is based off `staging` directly (post-#669 merge `4862e285`), so `origin/main` and `origin/premain` are not ancestors of HEAD. CI promotion-rehearsal runs `simulate-squash` (PASS locally) and `preserve-topology` (PASS locally) — either merge type is safe.

## Semver impact

**minor.** `.changeset/host-platform-g3.md` declares minor for `greater-components`, `@equaltoai/greater-components`, `@equaltoai/greater-components-host-platform`. No breaking changes.

## Consumer impact

- **lesser-host (Project 39, M2)**: can render provisioning progress, release history, and stack-drift dashboards without bespoke UI and without coupling Greater to unreleased Host API contracts.
- **sim, lesser UIs**: additive only — no required action.
- **External Mastodon-compatible consumers**: unaffected; hosted-platform-specific surface.

## Tasks

- [x] **G3.1 — Implement ProvisioningTimeline (#656)** — semantic `<ol>` with `aria-current="step"` on active; constrained `<section role="log" aria-live aria-atomic="false" aria-relevant="additions">` live-log wrapper; status icon + text (never color-only); empty-state with `role="status"`.
- [x] **G3.2 — Implement ReleaseTimeline (#657)** — semantic `<ol>` of releases with channel `aria-label`, `<time datetime>`, numeric adoption as nested `role="meter"` with `[0, 1]` range + clamping, string adoption as static text. Overridable `formatDate` + `formatAdoption`.
- [x] **G3.3 — Implement StackMatrix (#658)** — real `<table>` with `<caption>` (sr-only by default), `<th scope="col">`, `<th scope="row">`, `aria-sort`, drift indicators (non-color-only), `<div role="group">` row actions with row-specific accessible name. Presentation-only; consumer manages sort state.
- [x] **G3.4 — Test timeline + matrix accessibility (#659)** — 40 new tests across three files (13 ProvisioningTimeline + 15 ReleaseTimeline + 12 StackMatrix). Host-platform suite now **105 / 105 PASS** (was 57).
- [x] **G3.5 — Document and register (#660)** — inventory + api-reference grown from 3 → 6 components, playground demo extended with three new sections, CLI registry refreshed, registry regenerated.

## Changesets

- `.changeset/host-platform-g3.md` — `greater-components: minor`, `@equaltoai/greater-components: minor`, `@equaltoai/greater-components-host-platform: minor`.

## Validation (local)

- `pnpm install` — clean (no lockfile changes).
- `pnpm --filter @equaltoai/greater-components-host-platform build` — clean (host-platform.css 39,114 bytes; was 21,532 at G2).
- `pnpm --filter @equaltoai/greater-components-host-platform test` — **105 / 105 PASS** (was 57 at G2).
- `pnpm --filter @equaltoai/greater-components-cli test` — 822 / 822 PASS.
- `pnpm -r build` — workspace-wide clean.
- `pnpm test` — workspace-wide green; no regressions.
- `pnpm --filter @equaltoai/playground build` — 48 HTML files, 48 inline scripts extracted by CSP postprocessor. New `/host-platform` route extended with the three new component sections.
- `pnpm format`, `pnpm format:check` — clean.
- `pnpm lint` — 0 errors.
- `pnpm validate:registry` (PASS), `validate:cli` (2874 files, +12 over G2), `validate:exports` (35 packages), `validate:dist`, `validate:deps`, `validate:tokens`, `validate:ids` (no unstable id generation), `validate:csp` (0 new violations), `validate:versions` — all PASS.
- `node scripts/check-dco.js --base origin/staging --head HEAD` — PASS (2 commits).
- `node scripts/rehearse-release-promotion.js --candidate HEAD` — PASS (preserve-topology).
- `node scripts/rehearse-release-promotion.js --candidate HEAD --simulate-squash` — PASS (simulate-squash).

## Release-flow plan (handoff after merge to staging)

- [ ] Merge to staging (squash OR merge-commit both safe).
- [ ] Staging soak.
- [ ] Promote to premain via `release-components` (release-please RC PR; cuts `greater-vX.Y.Z-rc.N`).
- [ ] RC soak.
- [ ] Promote to main via `release-components` (cuts stable tag + CLI tarball + registry + GitHub Release).
- [ ] Backmerge main → premain → staging.

## Cross-repo coordination

- **lesser-host (Project 39 — primary consumer)**: unblocks operator-console adoption in lesser-host web M2.
- **sim, lesser UIs**: additive only — no required action.

## Advisor-brief authorization

N/A — this work proceeded from the existing Greater Project 39 roadmap (issues #636, #656–#660) and Aron's direct direction ("merged, sync to staging and proceed to implement-milestone G3, keeping our project status up to date as you go"). No `@lessersoul.ai` advisor brief was used.

## GitHub Project status

Already kept in sync: Project 39 items for G2 (#635 + #650–#655) moved to Done after PR #669 merge; G3 (#636 + #656–#660) moved to In Progress at PR open.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)