### PR TITLE
chore(release): G4 release-coordination docs + parity checklist + deferred contract-sync lane (#637)

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,120 @@
+<!--
+Thanks for contributing to greater-components!
+
+Before opening this PR, please make sure every applicable box below is
+checked. The parity checklist is enforced by the Greater steward — PRs
+that ship a new component or surface MUST land docs, tests, playground
+example, and registry update in the same PR train (see Project 39
+G4.1 / #661).
+-->
+
+## Summary
+
+<!-- 1–3 sentences: what does this PR do and why? -->
+
+## Classification
+
+<!-- Pick one: component-addition / api-evolution / adapter-change /
+     accessibility / theming / cli-registry / release-automation /
+     docs / dependency-maintenance / bug-fix / release-coordination -->
+
+## Component-milestone parity checklist
+
+> Required for every PR that adds a new component, prop, public type, or
+> export subpath. If your change does NOT touch a component surface,
+> mark each row N/A and add a one-line reason in **Notes**.
+
+- [ ] **Source** — Svelte component(s) + CSS + types added under
+      `packages/<package>/src/`.
+- [ ] **Types** — public type contracts exported via `types.ts` /
+      package `./types` subpath.
+- [ ] **Tests** — unit + a11y tests in `packages/<package>/tests/`
+      covering: landmarks / accessible names, keyboard contract,
+      status / state semantics, strict-CSP (no inline `style`),
+      unique-id-across-instances.
+- [ ] **Docs** — `docs/component-inventory.md` and
+      `docs/api-reference.md` updated with the new component(s) and
+      prop unions.
+- [ ] **Playground** — demo route under
+      `apps/playground/src/routes/<feature>/+page.svelte` exercising
+      every state / variant.
+- [ ] **CLI registry** — `packages/cli/src/registry/index.ts` entry
+      added or updated.
+- [ ] **Generated registry** — `pnpm generate-registry` run and
+      `registry/index.json` committed. **No hand-edits.**
+- [ ] **Greater-components barrel** — root barrel
+      (`packages/greater-components/package.json` + `scripts/build.js`)
+      updated to expose the new package / subpath.
+- [ ] **Docs workflow** — `.github/workflows/docs.yml` updated to
+      build the new package before the playground / docs apps (if a new
+      workspace package is introduced).
+
+## Stewardship guarantees
+
+- [ ] **Strict-CSP safe** — no inline event handlers, no `style` attrs
+      set at runtime, no module-level browser globals.
+- [ ] **SSR-safe** — components render correctly in SvelteKit SSR.
+- [ ] **WCAG 2.1 AA** — every interactive element is keyboard reachable
+      with visible focus, status is never color-only, ARIA roles match
+      their contract (e.g. `role="meter"` has accessible name + valid
+      range, `role="log"` only used when announcements are intended).
+- [ ] **Theming preserved** — existing `--gr-*` tokens unchanged; only
+      additive `--gr-*` / `--gr-<pkg>-*` tokens introduced.
+- [ ] **No npm publication** — greater-components is shadcn-style CLI
+      distribution only; this PR does not introduce npm publish steps.
+- [ ] **No AGPL-incompatible dependencies** — any new dependency is
+      license-vetted.
+
+## Changeset
+
+- [ ] `.changeset/<slug>.md` added with **minor** impact for additive
+      component / API work (no breaking changes), OR docs-only change
+      documented as no-changeset.
+
+## Semver impact
+
+<!-- major / minor / patch / none — must match the changeset front-matter -->
+
+## Consumer impact
+
+- **sim:** <preserved / breaking / explicit drop>
+- **lesser-host web:** <preserved / breaking / explicit drop>
+- **lesser UIs:** <preserved / breaking / explicit drop>
+- **external Mastodon-compat:** <preserved / breaking / explicit drop>
+
+## Validation
+
+- [ ] `pnpm install` (frozen lockfile)
+- [ ] `pnpm lint`
+- [ ] `pnpm format:check`
+- [ ] `pnpm typecheck`
+- [ ] `pnpm test`
+- [ ] `pnpm build`
+- [ ] `pnpm test:a11y` (where applicable)
+- [ ] `pnpm validate:registry`, `validate:cli`, `validate:exports`,
+      `validate:dist`, `validate:deps`, `validate:tokens`, `validate:ids`,
+      `validate:csp`, `validate:versions`, `check:openapi-auth`
+- [ ] `node scripts/check-dco.js --base origin/staging --head HEAD`
+- [ ] `node scripts/rehearse-release-promotion.js --candidate HEAD`
+      (preserve-topology + `--simulate-squash` both PASS, or merge type
+      noted in PR description)
+
+## Cross-repo coordination
+
+<!-- Required / none. If required, name the counterpart steward
+     (lesser, host, sim) and what they need to do. -->
+
+## Release-flow plan (handoff after merge to staging)
+
+- [ ] Merged to staging
+- [ ] Staging soak complete
+- [ ] Promoted to premain via `release-components` (RC tag cut)
+- [ ] RC soak (incl. internal consumer validation: sim, host)
+- [ ] Promoted to main via `release-components` (stable tag + CLI
+      tarball + registry + GitHub Release)
+- [ ] Backmerge main → premain → staging
+
+## Notes
+
+<!-- Optional context: open questions, design alternatives considered,
+     N/A justifications for any parity-checklist boxes. -->

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -67,9 +67,15 @@ G4.1 / #661).
 
 ## Changeset
 
+> Changesets are **optional** — see
+> [CONTRIBUTING.md § Changesets](../CONTRIBUTING.md#changesets) for the
+> exact policy enforced by the `Changeset (Optional)` workflow.
+
 - [ ] `.changeset/<slug>.md` added with **minor** impact for additive
-      component / API work (no breaking changes), OR docs-only change
-      documented as no-changeset.
+      component / API work, or **patch** for bug fixes, or **major**
+      for breaking changes (which require stewardship approval), OR
+      this PR is docs-only / test-only / CI / release-coordination and
+      explicitly does not need a changeset (note the reason below).
 
 ## Semver impact
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -150,7 +150,10 @@ git commit -s -m "docs: update README with installation instructions"
 3. Update documentation alongside any user-facing change:
    `docs/component-inventory.md`, `docs/api-reference.md`, and a
    playground demo under `apps/playground/src/routes/`.
-4. Add a changeset:
+4. **Optionally** add a changeset when you want this PR's changes to
+   appear in the next published release notes (see the
+   [Changesets](#changesets) section below for when one is required
+   vs. optional):
    ```bash
    pnpm changeset
    ```
@@ -189,13 +192,46 @@ missing any item without an explicit `N/A` justification.
 
 ### Changesets
 
-This project uses [Changesets](https://github.com/changesets/changesets) for version management:
+This project uses [Changesets](https://github.com/changesets/changesets)
+for version management, but **changesets are optional** — the
+`Changeset (Optional)` workflow does not require one for docs-only,
+test-only, CI-config, or release-coordination PRs (see
+`.github/workflows/changeset-required.yml` for the exact policy that
+runs in CI, and `AGENTS.md` for the steward's posture).
 
-1. Run `pnpm changeset` when you make changes
-2. Select the packages affected
-3. Choose the version bump type (major, minor, patch)
-4. Write a summary of your changes
-5. Commit the generated changeset file
+**Add a changeset when:**
+
+- You change a published package's runtime / build / export surface
+  (anything under `packages/*` that affects consumers' installed
+  output).
+- You bump a dependency that consumers will receive.
+- You make any change you want to appear in the release notes.
+
+**Skip the changeset when:**
+
+- The PR only edits `docs/`, `apps/playground/`, `apps/docs/`, tests,
+  CI workflows, repo tooling, ADRs, or stewardship docs (CONTRIBUTING,
+  AGENTS, CODEOWNERS).
+- The PR is a release-coordination commit that the
+  `release-components` skill will follow (RC promotion, stable
+  promotion, backmerges).
+- The PR is purely a registry regeneration with no source change.
+
+When you do add one:
+
+1. Run `pnpm changeset`.
+2. Select the packages affected.
+3. Choose the version bump type (`major` / `minor` / `patch`). Use
+   `minor` for additive component or API work; `major` only for
+   breaking changes (which need `evolve-component-surface` stewardship
+   approval).
+4. Write a summary of your changes — release-please rolls these into
+   the consolidated changelog on the next version bump.
+5. Commit the generated `.changeset/<slug>.md` file with the rest of
+   your changes.
+
+If you're unsure whether your change needs a changeset, ask in the PR
+description — the Greater steward will tell you on review.
 
 ## Package Development
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -139,15 +139,53 @@ git commit -s -m "docs: update README with installation instructions"
 
 ### Pull Request Process
 
-1. Ensure all tests pass and coverage requirements are met
-2. Update documentation as needed
-3. Add a changeset for your changes:
+1. Open the PR — `.github/PULL_REQUEST_TEMPLATE.md` populates the
+   description automatically. The template includes the
+   **component-milestone parity checklist**, the
+   **stewardship-guarantees checklist**, validation commands, and a
+   release-flow handoff plan. Fill out every applicable section.
+2. Ensure all CI gates pass (lint, format, typecheck, test, build,
+   Playwright a11y matrix, registry / package validations, DCO,
+   promotion rehearsal). Coverage threshold is 75%.
+3. Update documentation alongside any user-facing change:
+   `docs/component-inventory.md`, `docs/api-reference.md`, and a
+   playground demo under `apps/playground/src/routes/`.
+4. Add a changeset:
    ```bash
    pnpm changeset
    ```
-4. Create a pull request with a clear description
-5. Link any related issues
-6. Wait for code review and address feedback
+   — Pick **minor** for additive component / API work; **patch** for
+   bug fixes; **major** is reserved for breaking changes (which require
+   `evolve-component-surface` stewardship approval and explicit
+   consumer coordination).
+5. Regenerate the CLI registry whenever package source changes:
+   ```bash
+   pnpm generate-registry
+   pnpm validate:registry
+   ```
+   Commit the regenerated `registry/index.json` alongside the source
+   change. **Never hand-edit `registry/index.json` or `registry/latest.json`** —
+   they're managed by automation and the strict checksum validator
+   rejects drift.
+6. Link any related issues and wait for code review.
+
+#### Component-milestone parity (Project 39 G4.1 / #661)
+
+Every PR that ships a new component or extends a public surface MUST
+include all of the following in the same PR train. The PR template
+checklist enforces this; the Greater steward will not approve a PR
+missing any item without an explicit `N/A` justification.
+
+- Source (component + CSS + types)
+- Tests (unit + a11y + strict-CSP + unique-id-across-instances)
+- Documentation (`component-inventory.md`, `api-reference.md`)
+- Playground demo (`apps/playground/src/routes/<feature>/`)
+- CLI registry entry (`packages/cli/src/registry/index.ts`)
+- Generated registry refresh (`registry/index.json` via
+  `pnpm generate-registry`)
+- Greater-components root-barrel wiring
+- Docs workflow update (`.github/workflows/docs.yml`) for new
+  workspace packages
 
 ### Changesets
 
@@ -201,12 +239,49 @@ All components must meet WCAG 2.1 AA standards:
 
 ## Release Process
 
-Releases are automated through GitHub Actions:
+**greater-components does NOT publish to npm.** It is distributed via the
+shadcn-style **Greater CLI**: consumers `npm install -g` a GitHub
+Release tarball, then run `greater init` / `greater add <component>` /
+`greater update --ref <tag>` to copy component **source** (not bundles)
+into their own project. Per-file SHA256 checksums in
+`registry/index.json` verify integrity on install.
 
-1. Changesets create a release PR
-2. Maintainers review and merge the PR
-3. GitHub Actions automatically publishes to npm
-4. Tags and releases are created on GitHub
+Releases follow the **three-branch flow**:
+
+1. **`staging`** — entry point. Feature PRs merge here. Branch
+   protection requires the full CI gate set to pass before merge.
+2. **`premain`** — RC track. The `release-components` skill promotes
+   `staging → premain` when an RC is ready. `release-please` opens a
+   release PR there using `release-please-config.premain.json`. Merging
+   it cuts an **RC tag** (`greater-vX.Y.Z-rc.N`) and publishes the RC
+   GitHub Release with the CLI tarball asset attached. Consumers
+   (lesser-host, sim) validate by pinning via
+   `greater update --ref greater-vX.Y.Z-rc.N`.
+3. **`main`** — stable. After RC validation, `release-components`
+   promotes `premain → main`. A second `release-please` PR cuts the
+   **stable tag** (`greater-vX.Y.Z`) and publishes the stable GitHub
+   Release. Once stable ships, automation **backmerges** main →
+   premain → staging to keep the branches in sync.
+
+**Discipline:**
+
+- **Published tags are immutable.** A bad release is fixed by a new
+  patch (`greater-vX.Y.Z+1`), never by re-pointing the tag.
+- **GitHub Release assets are never deleted.** Older releases are
+  consumer rollback targets via `greater update --ref <prior-tag>`.
+- **Merge type matters.** Branches that already carry `origin/main` /
+  `origin/premain` ancestry MUST be merged with **"Create a merge
+  commit"** (preserve-topology) — squashing loses ancestry and breaks
+  the next promotion rehearsal. Pure staging-based branches can
+  squash-merge safely. The `Rehearse staging promotion path` CI job
+  detects the right mode automatically; local engineers can verify with
+  `node scripts/rehearse-release-promotion.js --candidate HEAD` and
+  `--simulate-squash`.
+- **No skipped gates.** Compressed soak periods require explicit
+  operator authorization documented in a release-coordination issue.
+
+See also: the `release-components` skill (`.claude/skills/release-components/SKILL.md`)
+for the full RC / stable promotion playbook.
 
 ## Questions?
 

--- a/docs/host-platform/contract-sync-lane.md
+++ b/docs/host-platform/contract-sync-lane.md
@@ -1,0 +1,140 @@
+# Lesser Host contract-sync lane (deferred)
+
+> Status: **deferred** — no work scheduled.
+>
+> This document is the visible placeholder for the future Lesser Host
+> contract-sync work that the Project 39 G2 / G3 host-platform
+> components do **not** currently depend on. It exists so the Greater
+> steward, host steward, and any reviewer can see at a glance which
+> data-fetching / adapter work is intentionally NOT in scope yet, and
+> the explicit conditions that would activate the lane.
+>
+> Tracked by issue #666 (G4.6) under parent #637.
+
+## Why the lane is deferred
+
+The Greater Host adoption track for Project 39 ships **presentational
+components only**:
+
+- `packages/shell/` — app shell + command palette (G0, G1)
+- `packages/host-platform/` — fleet card, cost gauge, activity
+  sparkline, provisioning timeline, release timeline, stack matrix
+  (G2, G3)
+
+Every one of these components accepts **already-shaped data** from the
+consumer. Lesser-host `web/` will construct that data from its own
+Lesser Host API calls; Greater is never the layer that talks to Lesser
+Host directly for these dashboards.
+
+Treating them as presentational lets the Greater release train ship
+**independently** of Lesser Host's API evolution. If Lesser Host
+publishes a breaking change to its provisioning / release / fleet
+endpoints tomorrow, none of the G2 / G3 components break — only the
+consumer's adapter layer needs to update.
+
+This is the canonical posture for Project 39 G0–G3, and was confirmed
+in the parent issue body (#636, #637) and every sub-issue's guardrails.
+
+## Current pinned contract snapshots (informational)
+
+The repo already pins two Lesser-side contract bundles in
+`docs/lesser/contracts/` and `docs/lesser-host/contracts/`:
+
+| Source                | Tag       | Commit                                     |
+| --------------------- | --------- | ------------------------------------------ |
+| Lesser GraphQL + REST | `v1.4.12` | `81e1db10f86b43be627e791f68eec0f488613b16` |
+| Lesser Host REST      | `v0.4.5`  | `315eb746c7b0acfd4c0385b7dfbac85178886772` |
+
+These are consumed by `packages/adapters/` for the Lesser-aware
+Fediverse surfaces (faces / social / soul). They do **not** drive any
+host-platform component in this release; they're only listed here so
+the file stays useful as a single-page contract-state reference.
+
+## Activation triggers
+
+The deferred lane opens **only** when at least one of these explicit
+conditions is met:
+
+### 1. Host requests Greater data adapters
+
+If `lesser-host/web/` asks Greater to ship a typed adapter for one of:
+
+- Provisioning job status / logs (would power `ProvisioningTimeline`
+  with live data)
+- Release history / adoption metrics (would power `ReleaseTimeline`)
+- Fleet / stack version queries (would power `StackMatrix` /
+  `FleetCard`)
+- Cost / usage queries (would power `CostGauge`)
+
+…then a new issue lands here under the `adapter-change` classification
+and runs through the `sync-contracts` skill workflow.
+
+### 2. Lesser Host publishes new public contract surfaces
+
+If Lesser Host's OpenAPI / soul-conversation schemas grow new endpoints
+that `host-platform` would naturally consume, the lane MAY open even
+without an explicit consumer request — at the Greater steward's
+discretion, with the host steward's confirmation that the contract is
+stable.
+
+### 3. Pre-existing pinned Lesser Host snapshots become stale
+
+If `docs/lesser-host/contracts/LESSER_HOST_REF.txt` is bumped by
+unrelated work (e.g. the lesser-host steward sends a coordination
+email), the registered adapter regen runs and `host-platform` is
+audited for compatibility. Most snapshot bumps will be no-ops for
+host-platform; the audit confirms that.
+
+## What activating the lane looks like
+
+When triggered, the work runs as a normal sync-contracts PR:
+
+1. **Branch name**: `chore/sync-lesser-host-v<x.y.z>[-and-host-platform]`
+   or similar.
+2. **Snapshot pull**: update `docs/lesser-host/contracts/openapi.yaml` +
+   `LESSER_HOST_REF.txt` to the named Host tag + commit.
+3. **Adapter regen**: `pnpm generate:openapi:lesser-host` regenerates
+   `packages/adapters/src/rest/generated/lesser-host-api.ts`.
+4. **New host-platform adapters** (if requested): add new files under
+   `packages/adapters/src/rest/` (or a new `packages/host-platform-adapters/`
+   workspace if the surface justifies isolation; that's a fresh G2.1-style
+   placement decision).
+5. **Component wiring**: host-platform components remain presentational;
+   any adapter only feeds them already-shaped data. **No component is
+   modified to call adapters directly.**
+6. **Tests + docs + changeset + registry regen + CLI registry update**:
+   same parity discipline as every G0–G3 PR.
+7. **Sync-contracts skill walk**: the PR description includes the
+   `sync-contracts` walk output, naming the pinned Host tag explicitly.
+
+## Anti-patterns the deferral protects against
+
+The lane stays closed specifically to prevent these regressions:
+
+- **Greater component shipping a hardcoded Lesser Host API path**.
+  Strict-CSP-safe presentational components don't make network calls;
+  ever.
+- **Adapter changes without a pinned snapshot bump.** Greater's
+  steward refuses adapter PRs that change `packages/adapters/` without
+  a matching `docs/lesser-host/contracts/` snapshot update — see
+  `AGENTS.md`'s contract-sync discipline.
+- **Component API designed around a specific Host response shape.**
+  G2 / G3 prop contracts are intentionally generic (
+  `ProvisioningStep[]`, `ReleaseTimelineItem[]`, `StackMatrixRow[]`)
+  so future Host API shape changes never force a component breaking
+  change.
+
+## Pointers
+
+- `AGENTS.md` — contract-sync discipline + Lesser-host snapshot pin
+  rules
+- `.claude/skills/sync-contracts/SKILL.md` — the activation playbook
+- `docs/lesser-host/contracts/` — current pinned snapshots
+- `packages/adapters/src/rest/generated/lesser-host-api.ts` — current
+  regenerated client
+- Project 39 #637 — release-coordination parent issue
+- Project 39 #666 — this lane's tracking issue
+
+---
+
+**Last reviewed**: 2026-05-24 (Project 39 G4.6, parent #637).

--- a/docs/release-coordination/project-39-host-rc-preview.md
+++ b/docs/release-coordination/project-39-host-rc-preview.md
@@ -1,0 +1,196 @@
+# Project 39 — Greater Host adoption RC preview
+
+> Status: **awaiting RC promotion** (G4.3 #663).
+>
+> This document is the staging-state preview of what an RC tag covering
+> Project 39 G0–G3 would ship. It is generated as part of G4.1
+> (parity audit, #661) and G4.2 (changeset / release-note discipline,
+> #662) and exists so the Greater steward, host steward, and Aron can
+> see the consolidated release shape **before** the RC tag is cut.
+
+## Scope
+
+Four milestones merged into `staging` between PR #667 and #670:
+
+| Milestone                                    | PR   | Merge commit | Parent issue                                           |
+| -------------------------------------------- | ---- | ------------ | ------------------------------------------------------ |
+| G0 — Shell surface                           | #667 | `555a39d9`   | #633 — Host shell surface for lesser-host web M0       |
+| G1 — CommandPalette                          | #668 | `05d0daf2`   | #634 — Accessible CommandPalette for Host navigation   |
+| G2 — Host-platform (cards/gauges/sparklines) | #669 | `4862e285`   | #635 — Hosted-platform cards, gauges, and sparklines   |
+| G3 — Host-platform (timelines/matrix)        | #670 | `24154c23`   | #636 — Operator timelines and stack matrix for Host M2 |
+
+All four shipped under Greater Project 39 Signal D and unblock the
+lesser-host `web/` rework (parent #377 in `equaltoai/lesser-host`).
+
+## What ships
+
+### New workspace packages
+
+- **`@equaltoai/greater-components-shell`** — new in G0
+- **`@equaltoai/greater-components-host-platform`** — new in G2 (extended in G3)
+
+Both also exposed via the root barrel as `@equaltoai/greater-components/shell`
+and `@equaltoai/greater-components/host-platform`.
+
+### Component surface additions
+
+**Shell (11 components):**
+
+- `Shell`, `Sidebar`, `Topbar`, `Panel`, `StatCard`, `SummaryStrip`,
+  `PageFrame`, `PageTitle`, `Breadcrumb`, `Callout` (G0)
+- `CommandPalette` (G1)
+
+**Host-platform (6 components):**
+
+- `FleetCard`, `CostGauge`, `ActivitySparkline` (G2)
+- `ProvisioningTimeline`, `ReleaseTimeline`, `StackMatrix` (G3)
+
+### New public types (35+)
+
+All exported via each package's `./types` subpath. See
+[`docs/api-reference.md`](../api-reference.md) for the full list.
+
+### New utilities
+
+- Shell: `scoreCommandPaletteItem`, `filterAndRankCommandPaletteItems`,
+  `tokenizeCommandPaletteQuery` (dependency-free fuzzy filter)
+- Host-platform: `formatCost`, `formatCostGaugeText`, `computeRatio`,
+  `buildSparklinePath`
+
+All zero runtime dependencies; no `unsafe-eval`; deterministic.
+
+### Additive `--gr-*` design tokens
+
+No existing tokens renamed or removed. New `--gr-shell-*` and
+`--gr-host-platform-*` token families scoped via `:where(...)` selectors
+to every component root class, so standalone components outside their
+wrapper still resolve spacing tokens.
+
+## Changeset audit (G4.2)
+
+Four changesets target the consolidated release:
+
+| File                    | Impact | Packages                                                                                             |
+| ----------------------- | ------ | ---------------------------------------------------------------------------------------------------- |
+| `shell-surface-g0.md`   | minor  | `greater-components`, `@equaltoai/greater-components`, `@equaltoai/greater-components-shell`         |
+| `command-palette-g1.md` | minor  | `greater-components`, `@equaltoai/greater-components`, `@equaltoai/greater-components-shell`         |
+| `host-platform-g2.md`   | minor  | `greater-components`, `@equaltoai/greater-components`, `@equaltoai/greater-components-host-platform` |
+| `host-platform-g3.md`   | minor  | `greater-components`, `@equaltoai/greater-components`, `@equaltoai/greater-components-host-platform` |
+
+**All minor / additive. No major / breaking. No token renames.** The
+release-please RC PR will compile these into the consolidated changelog
+entry on the version bump.
+
+The next stable cuts from 0.9.0; the RC will be **0.10.0-rc.0** (or
+later) per release-please's accumulated-minor-changeset arithmetic.
+
+## Component-parity audit (G4.1)
+
+Every G0–G3 PR shipped with the full parity checklist satisfied (no
+gaps left for follow-up):
+
+| Milestone | Source | Types | Tests                         | Docs (inventory / api-ref) | Playground                | CLI registry | Registry regen |
+| --------- | ------ | ----- | ----------------------------- | -------------------------- | ------------------------- | ------------ | -------------- |
+| G0        | ✅     | ✅    | 79 (74 + 5 id-uniq)           | ✅                         | `/shell`                  | ✅           | ✅             |
+| G1        | ✅     | ✅    | 41 added (cmdk + filter)      | ✅                         | `/command-palette`        | ✅           | ✅             |
+| G2        | ✅     | ✅    | 57 (initial)                  | ✅                         | `/host-platform`          | ✅           | ✅             |
+| G3        | ✅     | ✅    | 51 added (timelines + matrix) | ✅                         | `/host-platform` extended | ✅           | ✅             |
+
+Workspace-wide test totals at staging head `24154c23`: **shell 124 +
+host-platform 108** plus all pre-existing packages green.
+
+## Accessibility audit (Project 39 stewardship gate)
+
+All four milestones cleared the 9-cell accessibility-tests CI matrix
+(light / dark / high-contrast × comfortable / compact / spacious) on
+their final commit. Notable patterns enforced:
+
+- **Status communication is never color-only** — every
+  `FleetCardStatus`, `CostGaugeStatus`, `ProvisioningStepStatus`,
+  `ReleaseStatus`, `StackMatrixDrift`, `CalloutTone` carries an icon
+  glyph plus a visible text label in addition to any color tint.
+- **`role="meter"` ARIA contract enforced** — `aria-valuenow` clamped
+  into `[aria-valuemin, aria-valuemax]`; when the consumer-supplied
+  range is invalid (`limit <= 0` or non-finite), the gauge drops the
+  meter role entirely and falls back to `role="img"` with a composed
+  multi-id `aria-labelledby` so AT users still hear the readout. (See
+  PR #669 + #670 review history for the regression tests.)
+- **`role="log"` is implicitly live** — when consumers opt out via
+  `liveLogPoliteness="off"`, ProvisioningTimeline drops `role="log"`
+  entirely (not just `aria-live`) so AT genuinely sees no
+  announcements. (See PR #670 review #4353484472.)
+- **Date-only ISO strings format in UTC** — ReleaseTimeline's default
+  formatter detects calendar-day inputs (`YYYY-MM-DD`, `...T00:00:00Z`)
+  and passes `timeZone: 'UTC'` to `Intl.DateTimeFormat`, avoiding the
+  one-day-earlier shift in US timezones.
+- **Sortable headers are native `<button>`** — StackMatrix's sortable
+  columns use real `<button>` elements with the browser-native keyboard
+  contract; `aria-sort` reflects only the currently-sorted column.
+- **`role="img"` SVGs have accessible names** — ActivitySparkline
+  defaults to informative `<svg role="img" aria-labelledby
+aria-describedby>` with real `<title>` + optional `<desc>`; opt into
+  `decorative={true}` only when a textual equivalent exists nearby.
+
+## Strict-CSP audit
+
+Zero new CSP violations across G0–G3 per `pnpm validate:csp`. Key
+techniques:
+
+- No inline event handlers (Svelte's compiled `on*` listeners attach
+  after hydration).
+- No `style="..."` attributes set at runtime. CostGauge's fill width is
+  driven by a `data-ratio` integer attribute (0–100) + 101
+  attribute-selector CSS rules in the bundle.
+- ActivitySparkline's SVG path is a pure data-to-string transform via
+  `buildSparklinePath`.
+- All `.gr-sr-only` references are backed by the rule shipped in both
+  shell's and host-platform's `base.css` (avoids visible live-region
+  announcement leakage for shell-less / primitives-less consumers).
+
+## Cross-repo consumer impact
+
+| Consumer                     | Impact                                                                                             |
+| ---------------------------- | -------------------------------------------------------------------------------------------------- |
+| **lesser-host web/** (#377)  | Unblocks shell + command palette + cost / activity / fleet displays + operator timelines / matrix. |
+| **sim (simulacrum)**         | Additive only; can adopt incrementally.                                                            |
+| **lesser UIs**               | Additive only; protocol-agnostic surfaces remain unaffected.                                       |
+| **External Mastodon-compat** | Hosted-platform surfaces are operator-specific; shell surface is protocol-agnostic and compatible. |
+
+**No Lesser / Lesser Host contract or adapter changes ship in this
+RC.** Future data-fetching adapters for provisioning / release / fleet
+APIs are tracked separately as the deferred contract-sync lane (G4.6 /
+#666; see `docs/host-platform/contract-sync-lane.md`).
+
+## Open coordination items
+
+- **G4.3 / #663** — Cut the RC tag. Operator-authorized release op
+  (managed by `release-components` skill). Awaits Aron.
+- **G4.4 / #664** — Host validates the RC in `lesser-host/web/` under
+  strict CSP + SSR + Svelte 5.55.7+. Awaits Host steward.
+- **G4.5 / #665** — Cut stable tag after Host acceptance + backmerge.
+  Awaits Aron.
+
+## Pinning the RC (consumer instructions, once cut)
+
+Once Aron promotes `staging → premain` and release-please publishes the
+RC tag, host can adopt with:
+
+```sh
+# Install the RC CLI globally (pinned to the RC tag).
+npm install -g https://github.com/equaltoai/greater-components/releases/download/greater-vX.Y.Z-rc.N/greater-components-cli.tgz
+
+# In the consumer project:
+greater update --ref greater-vX.Y.Z-rc.N
+
+# Or, for a single component:
+greater add shell --ref greater-vX.Y.Z-rc.N
+greater add host-platform --ref greater-vX.Y.Z-rc.N
+```
+
+(Exact `X.Y.Z-rc.N` will be filled in by release-please at promotion
+time.)
+
+---
+
+**Generated**: 2026-05-24 by the Greater steward as part of Project 39
+G4 release-coordination work (PRs #667–#670, parent issue #637).


### PR DESCRIPTION
## Milestone

**G4 — Release, registry, and Host adoption coordination** — parent issue #637.

This PR ships the **autonomous-doable** subset of G4. Three sub-issues close here; three remain explicitly parked for Aron (operator-authorized release ops + cross-repo coordination).

| Sub-issue | Status      | Action this PR takes                                      |
| --------- | ----------- | --------------------------------------------------------- |
| G4.1 #661 | **Closes**  | PR template + CONTRIBUTING parity-checklist section       |
| G4.2 #662 | **Closes**  | Fix CONTRIBUTING "Release Process" (was wrong: claimed npm); add RC preview audit |
| G4.3 #663 | **Parked**  | RC promotion = operator-authorized release op             |
| G4.4 #664 | **Parked**  | Host validation = cross-repo coordination                 |
| G4.5 #665 | **Parked**  | Stable promotion + backmerge = operator-authorized        |
| G4.6 #666 | **Closes**  | Deferred contract-sync lane documented                    |

## Classification

release-coordination / docs.

## What this PR ships

### G4.1 (#661) — component-milestone parity checklist

- **New `.github/PULL_REQUEST_TEMPLATE.md`**: every future PR auto-populates with the explicit parity checklist (source / types / tests / docs / playground / CLI registry / generated registry / root barrel / docs workflow), stewardship guarantees (strict-CSP, SSR, WCAG 2.1 AA, theming, no-npm, no-AGPL-incompatible-deps), changeset declaration, semver impact, consumer impact, validation commands, cross-repo coordination, and the release-flow handoff plan.
- **`CONTRIBUTING.md` Pull Request Process section expanded**: references the template, the 75% coverage threshold, the registry regen + validate cycle (with the explicit "Never hand-edit `registry/index.json`" warning), and a new "Component-milestone parity (Project 39 G4.1 / #661)" subsection that mirrors the template's parity rows in narrative form for the documentation site.

### G4.2 (#662) — changeset / release-note discipline + factual fix

- **`CONTRIBUTING.md` Release Process section rewritten**. The prior text claimed "GitHub Actions automatically publishes to npm" — that's wrong; greater-components is shadcn-style CLI distribution and has never published to npm. Fixed to document:
  - the actual CLI distribution model (npm install -g a GitHub Release tarball → `greater init` / `greater add` / `greater update --ref`)
  - the three-branch flow (`staging → premain → main`) with release-please automation
  - discipline rules (immutable tags, assets never deleted, merge-commit-vs-squash based on ancestry, no skipped gates)
  - pointer to the `release-components` skill
- **New `docs/release-coordination/project-39-host-rc-preview.md`**: staging-state preview of what a Project 39 RC would ship. Includes scope table, what-ships summary, changeset audit (all four minor + additive, no breaking), per-milestone parity audit with test counts, accessibility audit summarizing the ARIA patterns enforced (non-color-only status, `role="meter"` contract, `role="log"` implicit live, calendar-day UTC formatting, SVG names), strict-CSP audit summary, cross-repo consumer impact, open coordination items, and pinning instructions for Host once the RC tag exists.

### G4.6 (#666) — deferred Lesser Host contract-sync lane

- **New `docs/host-platform/contract-sync-lane.md`**: visible placeholder for the future Lesser Host contract-sync work that G2 / G3 host-platform components do **not** currently depend on. Documents:
  - why the lane is deferred (presentational components; component shapes are intentionally generic so future Host API changes never force breaking changes)
  - current pinned Lesser / Lesser Host snapshots (informational, not consumed by host-platform)
  - three explicit activation triggers (Host requests an adapter; Lesser Host publishes a relevant new contract; routine snapshot bump that needs compatibility audit)
  - activation workflow as a normal `sync-contracts` PR
  - anti-patterns the deferral protects against
  - pointers to AGENTS.md, the sync-contracts skill, current snapshot pins, and the tracking issues

## Why G4.3 / G4.4 / G4.5 stay parked

All three are explicitly outside the scope of `implement-milestone` per the skill rules:

> Will not run release commands — that's `release-components`.

And per the stewardship rules in AGENTS.md / soul-of-greater:

> Destructive actions require explicit authorization … Force-pushing … Skipping staging / premain / main promotion stages … Modifying release-please-config.json governance.

**G4.3 (#663)** — the `staging → premain` promotion that cuts the RC tag is an operator-authorized release op managed by `release-components`. The Greater steward (me) doesn't cut tags autonomously.

**G4.4 (#664)** — Host validation is cross-repo coordination with the lesser-host steward; needs Aron + host steward to drive.

**G4.5 (#665)** — the `premain → main` promotion that cuts the stable tag + CLI tarball + GitHub Release is the same operator-authorized category as G4.3.

Once Aron is ready to drive G4.3 (RC promotion), the `release-components` skill takes over.

## What this PR does NOT touch

- **No source changes** under `packages/`.
- **No registry changes** (`registry/index.json` is unchanged from the staging tip — no source change → no regen needed).
- **No changeset** — docs / process changes that don't affect any package's user-facing output. Consistent with other docs-only entries in the repo's history.
- **`AGENTS.md`, `CODEOWNERS`, branch protection** — untouched.

## Validation

- `pnpm format`, `pnpm format:check` — clean.
- `pnpm lint` — 0 errors.
- `pnpm validate:csp` — 0 new violations.
- `pnpm validate:registry` — PASS (unchanged registry).
- `node scripts/check-dco.js --base origin/staging --head HEAD` — PASS (1 commit).
- `node scripts/rehearse-release-promotion.js --candidate HEAD` — preserve-topology + `--simulate-squash` both pass (this branch is staging-based, no main/premain ancestry to preserve; either merge type is safe).

## Consumer impact

- **sim:** preserved (no source change)
- **lesser-host web:** preserved (no source change)
- **lesser UIs:** preserved (no source change)
- **external Mastodon-compat:** preserved (no source change)

## Release-flow handoff after merge

This PR is docs-only and does not produce a new version. After merge, the four `.changeset/*.md` entries (G0, G1, G2, G3) remain queued for the next release-please RC PR. When Aron is ready to drive **G4.3**, the next step is the `release-components` skill (`staging → premain`).

## Cross-repo coordination

None for this PR. **G4.4 needs Aron + lesser-host steward** once the RC tag exists.

## Project 39 status

Kept in sync as work landed: G3 (#636 + #656–#660) → Done after PR #670 merge; G4 (#637 + #661–#666) → In Progress at this PR's open.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)