### PR TITLE
feat(adapters): expose Lesser agent metadata lookup

### DIFF
--- a/packages/adapters/src/__tests__/LesserSoulClient.test.ts
+++ b/packages/adapters/src/__tests__/LesserSoulClient.test.ts
@@ -3,6 +3,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 import {
 	LesserSoulClient,
 	LesserSoulClientError,
+	type LesserAgent,
 	type LesserSoulIncorporateResponse,
 	type LesserSoulsMineResponse,
 } from '../lesser/client';
@@ -65,6 +66,63 @@ describe('LesserSoulClient', () => {
 		expect(url).toBe('https://lesser.example/api/v1/souls/mine');
 		expect(headers.get('authorization')).toBe('Bearer test-token');
 		expect(response.souls[0]?.agent.ens_name).toBe('agent-1.lessersoul.eth');
+	});
+
+	it('fetches local agent metadata by username', async () => {
+		const responseBody: LesserAgent = {
+			username: 'agent-1',
+			display_name: 'Agent One',
+			verified: true,
+			quarantine_active: false,
+			agent_type: 'assistant',
+			agent_version: 'gpt-5-mini',
+			agent_capabilities: {
+				can_boost: true,
+				can_dm: true,
+				can_follow: true,
+				can_post: true,
+				can_reply: true,
+				max_posts_per_hour: 10,
+				requires_approval: false,
+			},
+			mcp_access: {
+				authorization_server_url: 'https://lesser.example/.well-known/oauth-authorization-server',
+				guidance: [],
+				mcp_url: 'https://lesser.example/mcp/agent-1',
+				protected_resource_url: 'https://lesser.example/.well-known/oauth-protected-resource',
+				registration_url: 'https://lesser.example/oauth/register',
+				scopes: [],
+			},
+			identity_semantics: {
+				soul_binding_state: 'BOUND',
+				continuity_state: 'CONTINUOUS',
+				continuity_summary: 'continuity preserved',
+				identity_label: 'agent-1',
+				identity_state: 'STABLE',
+				lifecycle_state: 'ACTIVE',
+				body_identity_preserved: true,
+				timeline_presence_preserved: true,
+				memory_references_preserved: true,
+				attribution_label: 'agent',
+				moderation_label: 'agent',
+			},
+		};
+
+		fetchMock.mockResolvedValueOnce(jsonResponse(responseBody));
+
+		const response = await client.getAgentByUsername(' agent-1 ');
+		const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+		const headers = new Headers(init.headers);
+
+		expect(url).toBe('https://lesser.example/api/v1/agents/agent-1');
+		expect(headers.get('authorization')).toBe('Bearer test-token');
+		expect(response.agent_version).toBe('gpt-5-mini');
+		expect(response.display_name).toBe('Agent One');
+	});
+
+	it('rejects blank agent usernames', async () => {
+		await expect(client.getAgentByUsername('   ')).rejects.toThrow('username is required');
+		expect(fetchMock).not.toHaveBeenCalled();
 	});
 
 	it('incorporates a soul by agent id', async () => {

--- a/packages/adapters/src/index.ts
+++ b/packages/adapters/src/index.ts
@@ -62,6 +62,7 @@ export type {
 export { LesserSoulClient, LesserSoulClientError, createLesserSoulClient } from './lesser/index.js';
 export type {
 	LesserFetchLike,
+	LesserAgent,
 	LesserSoulAgentIdentity,
 	LesserSoulAgentBinding,
 	LesserSoulBodyBinding,

--- a/packages/adapters/src/lesser/client.ts
+++ b/packages/adapters/src/lesser/client.ts
@@ -7,6 +7,7 @@ export type LesserSoulBodyBinding = LesserSoulAgentBinding;
 export type LesserSoulInventoryItem = components['schemas']['SoulInventoryItem'];
 export type LesserSoulsMineResponse = components['schemas']['SoulsMineResponse'];
 export type LesserSoulIncorporateResponse = components['schemas']['SoulIncorporateResponse'];
+export type LesserAgent = components['schemas']['Agent'];
 
 export type LesserFetchLike = FetchLike;
 
@@ -59,6 +60,13 @@ export class LesserSoulClient {
 
 	async getMySouls(): Promise<LesserSoulsMineResponse> {
 		return this.requestJson('/api/v1/souls/mine');
+	}
+
+	async getAgentByUsername(username: string): Promise<LesserAgent> {
+		const normalized = username.trim();
+		if (!normalized) throw new Error('username is required');
+
+		return this.requestJson(`/api/v1/agents/${encodeURIComponent(normalized)}`);
 	}
 
 	async incorporateSoul(

--- a/packages/adapters/src/lesser/index.ts
+++ b/packages/adapters/src/lesser/index.ts
@@ -1,6 +1,7 @@
 export { LesserSoulClient, LesserSoulClientError, createLesserSoulClient } from './client.js';
 export type {
 	LesserFetchLike,
+	LesserAgent,
 	LesserSoulAgentIdentity,
 	LesserSoulAgentBinding,
 	LesserSoulBodyBinding,

--- a/registry/index.json
+++ b/registry/index.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://equalto.ai/schemas/registry-index.schema.json",
   "schemaVersion": "1.0.0",
-  "generatedAt": "2026-05-26T03:57:24.940Z",
+  "generatedAt": "2026-05-29T06:30:24.723Z",
   "ref": "greater-v0.10.1",
   "version": "0.10.1",
   "checksums": {
@@ -836,9 +836,9 @@
     "packages/adapters/src/HttpPollingClient.d.ts": "sha256-6UbsJSk+ur6Rth93w5bnSj3HOl2teXThMIBozc0TQqI=",
     "packages/adapters/src/HttpPollingClient.ts": "sha256-3VvR+Q3A9QuT9IKrT2s2OP48Ir5wDbDiL3NFp6fhO0w=",
     "packages/adapters/src/index.d.ts": "sha256-N9rD+C+FY2TCOW91GXIb5Cqm9lMS5na3I8MoSewctBE=",
-    "packages/adapters/src/index.ts": "sha256-j36+9RNfqELxmWPSHeEWlgsfIDHRYvUGWCAkgrJguyc=",
-    "packages/adapters/src/lesser/client.ts": "sha256-gJqWj6E9oKFgyzAIUPvbnHVg4KNkQTc6VQyacPb71Mc=",
-    "packages/adapters/src/lesser/index.ts": "sha256-9IddT/UvLYVDv2redzoHAItiiJBaIwvz6hiBimxZ2YY=",
+    "packages/adapters/src/index.ts": "sha256-y/bkEbffcksYPI76z+nHOmzKEZeGy/ObU5HIykb5OAE=",
+    "packages/adapters/src/lesser/client.ts": "sha256-1zz1lpu6roGoTtOC/LIwXsT8oLHXkFV4TA8OblQ2Zhs=",
+    "packages/adapters/src/lesser/index.ts": "sha256-/G5V2Tcie3s4/bPAszGUu+RGRRiz6nhnEXbge7XGxTw=",
     "packages/adapters/src/logger.d.ts": "sha256-EWrIRS5/xIIlNv5OLPY+Rf37HgYqrYhXxGlfPX8oNgc=",
     "packages/adapters/src/logger.ts": "sha256-4M5fy8SndwLJfyZ3TrT1Qmql2Jg0GlUatjIHPQOedhQ=",
     "packages/adapters/src/mappers/index.d.ts": "sha256-IVlngJIkK6cSnV1Yjhe/K8uy/QEhYXZyEY9UBk75tlk=",
@@ -5687,18 +5687,18 @@
         },
         {
           "path": "src/index.ts",
-          "checksum": "sha256-j36+9RNfqELxmWPSHeEWlgsfIDHRYvUGWCAkgrJguyc=",
-          "size": 9139
+          "checksum": "sha256-y/bkEbffcksYPI76z+nHOmzKEZeGy/ObU5HIykb5OAE=",
+          "size": 9153
         },
         {
           "path": "src/lesser/client.ts",
-          "checksum": "sha256-gJqWj6E9oKFgyzAIUPvbnHVg4KNkQTc6VQyacPb71Mc=",
-          "size": 4621
+          "checksum": "sha256-1zz1lpu6roGoTtOC/LIwXsT8oLHXkFV4TA8OblQ2Zhs=",
+          "size": 4929
         },
         {
           "path": "src/lesser/index.ts",
-          "checksum": "sha256-9IddT/UvLYVDv2redzoHAItiiJBaIwvz6hiBimxZ2YY=",
-          "size": 333
+          "checksum": "sha256-/G5V2Tcie3s4/bPAszGUu+RGRRiz6nhnEXbge7XGxTw=",
+          "size": 347
         },
         {
           "path": "src/logger.d.ts",


### PR DESCRIPTION
## Summary
- add `LesserSoulClient.getAgentByUsername(username)` for Lesser `GET /api/v1/agents/{username}`
- export the generated `LesserAgent` type from lesser and root adapter barrels
- update `registry/index.json` checksums for the touched adapter source files
- cover URL/header behavior and blank username validation

## Why
M13 `/portal/souls` needs real Lesser agent metadata (`agent_version` / `agent_type` / `display_name`) rather than placeholder model values. Lesser already exposes this route in the pinned generated OpenAPI types; this PR adds the small REST adapter wrapper.

## Validation
- `corepack pnpm --filter @equaltoai/greater-components-adapters exec vitest run src/__tests__/LesserSoulClient.test.ts`
- `corepack pnpm --filter @equaltoai/greater-components-adapters typecheck`
- `corepack pnpm --filter @equaltoai/greater-components-adapters build`
- `corepack pnpm generate-registry`
- `corepack pnpm validate:registry`
