### PR TITLE
Project 43 M1 — greater-components client-component safety (GC-07/09/11/08/17)

### DIFF
--- a/apps/playground/src/routes/link/+page.svelte
+++ b/apps/playground/src/routes/link/+page.svelte
@@ -1,12 +1,21 @@
 <script lang="ts">
 	import { Link, Text, Heading } from '@equaltoai/greater-components-primitives';
 
-	let navigationLog = $state<string[]>([]);
+	type NavigationLogEntry = {
+		id: number;
+		label: string;
+	};
+
+	let nextNavigationLogId = 0;
+	let navigationLog = $state<NavigationLogEntry[]>([]);
 
 	function fakeNavigate(ev: MouseEvent, href: string) {
 		ev.preventDefault();
 		navigationLog = [
-			`${new Date().toLocaleTimeString()} — would navigate to: ${href}`,
+			{
+				id: nextNavigationLogId++,
+				label: `${new Date().toLocaleTimeString()} — would navigate to: ${href}`,
+			},
 			...navigationLog.slice(0, 9),
 		];
 	}
@@ -114,8 +123,8 @@
 			<Text>No navigations yet — click a link above.</Text>
 		{:else}
 			<ul class="log">
-				{#each navigationLog as entry (entry)}
-					<li>{entry}</li>
+				{#each navigationLog as entry (entry.id)}
+					<li>{entry.label}</li>
 				{/each}
 			</ul>
 		{/if}

--- a/packages/host-platform/src/components/ReleaseTimeline.svelte
+++ b/packages/host-platform/src/components/ReleaseTimeline.svelte
@@ -105,6 +105,30 @@ runtime style writes. All styling via stable `--gr-*` tokens.
 		return map;
 	});
 
+	const allowedLinkProtocols = new Set(['http:', 'https:', 'mailto:']);
+	const relativeUrlBase = 'https://example.invalid';
+
+	/**
+	 * Return an href safe to render into an `<a>` tag, or null for unsafe values.
+	 *
+	 * Allows relative URLs plus absolute http:, https:, and mailto: URLs. Unsafe
+	 * schemes such as javascript:, data:, and vbscript: return null.
+	 */
+	function toSafeHref(value?: string | null): string | null {
+		if (typeof value !== 'string') return null;
+
+		const href = value.trim();
+		if (!href) return null;
+
+		try {
+			const parsed = new URL(href, relativeUrlBase);
+			if (!allowedLinkProtocols.has(parsed.protocol)) return null;
+			return encodeURI(href);
+		} catch {
+			return null;
+		}
+	}
+
 	/**
 	 * True when the input string represents a date that should be interpreted
 	 * as a calendar day rather than a precise instant — e.g. a bare
@@ -183,6 +207,7 @@ runtime style writes. All styling via stable `--gr-*` tokens.
 				{@const isoDate = dateIsoAttr(release.date)}
 				{@const adoptionText = (formatAdoption ?? defaultFormatAdoption)(release.adoption)}
 				{@const adoptionRatio = numericAdoption(release.adoption)}
+				{@const safeHref = toSafeHref(release.href)}
 				<li
 					id={stableId.value ? `${stableId.value}-rel-${release.id}` : undefined}
 					class={[
@@ -251,12 +276,12 @@ runtime style writes. All styling via stable `--gr-*` tokens.
 								</p>
 							{/if}
 						{/if}
-						{#if release.href || itemActions}
+						{#if safeHref || itemActions}
 							<div class="gr-host-platform-release-timeline__actions" role="group">
-								{#if release.href}
+								{#if safeHref}
 									<a
 										class="gr-host-platform-release-timeline__link"
-										href={release.href}
+										href={safeHref}
 										aria-label={`Release notes for ${release.version}`}
 									>
 										Release notes

--- a/packages/host-platform/src/utils/sparkline.ts
+++ b/packages/host-platform/src/utils/sparkline.ts
@@ -32,6 +32,14 @@ export interface SparklinePathInput {
 	max?: number;
 }
 
+const MAX_SPARKLINE_POINTS = 1000;
+
+interface NormalizedSparklineData {
+	values: number[];
+	min: number;
+	max: number;
+}
+
 export interface SparklinePathOutput {
 	/** Full SVG `d` attribute for `<path>`. */
 	path: string;
@@ -61,24 +69,35 @@ export function buildSparklinePath(input: SparklinePathInput): SparklinePathOutp
 	const innerWidth = Math.max(0, width - 2 * padding);
 	const innerHeight = Math.max(0, height - 2 * padding);
 
-	const dataMin = input.min ?? Math.min(...data);
-	const dataMaxRaw = input.max ?? Math.max(...data);
+	const normalized = normalizeSparklineData(data, MAX_SPARKLINE_POINTS);
+	if (normalized.values.length === 0) {
+		return { path: '', last: { x: 0, y: height / 2 }, range: { min: 0, max: 0 } };
+	}
+
+	const inputMin = input.min;
+	const inputMax = input.max;
+	const dataMin =
+		typeof inputMin === 'number' && Number.isFinite(inputMin) ? inputMin : normalized.min;
+	const dataMaxRaw =
+		typeof inputMax === 'number' && Number.isFinite(inputMax) ? inputMax : normalized.max;
 	// Ensure max > min so the divisor isn't zero. For constant series we
 	// extend the range by 1 unit so the line sits at the midpoint.
 	const dataMax = dataMaxRaw > dataMin ? dataMaxRaw : dataMin + 1;
 
 	const range = { min: dataMin, max: dataMax };
 
-	const stepX = data.length > 1 ? innerWidth / (data.length - 1) : 0;
+	const values = normalized.values;
+	const stepX = values.length > 1 ? innerWidth / (values.length - 1) : 0;
 	const verticalSpan = dataMax - dataMin;
 
 	let path = '';
 	let lastX = 0;
 	let lastY = 0;
-	for (let i = 0; i < data.length; i++) {
-		const raw = data[i]!;
+	for (let i = 0; i < values.length; i++) {
+		const raw = values[i];
+		if (raw === undefined) continue;
 		const xRaw = padding + i * stepX;
-		const yRatio = verticalSpan === 0 ? 0.5 : 1 - (raw - dataMin) / verticalSpan;
+		const yRatio = toSparklineYRatio(raw, dataMin, verticalSpan);
 		const yRaw = padding + yRatio * innerHeight;
 		const x = roundFixed(xRaw);
 		const y = roundFixed(yRaw);
@@ -97,4 +116,58 @@ export function buildSparklinePath(input: SparklinePathInput): SparklinePathOutp
  */
 function roundFixed(n: number): number {
 	return Math.round(n * 1000) / 1000;
+}
+
+function normalizeSparklineData(data: number[], maxPoints: number): NormalizedSparklineData {
+	let min = Number.POSITIVE_INFINITY;
+	let max = Number.NEGATIVE_INFINITY;
+	const values: number[] = [];
+
+	const recordFiniteSample = (sample: number): boolean => {
+		if (!Number.isFinite(sample)) return false;
+		if (sample < min) min = sample;
+		if (sample > max) max = sample;
+		return true;
+	};
+
+	if (data.length <= maxPoints) {
+		for (let i = 0; i < data.length; i++) {
+			const sample = data[i];
+			if (sample === undefined) continue;
+			if (recordFiniteSample(sample)) values.push(sample);
+		}
+
+		return { values, min, max };
+	}
+
+	for (let bucket = 0; bucket < maxPoints; bucket++) {
+		const start = Math.floor((bucket * data.length) / maxPoints);
+		const end = Math.floor(((bucket + 1) * data.length) / maxPoints);
+
+		let count = 0;
+		let mean = 0;
+		let fallback = 0;
+		for (let i = start; i < end; i++) {
+			const sample = data[i];
+			if (sample === undefined) continue;
+			if (!recordFiniteSample(sample)) continue;
+
+			count += 1;
+			fallback = sample;
+			mean += (sample - mean) / count;
+		}
+
+		if (count > 0) values.push(Number.isFinite(mean) ? mean : fallback);
+	}
+
+	return { values, min, max };
+}
+
+function toSparklineYRatio(value: number, min: number, verticalSpan: number): number {
+	if (!Number.isFinite(verticalSpan) || verticalSpan <= 0) return 0.5;
+
+	const ratio = 1 - (value - min) / verticalSpan;
+	if (!Number.isFinite(ratio)) return 0.5;
+
+	return Math.min(1, Math.max(0, ratio));
 }

--- a/packages/host-platform/tests/activity-sparkline.test.ts
+++ b/packages/host-platform/tests/activity-sparkline.test.ts
@@ -2,6 +2,12 @@ import { describe, it, expect } from 'vitest';
 import { render } from '@testing-library/svelte';
 import ActivitySparkline from '../src/components/ActivitySparkline.svelte';
 
+const MAX_EXPECTED_SPARKLINE_POINTS = 1000;
+
+function countPathPoints(path: string): number {
+	return (path.match(/[ML]/g) ?? []).length;
+}
+
 describe('ActivitySparkline', () => {
 	it('renders an informative <svg role="img"> with <title> when label is supplied', () => {
 		const { container } = render(ActivitySparkline, {
@@ -76,6 +82,26 @@ describe('ActivitySparkline', () => {
 		const d = path?.getAttribute('d') ?? '';
 		expect(d.startsWith('M')).toBe(true);
 		expect(d.includes('L')).toBe(true);
+	});
+
+	it('renders large untrusted data without emitting an unbounded path', () => {
+		const data = Array.from({ length: 500_000 }, (_, i) => {
+			if (i % 99_991 === 0) return Number.NaN;
+			if (i % 131_071 === 0) return Number.POSITIVE_INFINITY;
+			if (i % 262_147 === 0) return Number.NEGATIVE_INFINITY;
+			return Math.cos(i / 75) * 12 + (i % 53);
+		});
+
+		const { container } = render(ActivitySparkline, {
+			data,
+			label: 'Untrusted activity',
+		});
+
+		const path = container.querySelector('path.gr-host-platform-activity-sparkline__path');
+		const d = path?.getAttribute('d') ?? '';
+		expect(d).toMatch(/^M/);
+		expect(d).not.toMatch(/NaN|Infinity/);
+		expect(countPathPoints(d)).toBeLessThanOrEqual(MAX_EXPECTED_SPARKLINE_POINTS);
 	});
 
 	it('applies the tone modifier class (paired with label text — never color-only)', () => {

--- a/packages/host-platform/tests/release-timeline.security.test.ts
+++ b/packages/host-platform/tests/release-timeline.security.test.ts
@@ -1,0 +1,48 @@
+import { render } from '@testing-library/svelte';
+import { describe, expect, it } from 'vitest';
+import ReleaseTimeline from '../src/components/ReleaseTimeline.svelte';
+import type { ReleaseTimelineItem } from '../src/types.js';
+
+const createRelease = (href: string): ReleaseTimelineItem => ({
+	id: 'release-1',
+	version: 'v1.0.0',
+	channel: 'stable',
+	date: '2026-05-22',
+	status: 'shipped',
+	href,
+});
+
+describe('ReleaseTimeline link safety', () => {
+	it.each([
+		['javascript:alert(1)', 'javascript:'],
+		['data:text/html,<script>alert(1)</script>', 'data:'],
+		['vbscript:msgbox(1)', 'vbscript:'],
+	])('omits release-notes links with unsafe URL scheme %s', (href, scheme) => {
+		const { container } = render(ReleaseTimeline, {
+			label: 'Release history',
+			releases: [createRelease(href)],
+		});
+
+		expect(container.querySelector('a.gr-host-platform-release-timeline__link')).toBeNull();
+		expect(container.innerHTML.toLowerCase()).not.toContain(scheme);
+		expect(container.textContent).toContain('v1.0.0');
+	});
+
+	it.each([
+		['http://example.com/releases/v1.0.0', 'http://example.com/releases/v1.0.0'],
+		['https://example.com/releases/v1.0.0', 'https://example.com/releases/v1.0.0'],
+		['mailto:releases@example.com', 'mailto:releases@example.com'],
+		['/releases/v1.0.0', '/releases/v1.0.0'],
+	])('keeps release-notes links with allowed href %s', (href, expectedHref) => {
+		const { container } = render(ReleaseTimeline, {
+			label: 'Release history',
+			releases: [createRelease(href)],
+		});
+
+		const link = container.querySelector('a.gr-host-platform-release-timeline__link');
+		expect(link).not.toBeNull();
+		expect(link?.getAttribute('href')).toBe(expectedHref);
+		expect(link?.textContent).toContain('Release notes');
+		expect(link?.getAttribute('aria-label')).toBe('Release notes for v1.0.0');
+	});
+});

--- a/packages/host-platform/tests/sparkline.test.ts
+++ b/packages/host-platform/tests/sparkline.test.ts
@@ -1,6 +1,12 @@
 import { describe, it, expect } from 'vitest';
 import { buildSparklinePath } from '../src/utils/sparkline.js';
 
+const MAX_EXPECTED_SPARKLINE_POINTS = 1000;
+
+function countPathPoints(path: string): number {
+	return (path.match(/[ML]/g) ?? []).length;
+}
+
 describe('buildSparklinePath', () => {
 	it('returns an empty path on an empty series', () => {
 		const result = buildSparklinePath({ data: [], width: 100, height: 28 });
@@ -60,5 +66,47 @@ describe('buildSparklinePath', () => {
 	it('handles a single sample by anchoring it at the start', () => {
 		const result = buildSparklinePath({ data: [5], width: 100, height: 28 });
 		expect(result.path).toMatch(/^M\d/);
+	});
+
+	it('skips non-finite samples instead of emitting invalid SVG coordinates', () => {
+		const result = buildSparklinePath({
+			data: [1, Number.NaN, 2, Number.POSITIVE_INFINITY, Number.NEGATIVE_INFINITY, 3],
+			width: 100,
+			height: 28,
+		});
+
+		expect(result.path).toMatch(/^M/);
+		expect(result.path).not.toMatch(/NaN|Infinity/);
+		expect(countPathPoints(result.path)).toBe(3);
+		expect(result.range).toEqual({ min: 1, max: 3 });
+	});
+
+	it('returns a no-op path when every sample is non-finite', () => {
+		const result = buildSparklinePath({
+			data: [Number.NaN, Number.POSITIVE_INFINITY, Number.NEGATIVE_INFINITY],
+			width: 100,
+			height: 28,
+		});
+
+		expect(result.path).toBe('');
+		expect(result.last).toEqual({ x: 0, y: 14 });
+		expect(result.range).toEqual({ min: 0, max: 0 });
+	});
+
+	it('bounds output for a 500k-sample untrusted series containing non-finite values', () => {
+		const data = Array.from({ length: 500_000 }, (_, i) => {
+			if (i % 100_003 === 0) return Number.NaN;
+			if (i % 131_071 === 0) return Number.POSITIVE_INFINITY;
+			if (i % 262_147 === 0) return Number.NEGATIVE_INFINITY;
+			return Math.sin(i / 50) * 20 + (i % 97);
+		});
+
+		const result = buildSparklinePath({ data, width: 100, height: 28 });
+
+		expect(result.path).toMatch(/^M/);
+		expect(result.path).not.toMatch(/NaN|Infinity/);
+		expect(countPathPoints(result.path)).toBeLessThanOrEqual(MAX_EXPECTED_SPARKLINE_POINTS);
+		expect(Number.isFinite(result.last.x)).toBe(true);
+		expect(Number.isFinite(result.last.y)).toBe(true);
 	});
 });

--- a/packages/primitives/src/components/Link.svelte
+++ b/packages/primitives/src/components/Link.svelte
@@ -120,6 +120,7 @@ integration and full browser link affordances.
 		target,
 		rel,
 		onclick,
+		style: _style,
 		...restProps
 	}: Props = $props();
 

--- a/packages/primitives/tests/Link.test.ts
+++ b/packages/primitives/tests/Link.test.ts
@@ -209,6 +209,12 @@ describe('Link.svelte', () => {
 			expect(link?.getAttribute('data-testid')).toBe('nav-link-budgets');
 		});
 
+		it('strips consumer-supplied style attributes from rest-props', () => {
+			const { container } = renderLink({ href: '/x', style: 'color:red' });
+			const link = container.querySelector('a');
+			expect(link?.hasAttribute('style')).toBe(false);
+		});
+
 		it('appends consumer-supplied class to base class list', () => {
 			const { container } = renderLink({ href: '/x', class: 'custom-class extra' });
 			const link = container.querySelector('a');

--- a/packages/shell/src/components/Breadcrumb.svelte
+++ b/packages/shell/src/components/Breadcrumb.svelte
@@ -3,9 +3,9 @@
 Breadcrumb — breadcrumb navigation with `aria-current="page"` on the current item.
 
 Renders a `<nav aria-label>` containing an `<ol>` of breadcrumb items. Items
-with `href` render as `<a>`; items without `href` (and the explicitly-current
-item) render as `<span>`. The current item additionally receives
-`aria-current="page"`.
+with safe `href` values render as `<a>`; items without `href`, unsafe URL
+schemes, and the explicitly-current item render as `<span>`. The current item
+additionally receives `aria-current="page"`.
 
 @example
 ```svelte
@@ -22,6 +22,7 @@ item) render as `<span>`. The current item additionally receives
 	import type { HTMLAttributes } from 'svelte/elements';
 	import type { Snippet } from 'svelte';
 	import type { BreadcrumbItem } from '../types.js';
+	import { toSafeHref } from '../utils/safe-href.js';
 
 	interface Props extends Omit<HTMLAttributes<HTMLElement>, 'aria-label'> {
 		/** Ordered breadcrumb items. @public */
@@ -62,10 +63,14 @@ item) render as `<span>`. The current item additionally receives
 	// Mark the last item as current if no explicit current is set.
 	const resolvedItems = $derived.by(() => {
 		const explicit = items.some((item) => item.current);
-		return items.map((item, index) => ({
-			...item,
-			current: explicit ? !!item.current : index === items.length - 1,
-		}));
+		return items.map((item, index) => {
+			const current = explicit ? !!item.current : index === items.length - 1;
+			return {
+				...item,
+				current,
+				safeHref: current ? null : toSafeHref(item.href),
+			};
+		});
 	});
 </script>
 
@@ -73,8 +78,8 @@ item) render as `<span>`. The current item additionally receives
 	<ol class="gr-shell-breadcrumb__list">
 		{#each resolvedItems as item, index (index)}
 			<li class="gr-shell-breadcrumb__item">
-				{#if item.href && !item.current}
-					<a href={item.href} class="gr-shell-breadcrumb__link">{item.label}</a>
+				{#if item.safeHref}
+					<a href={item.safeHref} class="gr-shell-breadcrumb__link">{item.label}</a>
 				{:else}
 					<span
 						class="gr-shell-breadcrumb__current"

--- a/packages/shell/src/utils/safe-href.ts
+++ b/packages/shell/src/utils/safe-href.ts
@@ -1,0 +1,34 @@
+/**
+ * @fileoverview Shared URL allowlist guard for Shell components that render links.
+ *
+ * Shell components can receive href-like values from route state, CMS content,
+ * or federated data. Svelte escapes attribute delimiters, but it does not make
+ * unsafe URL schemes safe. Keep all component-boundary href rendering behind
+ * this allowlist so unsafe schemes render as static text instead of links.
+ *
+ * @internal
+ */
+
+const allowedLinkProtocols = new Set(['http:', 'https:', 'mailto:']);
+const relativeUrlBase = 'https://example.invalid';
+
+/**
+ * Return an href safe to render into an `<a>` tag, or null for unsafe values.
+ *
+ * Allows relative URLs plus absolute http:, https:, and mailto: URLs. Unsafe
+ * schemes such as javascript:, data:, and vbscript: return null.
+ */
+export function toSafeHref(value?: string | null): string | null {
+	if (typeof value !== 'string') return null;
+
+	const href = value.trim();
+	if (!href) return null;
+
+	try {
+		const parsed = new URL(href, relativeUrlBase);
+		if (!allowedLinkProtocols.has(parsed.protocol)) return null;
+		return encodeURI(href);
+	} catch {
+		return null;
+	}
+}

--- a/packages/shell/tests/breadcrumb.test.ts
+++ b/packages/shell/tests/breadcrumb.test.ts
@@ -44,6 +44,47 @@ describe('Breadcrumb.svelte', () => {
 		expect(container.querySelectorAll('span.gr-shell-breadcrumb__current').length).toBe(2);
 	});
 
+	it('drops unsafe href protocols while preserving allowed breadcrumb links', () => {
+		const { container } = render(Breadcrumb, {
+			items: [
+				{ label: 'Relative', href: '/relative' },
+				{ label: 'HTTP', href: 'http://example.com/path' },
+				{ label: 'HTTPS', href: 'https://example.com/path' },
+				{ label: 'Email', href: 'mailto:hello@example.com' },
+				{ label: 'JavaScript', href: 'javascript:alert(1)' },
+				{ label: 'Data', href: 'data:text/html,<script>alert(1)</script>' },
+				{ label: 'VBScript', href: 'vbscript:msgbox(1)' },
+				{ label: 'Current', current: true },
+			],
+		});
+
+		const anchors = Array.from(container.querySelectorAll('a.gr-shell-breadcrumb__link'));
+		expect(anchors.map((anchor) => anchor.textContent?.trim())).toEqual([
+			'Relative',
+			'HTTP',
+			'HTTPS',
+			'Email',
+		]);
+		expect(anchors.map((anchor) => anchor.getAttribute('href'))).toEqual([
+			'/relative',
+			'http://example.com/path',
+			'https://example.com/path',
+			'mailto:hello@example.com',
+		]);
+
+		for (const label of ['JavaScript', 'Data', 'VBScript']) {
+			expect(
+				anchors.some((anchor) => anchor.textContent?.trim() === label),
+				`${label} should not render as a clickable breadcrumb anchor`
+			).toBe(false);
+		}
+
+		const staticLabels = Array.from(
+			container.querySelectorAll('span.gr-shell-breadcrumb__current')
+		).map((span) => span.textContent?.trim());
+		expect(staticLabels).toEqual(expect.arrayContaining(['JavaScript', 'Data', 'VBScript']));
+	});
+
 	it('marks the last item as current with aria-current="page" when no explicit current set', () => {
 		const { container } = render(Breadcrumb, {
 			items: [

--- a/registry/index.json
+++ b/registry/index.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://equalto.ai/schemas/registry-index.schema.json",
   "schemaVersion": "1.0.0",
-  "generatedAt": "2026-05-29T06:30:24.723Z",
+  "generatedAt": "2026-05-30T11:50:48.768Z",
   "ref": "greater-v0.10.1",
   "version": "0.10.1",
   "checksums": {
@@ -37,7 +37,7 @@
     "packages/primitives/src/components/Heading.svelte.d.ts": "sha256-PvoPUjrvU2zOaXYWbgkZZNRE8qMg2Jx7B3vBp8v/Kfw=",
     "packages/primitives/src/components/IconBadge.svelte": "sha256-kl6PCEtl6Ys63aXiHu9yz0JhbvThOBLZu9fozwVbk54=",
     "packages/primitives/src/components/IconBadge.svelte.d.ts": "sha256-451lSVgNMmxq69y/tl1ZOfqwAoG9w8rZpMIpoul28BM=",
-    "packages/primitives/src/components/Link.svelte": "sha256-yG+okvfpFcTa8KltWBIosJ5kuV2RiViWO0XsjEYm2EM=",
+    "packages/primitives/src/components/Link.svelte": "sha256-YY1VcbLCFZBcP5tYvr6txpbxcI58AaiKQBqS0iDaTr0=",
     "packages/primitives/src/components/Link.svelte.d.ts": "sha256-h17/IpRbQX9xySta8J/mkZh5NiPTzH7xfs32n8HCFuE=",
     "packages/primitives/src/components/List.svelte": "sha256-9FcW7tgg2Bz/I3tC80WAsswmB4qWa7q74+5vUY2no6w=",
     "packages/primitives/src/components/List.svelte.d.ts": "sha256-kQQKN8WiXDbkaE7agL85+hxnNgng+P1ry4hiGr9t8Oo=",
@@ -899,7 +899,7 @@
     "packages/content/src/components/MarkdownRenderer.svelte": "sha256-QDI+xz6KliGlz3YV4aCWAoqUmX4cajonVHV/+1doQL0=",
     "packages/content/src/index.ts": "sha256-scEWe7C3B3+/JBaILqZd8c1ZiqZnKapfy8kz4SPFZSY=",
     "packages/shell/src/components/Breadcrumb.css": "sha256-SW9UA4xhl8K1fKwS/h/Htyui7GujRdNCCznfRrPJ8qY=",
-    "packages/shell/src/components/Breadcrumb.svelte": "sha256-NP1cHv6jMKWSe4PYsafPn/ta/Hle13f154pY6IS/Rig=",
+    "packages/shell/src/components/Breadcrumb.svelte": "sha256-Wy1+D8ogvJ7egWGxelLqprshUgz2uqrncc1W8HSc9Ms=",
     "packages/shell/src/components/Callout.css": "sha256-LnnrUMfn9/3VcHX6zcDZFSpqe7nKRMZKAI71Jkpgq+8=",
     "packages/shell/src/components/Callout.svelte": "sha256-ph59kDztSXz4xJ+NHdg4dkyhyMM5kv/uGpl/ZvdzgmY=",
     "packages/shell/src/components/CommandPalette.css": "sha256-/IGfp1GGTymIqO1Ti/TqyhNh4l6bvCqhd4On971rKCo=",
@@ -924,6 +924,7 @@
     "packages/shell/src/styles/base.css": "sha256-INLODwNQNHYVsBKgGXbW/PENIwGo7NuIODzsRFuUUN8=",
     "packages/shell/src/types.ts": "sha256-xRnEGFsxQoJKt05wbZb+rbvOVbkbNb5UCpXOSovR8hI=",
     "packages/shell/src/utils/fuzzy-filter.ts": "sha256-ZopMxsr/aoZ3BqcmGydIR4DOwysud9oxTBLp88qVXt8=",
+    "packages/shell/src/utils/safe-href.ts": "sha256-5LJjvZP1lV7HojkVIvxKuySP+mF+FgNL2FyTP9bGysY=",
     "packages/host-platform/src/components/ActivitySparkline.css": "sha256-M5jmOBJkZLPyqJ7v9irZ+pKWRT3mFFWSEvfuhTvtxPE=",
     "packages/host-platform/src/components/ActivitySparkline.svelte": "sha256-/uonlTULps3w17cjm1/ZRLiXvL9HlU5P4pZ8/gyvONw=",
     "packages/host-platform/src/components/CostGauge.css": "sha256-Nqt1VHD3Oo4dTazxtAkpohWq97YHnRKs2lI44IDCNbY=",
@@ -933,14 +934,14 @@
     "packages/host-platform/src/components/ProvisioningTimeline.css": "sha256-rphEj1C3PlOup0baAgJyDSkSiZmzvMX2JhOBlpGj+J4=",
     "packages/host-platform/src/components/ProvisioningTimeline.svelte": "sha256-p5Vnk8hHwe/VUaYsZwZ33+Q9IG42UuzZLo8vAa5tCdw=",
     "packages/host-platform/src/components/ReleaseTimeline.css": "sha256-UCzT8op2KiKophHU40Bcfv80iMmv22DjWH2nMAxfLNY=",
-    "packages/host-platform/src/components/ReleaseTimeline.svelte": "sha256-L8/Bx4pTa5DDE6kB8uxozkRjkMtDXqpLPUss8LR54/Y=",
+    "packages/host-platform/src/components/ReleaseTimeline.svelte": "sha256-UoZlC3xAeOn+Sz+p0byrHXAmG/2oJ40LPQkVekXZhdY=",
     "packages/host-platform/src/components/StackMatrix.css": "sha256-K59j8igR3hBFO2cFyaq3Rp0Dkjypg3+DM4wLCSWN9cY=",
     "packages/host-platform/src/components/StackMatrix.svelte": "sha256-aMruAWkbvQmTTEXLd8Yp5kQdHegwLoj64//o2q5UGPo=",
     "packages/host-platform/src/index.ts": "sha256-hFXD84EuQLU6bKXPyTkFUwxOewMy8fkcwkVzbRpAsTg=",
     "packages/host-platform/src/styles/base.css": "sha256-razMHs+WCheiXksb3g4y90O42WAyMruExK9MiNmJbhc=",
     "packages/host-platform/src/types.ts": "sha256-9wKDSQaj3aQ9OXIqdTbYM6O6sGbAxfpwa0I1119yBLg=",
     "packages/host-platform/src/utils/formatters.ts": "sha256-kkUGG/4k60g54llCi+xp5RmnYrg8TuFqMiKgdgd01cE=",
-    "packages/host-platform/src/utils/sparkline.ts": "sha256-w8R8uqcnpPo2QK8crNVtabB10ChInLNOdNeQ6HxNUCM=",
+    "packages/host-platform/src/utils/sparkline.ts": "sha256-j+qDcXr+pTHHVFNCTtly1D0gVIUpVVjq+wxCCDVkTFc=",
     "packages/faces/social/src/adapters/batcher.ts": "sha256-6PnUshOPk84U+PSnkADYzhN9SpUrvwiy+tN10HPaVeE=",
     "packages/faces/social/src/adapters/cache.ts": "sha256-32jUHLAsYoK4U0JZ6hswGUlQOmwhJ5yquqhMqyfrc4I=",
     "packages/faces/social/src/adapters/graphql/client.ts": "sha256-yor+sP4J7hzK+igh2s4mujPOUZTRDN/e3nU1eccrSyo=",
@@ -1614,8 +1615,8 @@
         },
         {
           "path": "src/components/Link.svelte",
-          "checksum": "sha256-yG+okvfpFcTa8KltWBIosJ5kuV2RiViWO0XsjEYm2EM=",
-          "size": 4652
+          "checksum": "sha256-YY1VcbLCFZBcP5tYvr6txpbxcI58AaiKQBqS0iDaTr0=",
+          "size": 4669
         },
         {
           "path": "src/components/Link.svelte.d.ts",
@@ -6044,8 +6045,8 @@
         },
         {
           "path": "src/components/Breadcrumb.svelte",
-          "checksum": "sha256-NP1cHv6jMKWSe4PYsafPn/ta/Hle13f154pY6IS/Rig=",
-          "size": 2695
+          "checksum": "sha256-Wy1+D8ogvJ7egWGxelLqprshUgz2uqrncc1W8HSc9Ms=",
+          "size": 2861
         },
         {
           "path": "src/components/Callout.css",
@@ -6166,6 +6167,11 @@
           "path": "src/utils/fuzzy-filter.ts",
           "checksum": "sha256-ZopMxsr/aoZ3BqcmGydIR4DOwysud9oxTBLp88qVXt8=",
           "size": 5020
+        },
+        {
+          "path": "src/utils/safe-href.ts",
+          "checksum": "sha256-5LJjvZP1lV7HojkVIvxKuySP+mF+FgNL2FyTP9bGysY=",
+          "size": 1125
         }
       ],
       "dependencies": [
@@ -6233,8 +6239,8 @@
         },
         {
           "path": "src/components/ReleaseTimeline.svelte",
-          "checksum": "sha256-L8/Bx4pTa5DDE6kB8uxozkRjkMtDXqpLPUss8LR54/Y=",
-          "size": 9974
+          "checksum": "sha256-UoZlC3xAeOn+Sz+p0byrHXAmG/2oJ40LPQkVekXZhdY=",
+          "size": 10724
         },
         {
           "path": "src/components/StackMatrix.css",
@@ -6268,8 +6274,8 @@
         },
         {
           "path": "src/utils/sparkline.ts",
-          "checksum": "sha256-w8R8uqcnpPo2QK8crNVtabB10ChInLNOdNeQ6HxNUCM=",
-          "size": 3430
+          "checksum": "sha256-j+qDcXr+pTHHVFNCTtly1D0gVIUpVVjq+wxCCDVkTFc=",
+          "size": 5481
         }
       ],
       "dependencies": [{ "name": "utils", "version": "0.10.1" }],


### PR DESCRIPTION
Project 43 (Security Remediation — Codex 2026-05-30) Milestone 1 integration for greater-components, merged into the dedicated branch and now PR'd to the default branch (staging).

Findings (each reviewed by Arch and merged into project-43-security-remediation with verified/DCO-signed commits, DCO+Snyk+CI green):
- GC-07 #710 — Breadcrumb javascript: href XSS (shared toSafeHref allowlist in packages/shell)
- GC-09 #711 — ReleaseTimeline javascript: href XSS (host-platform toSafeHref guard + security test)
- GC-11 #712 — Link rest-props style injection (strip style from restProps)
- GC-08 #713 — Unbounded sparkline DoS (iterative min/max + finite filter + <=1000 cap/downsample)
- GC-17 #714 — Playground duplicate-key crash (stable id keying)

Branch synced with staging. Provenance: theorymcp_lab GitHub App (Arch reviews) + verified steward commits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)