### PR TITLE
Project 43 M2 — greater-components supply-chain & CI provenance (GC-01/03/05/06/13)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -34,6 +34,9 @@ jobs:
           node-version-file: '.nvmrc'
           cache: 'pnpm'
 
+      - name: Audit lockfile integrity
+        run: pnpm audit:lockfile-integrity
+
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -168,6 +168,37 @@ greater --help
 - Fall back to the general GitHub plugin or `gh` only for capabilities the routed tools do not expose, such as diffs, inline review comments, unresolved threads, Actions logs, labels, search, approvals, or large local pushes. State the fallback reason when a GitHub write uses a non-routed path.
 - Routed provenance does not relax Greater gates: preserve component API stability, pinned Lesser/Lesser Host contract sync, WCAG 2.1 AA accessibility, CLI registry integrity, theming token stability, Mastodon-compatible behavior where applicable, and AGPL/dependency discipline.
 
+## Project MCP Trust Posture
+
+- `.mcp.json` intentionally registers the `greater_lab` remote MCP server at
+  `https://lab.theorymcp.ai/equaltoai/agents/greater/mcp`. The endpoint is
+  first-party EqualToAI/TheoryMCP steward-routing infrastructure for this repo,
+  not a general-purpose developer tool server.
+- Ownership: `lab.theorymcp.ai` is operated as EqualToAI/TheoryMCP infrastructure
+  for routed steward-agent sessions. The `greater_lab` route is scoped to the
+  Greater steward identity and exposes managed tools such as memory, email,
+  knowledge, and bounded GitHub operations.
+- Prefer `mcp__greater_lab__` GitHub tools for supported GitHub work because they
+  preserve routed-agent provenance, constrain writes to server-authorized repo
+  surfaces, and keep memory/email/GitHub actions attributable to the Greater
+  steward. Use fallback GitHub tooling only for capabilities the routed tools do
+  not expose, and state the fallback reason.
+- Trust assumptions: contributors and agents who enable the project MCP config
+  trust DNS/TLS resolution for `lab.theorymcp.ai`, the TheoryMCP service's tool
+  descriptions/resources/responses, and its server-side authorization policy for
+  the Greater steward route. Enabling project MCP connects the IDE agent to an
+  external server that controls tool behavior; never pass local secrets, tokens,
+  private keys, seed phrases, or unrelated repository contents through MCP tools.
+- Contributor consent: opening the repository does not by itself require using
+  the endpoint, but enabling project MCP in a compatible client is an informed
+  trust decision. Contributors who do not accept that remote-tool trust model
+  should leave project MCP disabled and use ordinary local/GitHub workflows.
+- Endpoint pinning / allowlist recommendation: keep any non-interactive client,
+  proxy, firewall, or enterprise MCP policy pinned to the exact HTTPS origin and
+  path above. Prefer certificate/SPKI pinning or an exact egress allowlist where
+  the client/runtime supports it without interactive prompts. Do not add local
+  approval gates that break non-interactive steward operation.
+
 ## Environment & Tooling Notes
 
 - Husky with lint-staged formats staged files and runs lightweight checks; fix failures locally before retrying the commit.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -101,6 +101,29 @@ By making a contribution to this project, I certify that:
 
 ## Development Workflow
 
+### Project MCP informed consent
+
+The root `.mcp.json` is intentionally committed so MCP-enabled developer clients
+can discover the `greater_lab` steward endpoint:
+`https://lab.theorymcp.ai/equaltoai/agents/greater/mcp`. `lab.theorymcp.ai` is
+first-party EqualToAI/TheoryMCP infrastructure used for routed steward-agent
+sessions. It is the preferred GitHub path for Greater steward work because it
+preserves agent provenance and scopes GitHub/email/memory/knowledge tools through
+server-side policy.
+
+If you accept or enable this project MCP configuration, your IDE agent connects
+to an external server that controls the exposed MCP tool descriptions, resources,
+and responses. Treat that as a trust decision: do not send local secrets, tokens,
+wallet keys, seed phrases, private customer data, or unrelated repository content
+through MCP tools. If you do not want that remote-tool trust posture, leave
+project MCP disabled and contribute using the normal local Git and GitHub flow.
+
+Recommended network control: pin or allowlist the exact HTTPS endpoint above in
+any non-interactive MCP client, proxy, firewall, or enterprise policy that
+supports it. Prefer certificate/SPKI pinning where available. The repository does
+not add approval prompts around `greater_lab`; non-interactive steward operation
+is an accepted governance requirement.
+
 ### Code Style
 
 - We use ESLint and Prettier for code formatting

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,60 @@
+# Security Policy
+
+## Reporting vulnerabilities
+
+Please report security vulnerabilities privately to security@equalto.ai. Do not
+open public issues for vulnerabilities until the maintainers have triaged and
+coordinated disclosure.
+
+## Project MCP trust posture
+
+The root `.mcp.json` intentionally registers the `greater_lab` remote MCP server
+at `https://lab.theorymcp.ai/equaltoai/agents/greater/mcp`. This endpoint is
+first-party EqualToAI/TheoryMCP infrastructure for routed Greater steward-agent
+sessions. It is not shipped to Greater CLI consumers as component runtime code,
+and it does not change the Svelte component production runtime.
+
+### Ownership and rationale
+
+- `lab.theorymcp.ai` is operated as EqualToAI/TheoryMCP steward-routing
+  infrastructure.
+- The `greater_lab` route is scoped to the Greater steward identity and exposes
+  managed tools such as memory, email, knowledge, and bounded GitHub operations.
+- Greater prefers this routed GitHub path for steward work because it records
+  agent provenance, narrows tool access through server-side policy, and keeps
+  project memory/email/GitHub activity tied to the steward endpoint.
+
+### Trust assumptions
+
+Enabling project MCP in a compatible client connects the local IDE agent to an
+external server that controls MCP tool descriptions, resources, and responses.
+Users who enable it are trusting:
+
+- DNS and TLS resolution for `lab.theorymcp.ai`;
+- the TheoryMCP service implementation and its operational controls;
+- server-side authorization that scopes the route to the Greater steward's
+  allowed mailbox, memory, knowledge, and GitHub surfaces; and
+- the local agent/client to avoid sending secrets or unrelated sensitive data
+  through MCP tool calls.
+
+Do not pass local secrets, access tokens, wallet keys, seed phrases, private
+customer data, or unrelated repository content through MCP tools. If you do not
+accept this trust model, leave project MCP disabled and use normal local/GitHub
+workflows instead.
+
+### Endpoint pinning / allowlist recommendation
+
+For non-interactive steward operation, keep `.mcp.json` active and do not add
+interactive approval gates. To reduce DNS/TLS subversion risk, enforce an exact
+allowlist or pin outside the portable project config where your MCP client,
+enterprise policy, proxy, firewall, or OS trust tooling supports it:
+
+- exact origin: `https://lab.theorymcp.ai`;
+- exact path: `/equaltoai/agents/greater/mcp`;
+- preferred extra control: certificate/SPKI pinning or equivalent endpoint
+  identity monitoring, if available without prompting during agent runs.
+
+The repo-level `.mcp.json` remains limited to the portable non-interactive MCP
+server declaration (`type` + `url`). Do not broaden allowlists to unrelated
+TheoryMCP paths or wildcard domains unless an operator explicitly approves that
+larger blast radius.

--- a/docs/adr/0001-accept-greater-lab-mcp-routing.md
+++ b/docs/adr/0001-accept-greater-lab-mcp-routing.md
@@ -1,0 +1,106 @@
+# ADR 0001: Accept and document `greater_lab` MCP steward routing
+
+- **Status:** Accepted
+- **Date:** 2026-05-30
+- **Issue:** [#716](https://github.com/equaltoai/greater-components/issues/716)
+- **Decision owner:** Aron / Greater stewardship governance
+
+## Context
+
+Greater commits a project-scoped `.mcp.json` that registers the remote
+`greater_lab` MCP server:
+
+```json
+{
+	"mcpServers": {
+		"greater_lab": {
+			"type": "http",
+			"url": "https://lab.theorymcp.ai/equaltoai/agents/greater/mcp"
+		}
+	}
+}
+```
+
+MCP-enabled developer tools may auto-discover this file. When a contributor or
+steward enables the project MCP config, the local IDE agent connects to
+`lab.theorymcp.ai`; that remote server controls the MCP tool descriptions,
+resources, and responses presented to the agent. This expands the developer-tool
+trust surface even though it does not affect Greater's shipped Svelte component
+runtime.
+
+The same remote-MCP-routing class was reviewed for SIM-02 and LB-02. Governance
+for Project 43 M2 is **accept and document**: keep `.mcp.json`, keep
+`greater_lab` as the preferred routed GitHub path, avoid approval gates that
+break non-interactive steward operation, and document the residual trust model
+plus endpoint pinning recommendation.
+
+## Decision
+
+Keep the root `.mcp.json` and the `greater_lab` remote endpoint active. Treat
+`lab.theorymcp.ai` as first-party EqualToAI/TheoryMCP steward-routing
+infrastructure for the Greater steward identity.
+
+Document the trust posture in contributor- and agent-facing repo docs:
+
+- ownership of `lab.theorymcp.ai` as EqualToAI/TheoryMCP infrastructure;
+- why `greater_lab` is preferred for supported GitHub work (bounded routed tools,
+  provenance, memory/email/knowledge continuity);
+- trust assumptions for DNS/TLS, TheoryMCP service behavior, and server-side
+  authorization;
+- informed consent for contributors who enable project MCP; and
+- endpoint pinning / exact allowlist recommendations for environments that can
+  enforce them without interactive prompts.
+
+Do not add interactive approval gates. Do not move the endpoint out of the
+project root while this governance decision stands.
+
+## Endpoint pinning / allowlist control
+
+The desired mitigation for DNS/TLS subversion is an exact non-interactive
+allowlist or pin applied by the MCP client, enterprise policy, egress proxy,
+firewall, OS trust tooling, or equivalent operator control:
+
+- origin: `https://lab.theorymcp.ai`;
+- path: `/equaltoai/agents/greater/mcp`;
+- preferred enhancement: certificate/SPKI pinning or endpoint identity monitoring
+  where supported without prompting during agent runs.
+
+No concrete pin is added to `.mcp.json` in this ADR because the portable project
+config used here declares the remote server by `type` and `url`; adding
+unsupported pinning fields could be ignored by clients or trigger compatibility
+and approval-prompt behavior. The enforceable pin belongs in the MCP runtime or
+network policy layer unless/until the project config format supports a portable,
+non-interactive pin.
+
+## Rejected alternatives
+
+### Remove `.mcp.json` / remove `greater_lab`
+
+Rejected. Removing the project MCP config would reduce auto-discovered remote MCP
+exposure, but it would also break the accepted steward workflow that relies on
+routed memory, email, knowledge, and bounded GitHub tools. It would weaken
+provenance for GitHub writes and diverge from the SIM-02/LB-02 governance ruling.
+
+### Add interactive approval gates
+
+Rejected. Approval gates can reduce accidental endpoint use, but Project 43 M2
+explicitly requires non-interactive Greater steward operation. Gates that prompt
+mid-run would strand routed memory/GitHub/email workflows and make automation
+less reliable.
+
+### Move steward routing to an opt-in location
+
+Rejected. A user-scoped or hidden opt-in config would make the trust decision
+less visible in the repository and would make the Greater steward environment
+less reproducible. The accepted mitigation is transparent documentation,
+informed consent, and endpoint pinning/allowlisting outside `.mcp.json`.
+
+## Consequences
+
+- Contributors have a visible repo-level warning before enabling project MCP.
+- The Greater steward keeps the preferred routed `greater_lab` GitHub path and
+  non-interactive memory/email/knowledge/GitHub operation.
+- The residual developer-tool trust surface remains accepted: anyone enabling
+  project MCP trusts `lab.theorymcp.ai` and the local client/agent boundary.
+- Production component code, adapter contracts, registry checksums, theming
+  tokens, and shipped Greater CLI component source are unchanged by this ADR.

--- a/package.json
+++ b/package.json
@@ -72,6 +72,7 @@
     "release:tag": "node scripts/release-tag.js",
     "release:artifacts": "bash scripts/build-release-artifacts.sh",
     "release:tag:dry": "node scripts/release-tag.js --dry-run",
+    "audit:lockfile-integrity": "node scripts/audit-lockfile-integrity.mjs",
     "audit:tarball-integrity": "node scripts/verify-tarball-integrity.js",
     "release:rehearse": "node scripts/rehearse-release-promotion.js"
   },

--- a/packages/adapters/package.json
+++ b/packages/adapters/package.json
@@ -38,7 +38,7 @@
     "@graphql-typed-document-node/core": "^3.2.0",
     "graphql": "^16.13.2",
     "graphql-ws": "^6.0.8",
-    "viem": "^2.51.0"
+    "viem": "2.51.3"
   },
   "devDependencies": {
     "@types/node": "^25.6.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -301,8 +301,8 @@ importers:
         specifier: ^6.0.8
         version: 6.0.8(graphql@16.13.2)(ws@8.21.0)
       viem:
-        specifier: ^2.51.0
-        version: 2.51.0(typescript@6.0.2)(zod@4.3.6)
+        specifier: 2.51.3
+        version: 2.51.3(typescript@6.0.2)(zod@4.3.6)
     devDependencies:
       '@types/node':
         specifier: ^25.6.0
@@ -5581,9 +5581,8 @@ packages:
       typescript:
         optional: true
 
-  ox@https://pkg.pr.new/ox@386a3439fe1ce76d237930f8c6e6bb493746069a:
-    resolution: {tarball: https://pkg.pr.new/ox@386a3439fe1ce76d237930f8c6e6bb493746069a}
-    version: 0.14.26-386a343.0
+  ox@0.14.25:
+    resolution: {integrity: sha512-8DoibKtxE8yw63Y2jjMhlbjaURev6WCx4QR4MWLusl2/qIaeTzMJMBIYIDl1KOF45+8H1Ur6eLTdPlUoO8PlRw==}
     peerDependencies:
       typescript: '>=5.4.0'
     peerDependenciesMeta:
@@ -6538,8 +6537,8 @@ packages:
       typescript:
         optional: true
 
-  viem@2.51.0:
-    resolution: {integrity: sha512-8C0Ca+eEapXE29vHMUW59NqKENl1X4s9P6xSNC9Nvw6EvAeAhn/LNUlgztk6TOw7KN1Gzz5a/n9Wv4okUfmY9g==}
+  viem@2.51.3:
+    resolution: {integrity: sha512-DA4EbrsvatzzLo6MwcWWiv6kI6dIr3I9HH9B6qsJaClN/s0AjIDUz5RIxl+VmGrovIUCcIvG8744yuGH7d37zw==}
     peerDependencies:
       typescript: '>=5.0.4'
     peerDependenciesMeta:
@@ -11417,7 +11416,7 @@ snapshots:
     transitivePeerDependencies:
       - zod
 
-  ox@https://pkg.pr.new/ox@386a3439fe1ce76d237930f8c6e6bb493746069a(typescript@6.0.2)(zod@4.3.6):
+  ox@0.14.25(typescript@6.0.2)(zod@4.3.6):
     dependencies:
       '@adraffy/ens-normalize': 1.11.1
       '@noble/ciphers': 1.3.0
@@ -12478,7 +12477,7 @@ snapshots:
       - utf-8-validate
       - zod
 
-  viem@2.51.0(typescript@6.0.2)(zod@4.3.6):
+  viem@2.51.3(typescript@6.0.2)(zod@4.3.6):
     dependencies:
       '@noble/curves': 1.9.1
       '@noble/hashes': 1.8.0
@@ -12486,7 +12485,7 @@ snapshots:
       '@scure/bip39': 1.6.0
       abitype: 1.2.3(typescript@6.0.2)(zod@4.3.6)
       isows: 1.0.7(ws@8.21.0)
-      ox: https://pkg.pr.new/ox@386a3439fe1ce76d237930f8c6e6bb493746069a(typescript@6.0.2)(zod@4.3.6)
+      ox: 0.14.25(typescript@6.0.2)(zod@4.3.6)
       ws: 8.21.0
     optionalDependencies:
       typescript: 6.0.2

--- a/scripts/audit-lockfile-integrity.mjs
+++ b/scripts/audit-lockfile-integrity.mjs
@@ -1,0 +1,100 @@
+#!/usr/bin/env node
+/**
+ * Audit pnpm-lock.yaml for preview tarballs and integrity-less package resolutions.
+ *
+ * Greater's source-install model relies on lockfile SRI for dependency provenance.
+ * Preview-package services such as pkg.pr.new are intentionally mutable and must
+ * not enter committed lockfiles; any package resolution block also needs a
+ * sha512 integrity field so pnpm can verify fetched artifacts.
+ */
+
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const rootDir = path.resolve(__dirname, '..');
+
+const LOCKFILE = process.env.LOCKFILE_PATH
+	? path.resolve(process.env.LOCKFILE_PATH)
+	: path.join(rootDir, 'pnpm-lock.yaml');
+const DISALLOWED_TARBALL_RE = /pkg\.pr\.new/i;
+const SHA512_INTEGRITY_RE = /\bintegrity:\s+sha512-[A-Za-z0-9+/]+=*/;
+
+function packageSectionLines(lockfile) {
+	const lines = lockfile.split('\n');
+	const start = lines.findIndex((line) => line === 'packages:');
+	if (start === -1) {
+		throw new Error('pnpm-lock.yaml is missing a packages: section');
+	}
+
+	const end = lines.findIndex((line, index) => index > start && /^[^ \t].*:$/.test(line));
+	return {
+		lines: lines.slice(start + 1, end === -1 ? lines.length : end),
+		startLineNumber: start + 2,
+	};
+}
+
+function collectPackageBlocks(lines, startLineNumber) {
+	const blocks = [];
+	let current = null;
+
+	for (const [index, line] of lines.entries()) {
+		if (/^ {2}\S.*:$/.test(line)) {
+			if (current) blocks.push(current);
+			current = {
+				key: line.trim().replace(/:$/, ''),
+				lineNumber: startLineNumber + index,
+				lines: [line],
+			};
+			continue;
+		}
+
+		current?.lines.push(line);
+	}
+
+	if (current) blocks.push(current);
+	return blocks;
+}
+
+function main() {
+	const lockfile = fs.readFileSync(LOCKFILE, 'utf8');
+	const errors = [];
+
+	const disallowedTarballLines = lockfile
+		.split('\n')
+		.map((line, index) => ({ line, lineNumber: index + 1 }))
+		.filter(({ line }) => DISALLOWED_TARBALL_RE.test(line));
+
+	for (const { line, lineNumber } of disallowedTarballLines) {
+		errors.push(`pnpm-lock.yaml:${lineNumber}: disallowed pkg.pr.new reference: ${line.trim()}`);
+	}
+
+	const packageSection = packageSectionLines(lockfile);
+	const packageBlocks = collectPackageBlocks(packageSection.lines, packageSection.startLineNumber);
+	const resolutionBlocks = packageBlocks.filter(({ lines }) =>
+		lines.some((line) => /^\s+resolution:/.test(line))
+	);
+	const missingIntegrityBlocks = resolutionBlocks.filter(
+		({ lines }) => !SHA512_INTEGRITY_RE.test(lines.join('\n'))
+	);
+
+	for (const { key, lineNumber } of missingIntegrityBlocks) {
+		errors.push(`pnpm-lock.yaml:${lineNumber}: ${key} resolution is missing sha512 integrity`);
+	}
+
+	if (errors.length > 0) {
+		console.error('Lockfile integrity audit failed:');
+		for (const error of errors) {
+			console.error(`- ${error}`);
+		}
+		process.exit(1);
+	}
+
+	console.log(
+		`Lockfile integrity audit passed: no pkg.pr.new references; ${resolutionBlocks.length} package resolution blocks include sha512 integrity.`
+	);
+}
+
+main();

--- a/scripts/check-dco.js
+++ b/scripts/check-dco.js
@@ -30,10 +30,61 @@ function parseCommit(sha) {
 	};
 }
 
-function validSignoff(commit) {
+function normalizeEmail(email) {
+	return email.trim().toLowerCase();
+}
+
+function routedStewardAgent(commit) {
+	const loginPattern = /^([a-z0-9](?:[a-z0-9-]*[a-z0-9])?)-steward\[bot\]$/i;
+	const emailPattern =
+		/^[0-9]+\+([a-z0-9](?:[a-z0-9-]*[a-z0-9])?)-steward\[bot\]@users\.noreply\.github\.com$/i;
+	const loginMatch = commit.authorName.trim().match(loginPattern);
+	const emailMatch = commit.authorEmail.trim().match(emailPattern);
+	if (!loginMatch || !emailMatch) return undefined;
+
+	const loginAgent = loginMatch[1].toLowerCase();
+	const emailAgent = emailMatch[1].toLowerCase();
+	return loginAgent === emailAgent ? loginAgent : undefined;
+}
+
+function matchesRoutedStewardSignoff(commit, signoffEmail) {
+	const agent = routedStewardAgent(commit);
+	if (!agent) return false;
+
+	/*
+	 * Aron-approved narrow exception: routed TheoryMCP commits are authored by
+	 * the GitHub App bot (<agent>-steward[bot] / numeric+<agent>-steward[bot]
+	 * noreply email), while the auditable DCO identity is the steward agent
+	 * mailbox. Accept only that corresponding <agent>.equaltoai@theorymcp.ai
+	 * signoff. Human commits and all non-routed bots still require strict
+	 * author-email == signoff-email matching.
+	 */
+	return normalizeEmail(signoffEmail) === `${agent}.equaltoai@theorymcp.ai`;
+}
+
+function matchingSignoff(commit) {
 	const signoffPattern = /^Signed-off-by:\s*(.*?)\s*<([^>]+)>\s*$/gim;
-	const matches = [...commit.body.matchAll(signoffPattern)];
-	return matches.length > 0;
+	const authorEmail = normalizeEmail(commit.authorEmail);
+
+	for (const match of commit.body.matchAll(signoffPattern)) {
+		const signoff = {
+			name: match[1].trim(),
+			email: match[2].trim(),
+			routedSteward: false,
+		};
+		const signoffEmail = normalizeEmail(signoff.email);
+		if (signoffEmail === authorEmail) return signoff;
+		if (matchesRoutedStewardSignoff(commit, signoff.email)) {
+			signoff.routedSteward = true;
+			return signoff;
+		}
+	}
+
+	return undefined;
+}
+
+function validSignoff(commit) {
+	return matchingSignoff(commit) !== undefined;
 }
 
 function remediationConfigEnabled() {
@@ -104,8 +155,12 @@ for (const commit of parsedCommits) {
 		continue;
 	}
 
-	if (validSignoff(commit)) {
-		console.log(`dco: ${commit.sha} signed off by ${commit.authorName} <${commit.authorEmail}>`);
+	const signoff = matchingSignoff(commit);
+	if (signoff) {
+		const allowlistNote = signoff.routedSteward ? ' via routed TheoryMCP App allowlist' : '';
+		console.log(
+			`dco: ${commit.sha} signed off by ${signoff.name} <${signoff.email}>${allowlistNote}`
+		);
 		continue;
 	}
 
@@ -122,7 +177,7 @@ for (const commit of parsedCommits) {
 	}
 
 	error(
-		`Commit ${commit.sha} is missing Signed-off-by for ${commit.authorName} <${commit.authorEmail}>`
+		`Commit ${commit.sha} is missing Signed-off-by matching ${commit.authorName} <${commit.authorEmail}>`
 	);
 	failed = true;
 }

--- a/scripts/check-dco.test.mjs
+++ b/scripts/check-dco.test.mjs
@@ -1,0 +1,234 @@
+import assert from 'node:assert/strict';
+import { execFileSync, spawnSync } from 'node:child_process';
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const repoRoot = resolve(__dirname, '..');
+const checkDcoScript = join(repoRoot, 'scripts', 'check-dco.js');
+
+function git(cwd, args) {
+	return execFileSync('git', args, { cwd, encoding: 'utf8' }).trimEnd();
+}
+
+function createRepo() {
+	const cwd = mkdtempSync(join(tmpdir(), 'greater-check-dco-'));
+	git(cwd, ['init', '-q']);
+	mkdirSync(join(cwd, '.github'), { recursive: true });
+	writeFileSync(join(cwd, '.github', 'dco.yml'), 'allowRemediationCommits:\n  individual: true\n');
+	git(cwd, ['add', '.github/dco.yml']);
+	git(cwd, [
+		'-c',
+		'user.name=Test Committer',
+		'-c',
+		'user.email=committer@example.com',
+		'-c',
+		'commit.gpgsign=false',
+		'commit',
+		'-q',
+		'-m',
+		'base',
+	]);
+	return cwd;
+}
+
+function commit(cwd, { authorEmail, authorName, body, subject = 'test commit' }) {
+	const args = [
+		'-c',
+		'user.name=Test Committer',
+		'-c',
+		'user.email=committer@example.com',
+		'-c',
+		'commit.gpgsign=false',
+		'commit',
+		'-q',
+		'--allow-empty',
+		`--author=${authorName} <${authorEmail}>`,
+		'-m',
+		subject,
+	];
+	if (body) args.push('-m', body);
+	git(cwd, args);
+	return git(cwd, ['rev-parse', 'HEAD']);
+}
+
+function runDco(cwd, base, head = 'HEAD') {
+	return spawnSync(process.execPath, [checkDcoScript, '--base', base, '--head', head], {
+		cwd,
+		encoding: 'utf8',
+	});
+}
+
+function withRepo(fn) {
+	const cwd = createRepo();
+	try {
+		return fn(cwd);
+	} finally {
+		rmSync(cwd, { force: true, recursive: true });
+	}
+}
+
+function expectDcoPass(cwd, base, head) {
+	const result = runDco(cwd, base, head);
+	assert.equal(
+		result.status,
+		0,
+		`expected DCO pass\nstdout:\n${result.stdout}\nstderr:\n${result.stderr}`
+	);
+	return result;
+}
+
+function expectDcoFail(cwd, base, head) {
+	const result = runDco(cwd, base, head);
+	assert.notEqual(
+		result.status,
+		0,
+		`expected DCO failure\nstdout:\n${result.stdout}\nstderr:\n${result.stderr}`
+	);
+	return result;
+}
+
+const tests = [
+	[
+		'human author with matching Signed-off-by passes',
+		() =>
+			withRepo((cwd) => {
+				const base = git(cwd, ['rev-parse', 'HEAD']);
+				commit(cwd, {
+					authorName: 'Author Example',
+					authorEmail: 'author@example.com',
+					body: 'Signed-off-by: Author Example <AUTHOR@example.com>',
+				});
+
+				expectDcoPass(cwd, base);
+			}),
+	],
+	[
+		'human author with only non-matching Signed-off-by fails',
+		() =>
+			withRepo((cwd) => {
+				const base = git(cwd, ['rev-parse', 'HEAD']);
+				commit(cwd, {
+					authorName: 'Author Example',
+					authorEmail: 'author@example.com',
+					body: 'Signed-off-by: Someone Else <other@example.com>',
+				});
+
+				const result = expectDcoFail(cwd, base);
+				assert.match(
+					result.stderr,
+					/missing Signed-off-by matching Author Example <author@example\.com>/
+				);
+			}),
+	],
+	[
+		'routed TheoryMCP App author with corresponding agent signoff passes',
+		() =>
+			withRepo((cwd) => {
+				const base = git(cwd, ['rev-parse', 'HEAD']);
+				commit(cwd, {
+					authorName: 'greater-steward[bot]',
+					authorEmail: '287077153+greater-steward[bot]@users.noreply.github.com',
+					body: 'Signed-off-by: Greater steward <greater.equaltoai@theorymcp.ai>',
+				});
+
+				const result = expectDcoPass(cwd, base);
+				assert.match(result.stdout, /routed TheoryMCP App allowlist/);
+			}),
+	],
+	[
+		'non-allowlisted bot author with mismatched signoff fails',
+		() =>
+			withRepo((cwd) => {
+				const base = git(cwd, ['rev-parse', 'HEAD']);
+				commit(cwd, {
+					authorName: 'dependabot[bot]',
+					authorEmail: '49699333+dependabot[bot]@users.noreply.github.com',
+					body: 'Signed-off-by: Greater steward <greater.equaltoai@theorymcp.ai>',
+				});
+
+				expectDcoFail(cwd, base);
+			}),
+	],
+	[
+		'merge commits without signoff are skipped',
+		() =>
+			withRepo((cwd) => {
+				const base = git(cwd, ['rev-parse', 'HEAD']);
+				git(cwd, ['checkout', '-q', '-b', 'topic']);
+				commit(cwd, {
+					authorName: 'Topic Author',
+					authorEmail: 'topic@example.com',
+					body: 'Signed-off-by: Topic Author <topic@example.com>',
+				});
+				git(cwd, ['checkout', '-q', '-']);
+				commit(cwd, {
+					authorName: 'Main Author',
+					authorEmail: 'main@example.com',
+					body: 'Signed-off-by: Main Author <main@example.com>',
+				});
+				git(cwd, [
+					'-c',
+					'user.name=Merge Committer',
+					'-c',
+					'user.email=merge@example.com',
+					'-c',
+					'commit.gpgsign=false',
+					'merge',
+					'-q',
+					'--no-ff',
+					'topic',
+					'-m',
+					'Merge topic',
+				]);
+
+				const result = expectDcoPass(cwd, base);
+				assert.match(result.stdout, /skipping merge commit/);
+			}),
+	],
+	[
+		'signed remediation commits continue to remediate individual commits',
+		() =>
+			withRepo((cwd) => {
+				const base = git(cwd, ['rev-parse', 'HEAD']);
+				const badSha = commit(cwd, {
+					authorName: 'Author Example',
+					authorEmail: 'author@example.com',
+					subject: 'unsigned commit',
+				});
+				commit(cwd, {
+					authorName: 'Author Example',
+					authorEmail: 'author@example.com',
+					subject: 'DCO remediation commit for Author Example <author@example.com>',
+					body: [
+						`I, Author Example <author@example.com>, hereby add my Signed-off-by to this commit: ${badSha}`,
+						'',
+						'Signed-off-by: Author Example <author@example.com>',
+					].join('\n'),
+				});
+
+				const result = expectDcoPass(cwd, base);
+				assert.match(
+					result.stdout,
+					new RegExp(`remediated by [0-9a-f]{40} for Author Example <author@example\\.com>`)
+				);
+			}),
+	],
+];
+
+let failed = false;
+for (const [name, test] of tests) {
+	try {
+		test();
+		console.log(`ok - ${name}`);
+	} catch (cause) {
+		failed = true;
+		console.error(`not ok - ${name}`);
+		console.error(cause);
+	}
+}
+
+if (failed) process.exit(1);
+console.log(`check-dco tests: PASS (${tests.length} tests)`);

--- a/scripts/dispatch-release-pr-checks.sh
+++ b/scripts/dispatch-release-pr-checks.sh
@@ -79,6 +79,25 @@ date_to_epoch() {
 	date -d "${value}" +%s 2>/dev/null
 }
 
+is_numeric_run_id() {
+	local value="$1"
+	[[ "${value}" =~ ^[0-9]+$ ]]
+}
+
+fail_invalid_run_id() {
+	local context="$1"
+	local workflow="$2"
+	local run_id="$3"
+
+	set_status "${context}" "failure" "Could not find fresh dispatched ${context} run"
+	if [[ -z "${run_id}" ]]; then
+		echo "::error::release-pr-checks: could not find fresh dispatched ${workflow} run" >&2
+	else
+		printf '::error::release-pr-checks: resolved %s run ID is not numeric: %q\n' "${workflow}" "${run_id}" >&2
+	fi
+	return 1
+}
+
 validate_dispatched_run() {
 	local run_id="$1"
 	local dispatch_started_epoch="$2"
@@ -157,6 +176,7 @@ find_fresh_dispatched_run() {
 	local workflow="$1"
 	local dispatch_started_epoch="$2"
 
+	# The caller captures stdout as run_id; keep all diagnostics on stderr.
 	for (( attempt = 1; attempt <= RUN_LOOKUP_ATTEMPTS; attempt++ )); do
 		local runs_json
 		runs_json="$(
@@ -195,6 +215,10 @@ find_fresh_dispatched_run() {
 		fi
 
 		local run_id="${candidate_run_ids[0]}"
+		if ! is_numeric_run_id "${run_id}"; then
+			printf '::error::release-pr-checks: resolved %s run ID is not numeric: %q\n' "${workflow}" "${run_id}" >&2
+			return 1
+		fi
 		if ! validate_dispatched_run "${run_id}" "${dispatch_started_epoch}" "${workflow}" "true"; then
 			return 1
 		fi
@@ -242,21 +266,32 @@ run_workflow_check() {
 		return 1
 	fi
 
-	if [[ -z "${run_id}" ]]; then
-		set_status "${context}" "failure" "Could not find deterministic dispatched ${context} run"
-		echo "::error::release-pr-checks: could not find deterministic dispatched ${workflow} run"
+	if ! is_numeric_run_id "${run_id}"; then
+		fail_invalid_run_id "${context}" "${workflow}" "${run_id}"
 		return 1
 	fi
 
 	local run_url
+	if ! is_numeric_run_id "${run_id}"; then
+		fail_invalid_run_id "${context}" "${workflow}" "${run_id}"
+		return 1
+	fi
 	run_url="$(gh run view "${run_id}" --json url --jq '.url')"
 
+	if ! is_numeric_run_id "${run_id}"; then
+		fail_invalid_run_id "${context}" "${workflow}" "${run_id}"
+		return 1
+	fi
 	if gh run watch "${run_id}" --exit-status; then
 		set_status "${context}" "success" "${context} passed" "${run_url}"
 		return 0
 	fi
 
 	local conclusion
+	if ! is_numeric_run_id "${run_id}"; then
+		fail_invalid_run_id "${context}" "${workflow}" "${run_id}"
+		return 1
+	fi
 	conclusion="$(gh run view "${run_id}" --json conclusion --jq '.conclusion // "failure"')"
 	set_status "${context}" "failure" "${context} ${conclusion}" "${run_url}"
 	return 1

--- a/scripts/dispatch-release-pr-checks.sh
+++ b/scripts/dispatch-release-pr-checks.sh
@@ -6,10 +6,10 @@ set -euo pipefail
 # the promotion guard + DCO gate, then mirror those verified results onto the
 # release PR head SHA as commit statuses so the PR is visibly gated.
 #
-# CSR-028 hardening: dispatched runs are now validated for freshness (created
-# within MAX_RUN_AGE_SEC seconds). The most-recently-created matching run is
-# always selected; stale runs are skipped. If no fresh run can be found after
-# retries, the check fails rather than trusting a potentially stale result.
+# CSR-028/GC-05 hardening: dispatched runs are bound to this script's dispatch
+# timestamp and, for list-based resolution, to the expected workflow_dispatch
+# base_ref input. If the dispatched run cannot be resolved deterministically,
+# the check fails closed rather than trusting a stale or raced workflow result.
 
 : "${GH_REPO:?GH_REPO is required}"
 : "${RELEASE_BRANCH:?RELEASE_BRANCH is required}"
@@ -71,54 +71,133 @@ set_status() {
 	gh api "${args[@]}" >/dev/null
 }
 
-# Maximum age (seconds) for a dispatched run to be considered fresh.
-# Runs older than this are rejected to prevent trusting stale workflow results.
-MAX_RUN_AGE_SEC="${MAX_RUN_AGE_SEC:-180}"
+RUN_LOOKUP_ATTEMPTS="${RUN_LOOKUP_ATTEMPTS:-12}"
+RUN_LOOKUP_SLEEP_SEC="${RUN_LOOKUP_SLEEP_SEC:-5}"
+
+date_to_epoch() {
+	local value="$1"
+	date -d "${value}" +%s 2>/dev/null
+}
+
+validate_dispatched_run() {
+	local run_id="$1"
+	local dispatch_started_epoch="$2"
+	local workflow="$3"
+	local require_base_ref_input="$4"
+
+	local run_json
+	if ! run_json="$(gh api "repos/${GH_REPO}/actions/runs/${run_id}")"; then
+		echo "::error::release-pr-checks: could not fetch metadata for run ${run_id}" >&2
+		return 1
+	fi
+
+	local event created_at run_head_sha head_branch workflow_path
+	event="$(jq -r '.event // empty' <<<"${run_json}")"
+	created_at="$(jq -r '.created_at // .createdAt // empty' <<<"${run_json}")"
+	run_head_sha="$(jq -r '.head_sha // .headSha // empty' <<<"${run_json}")"
+	head_branch="$(jq -r '.head_branch // .headBranch // empty' <<<"${run_json}")"
+	workflow_path="$(jq -r '.path // empty' <<<"${run_json}")"
+
+	if [[ "${event}" != "workflow_dispatch" ]]; then
+		echo "::error::release-pr-checks: run ${run_id} event is ${event:-<missing>}, not workflow_dispatch" >&2
+		return 1
+	fi
+
+	if [[ "${head_branch}" != "${RELEASE_BRANCH}" ]]; then
+		echo "::error::release-pr-checks: run ${run_id} head branch is ${head_branch:-<missing>}, expected ${RELEASE_BRANCH}" >&2
+		return 1
+	fi
+
+	if [[ "${run_head_sha}" != "${head_sha}" ]]; then
+		echo "::error::release-pr-checks: run ${run_id} head SHA is ${run_head_sha:-<missing>}, expected ${head_sha}" >&2
+		return 1
+	fi
+
+	if [[ -n "${workflow_path}" && "${workflow_path}" != ".github/workflows/${workflow}" && "${workflow_path##*/}" != "${workflow}" ]]; then
+		echo "::error::release-pr-checks: run ${run_id} workflow path is ${workflow_path}, expected ${workflow}" >&2
+		return 1
+	fi
+
+	local created_at_epoch
+	if [[ -z "${created_at}" ]] || ! created_at_epoch="$(date_to_epoch "${created_at}")"; then
+		echo "::error::release-pr-checks: could not parse createdAt for run ${run_id}" >&2
+		return 1
+	fi
+
+	if (( created_at_epoch < dispatch_started_epoch )); then
+		echo "::error::release-pr-checks: run ${run_id} was created before this dispatch started" >&2
+		return 1
+	fi
+
+	if [[ "${require_base_ref_input}" == "true" ]]; then
+		local base_ref
+		base_ref="$(
+			jq -r '
+				.inputs.base_ref
+				// .event.inputs.base_ref
+				// .workflow_dispatch.inputs.base_ref
+				// .workflowDispatch.inputs.base_ref
+				// empty
+			' <<<"${run_json}"
+		)"
+
+		if [[ -z "${base_ref}" ]]; then
+			echo "::error::release-pr-checks: could not verify workflow_dispatch input base_ref for run ${run_id}" >&2
+			return 1
+		fi
+
+		if [[ "${base_ref}" != "${BASE_BRANCH}" ]]; then
+			echo "::error::release-pr-checks: run ${run_id} base_ref is ${base_ref}, expected ${BASE_BRANCH}" >&2
+			return 1
+		fi
+	fi
+}
 
 find_fresh_dispatched_run() {
 	local workflow="$1"
+	local dispatch_started_epoch="$2"
 
-	for _ in {1..12}; do
-		local run_id
-		run_id="$(
+	for (( attempt = 1; attempt <= RUN_LOOKUP_ATTEMPTS; attempt++ )); do
+		local runs_json
+		runs_json="$(
 			gh run list \
 				--workflow "${workflow}" \
 				--branch "${RELEASE_BRANCH}" \
 				--event workflow_dispatch \
 				--limit 20 \
-				--json databaseId,headSha,createdAt \
-				--jq "
-					[.[] | select(.headSha == \"${head_sha}\")]
-					| sort_by(.createdAt)
-					| reverse
-					| .[0]
-					| .databaseId
-				"
+				--json databaseId,headSha,createdAt
 		)"
 
-		if [[ -z "${run_id}" || "${run_id}" == "null" ]]; then
-			sleep 5
+		local -a candidate_run_ids
+		mapfile -t candidate_run_ids < <(
+			jq -r \
+				--arg head_sha "${head_sha}" \
+				--argjson dispatch_started_epoch "${dispatch_started_epoch}" \
+				'
+					[
+						.[] |
+						select(.headSha == $head_sha) |
+						select((.createdAt | fromdateiso8601) >= $dispatch_started_epoch) |
+						.databaseId
+					] |
+					.[]?
+				' <<<"${runs_json}"
+		)
+
+		if [[ "${#candidate_run_ids[@]}" -eq 0 ]]; then
+			sleep "${RUN_LOOKUP_SLEEP_SEC}"
 			continue
 		fi
 
-		# Verify freshness: reject runs older than MAX_RUN_AGE_SEC.
-		local created_at_epoch now_epoch run_age
-		created_at_epoch="$(gh run view "${run_id}" --json createdAt --jq '.createdAt' | xargs -I{} date -d '{}' +%s 2>/dev/null || echo 0)"
-		now_epoch="$(date +%s)"
-
-		if [[ "${created_at_epoch}" -eq 0 ]]; then
-			echo "::warning::release-pr-checks: could not parse createdAt for run ${run_id}; accepting anyway"
-			echo "${run_id}"
-			return 0
+		if [[ "${#candidate_run_ids[@]}" -ne 1 ]]; then
+			echo "::error::release-pr-checks: found ${#candidate_run_ids[@]} candidate ${workflow} runs after dispatch; refusing heuristic selection" >&2
+			return 1
 		fi
 
-		run_age=$(( now_epoch - created_at_epoch ))
-		if [[ "${run_age}" -gt "${MAX_RUN_AGE_SEC}" ]]; then
-			echo "::warning::release-pr-checks: run ${run_id} is ${run_age}s old (> ${MAX_RUN_AGE_SEC}s max); skipping stale run"
-			sleep 5
-			continue
+		local run_id="${candidate_run_ids[0]}"
+		if ! validate_dispatched_run "${run_id}" "${dispatch_started_epoch}" "${workflow}" "true"; then
+			return 1
 		fi
-
 		echo "${run_id}"
 		return 0
 	done
@@ -131,6 +210,14 @@ run_workflow_check() {
 	local context="$2"
 
 	set_status "${context}" "pending" "Running ${context}"
+
+	local dispatch_started_at dispatch_started_epoch
+	dispatch_started_at="$(date -u '+%Y-%m-%dT%H:%M:%SZ')"
+	if ! dispatch_started_epoch="$(date_to_epoch "${dispatch_started_at}")"; then
+		set_status "${context}" "failure" "Could not timestamp ${context} dispatch"
+		echo "::error::release-pr-checks: could not parse dispatch timestamp ${dispatch_started_at}"
+		return 1
+	fi
 
 	local output
 	if ! output="$(
@@ -149,12 +236,15 @@ run_workflow_check() {
 	run_id="$(grep -Eo 'https://github.com/[^[:space:]]+/actions/runs/[0-9]+' <<<"${output}" | tail -n 1 | awk -F/ '{print $NF}' || true)"
 
 	if [[ -z "${run_id}" ]]; then
-		run_id="$(find_fresh_dispatched_run "${workflow}" || true)"
+		run_id="$(find_fresh_dispatched_run "${workflow}" "${dispatch_started_epoch}" || true)"
+	elif ! validate_dispatched_run "${run_id}" "${dispatch_started_epoch}" "${workflow}" "false"; then
+		set_status "${context}" "failure" "Dispatched ${context} run failed validation"
+		return 1
 	fi
 
 	if [[ -z "${run_id}" ]]; then
-		set_status "${context}" "failure" "Could not find fresh dispatched ${context} run"
-		echo "::error::release-pr-checks: could not find fresh dispatched ${workflow} run"
+		set_status "${context}" "failure" "Could not find deterministic dispatched ${context} run"
+		echo "::error::release-pr-checks: could not find deterministic dispatched ${workflow} run"
 		return 1
 	fi
 


### PR DESCRIPTION
Project 43 (Security Remediation — Codex 2026-05-30) Milestone 2 integration for greater-components, all 5 findings merged into the dedicated branch (each Arch-reviewed, verified/DCO commits, DCO+Snyk green) and now PR'd to the default branch (staging). M1 already landed on staging via #734; this PR is the M2 diff only.

- GC-01 #715 — viem pinned to a registry-sourced ox (no pkg.pr.new tarball; full lockfile integrity) + a CI lockfile-integrity guard
- GC-06 #716 — .mcp.json greater_lab trust posture: accept-and-document (ADR 0001 + SECURITY/CONTRIBUTING trust notes), no approval gates
- GC-03 #717 — DCO checker now requires author-matched Signed-off-by, with a documented routed-App allowlist (*-steward[bot] + <agent>.equaltoai@theorymcp.ai)
- GC-05 #718 — release-PR dispatch binds to a created-after run + base_ref, fails closed (no stale/raced run trust)
- GC-13 #719 — release-dispatch run_id is numeric-only (warnings to stderr) + fail-closed caller

🤖 Generated with [Claude Code](https://claude.com/claude-code)