### PR TITLE
fix(playground): build CSS deps before playground

### DIFF
--- a/apps/playground/package.json
+++ b/apps/playground/package.json
@@ -13,6 +13,9 @@
   "scripts": {
     "dev": "vite dev",
     "dev:csr": "vite dev --mode csr",
+    "build:css-deps": "pnpm --dir ../.. --filter @equaltoai/greater-components-tokens build && pnpm --dir ../.. --filter @equaltoai/greater-components-primitives build && pnpm --dir ../.. --filter @equaltoai/greater-components-shell build && pnpm --dir ../.. --filter @equaltoai/greater-components-host-platform build",
+    "prebuild": "pnpm run build:css-deps",
+    "predev": "pnpm run build:css-deps",
     "build": "svelte-kit sync && vite build && node ./scripts/export-static.mjs && node ../../scripts/postprocess-csp-build.mjs build --base /greater-components",
     "preview": "vite preview",
     "typecheck": "tsc --noEmit",
@@ -26,9 +29,11 @@
     "@equaltoai/greater-components-chat": "workspace:*",
     "@equaltoai/greater-components-content": "workspace:*",
     "@equaltoai/greater-components-headless": "workspace:*",
+    "@equaltoai/greater-components-host-platform": "workspace:*",
     "@equaltoai/greater-components-icons": "workspace:*",
     "@equaltoai/greater-components-notifications": "workspace:*",
     "@equaltoai/greater-components-primitives": "workspace:*",
+    "@equaltoai/greater-components-shell": "workspace:*",
     "@equaltoai/greater-components-social": "workspace:*",
     "@equaltoai/greater-components-tokens": "workspace:*",
     "@equaltoai/greater-components-utils": "workspace:*"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -236,6 +236,9 @@ importers:
       '@equaltoai/greater-components-headless':
         specifier: workspace:*
         version: link:../../packages/headless
+      '@equaltoai/greater-components-host-platform':
+        specifier: workspace:*
+        version: link:../../packages/host-platform
       '@equaltoai/greater-components-icons':
         specifier: workspace:*
         version: link:../../packages/icons
@@ -245,6 +248,9 @@ importers:
       '@equaltoai/greater-components-primitives':
         specifier: workspace:*
         version: link:../../packages/primitives
+      '@equaltoai/greater-components-shell':
+        specifier: workspace:*
+        version: link:../../packages/shell
       '@equaltoai/greater-components-social':
         specifier: workspace:*
         version: link:../../packages/faces/social


### PR DESCRIPTION
## Summary

- Add `@equaltoai/greater-components-shell` and `@equaltoai/greater-components-host-platform` as `workspace:*` playground dependencies.
- Add playground `prebuild`/`predev` CSS dependency generation so clean filtered playground `build`/`dev` commands generate the token, primitive, shell, and host-platform CSS dist artifacts before Vite resolves route imports.
- Keep GC-15 scoped to playground package metadata/runtime build correctness; no component API, theming token, adapter, registry, or a11y behavior changes.

## Validation

From a clean generated-output state (`packages/{tokens,primitives,shell,host-platform}/dist`, `apps/playground/.svelte-kit`, and `apps/playground/build` removed before validation):

- `corepack pnpm install --frozen-lockfile` — PASS (lockfile up to date; existing pnpm warnings about missing CLI bin before CLI build and ignored build scripts for core-js/esbuild).
- `corepack pnpm --filter @equaltoai/playground build` — PASS; prebuild generated CSS deps, Vite build succeeded, static export completed, CSP postprocess updated 49 HTML files; `/shell` and `/host-platform` prerendered as `apps/playground/build/shell.html` and `apps/playground/build/host-platform.html` with no missing-CSS-module error.
- `CHOKIDAR_USEPOLLING=1 corepack pnpm --filter @equaltoai/playground dev --host 127.0.0.1 --port 4175` — PASS for startup and route resolution; predev generated CSS deps, Vite became ready, then `curl` returned `/shell status=200 bytes=557970` and `/host-platform status=200 bytes=603173`. The earlier non-polling dev attempt hit local inotify `ENOSPC`, so polling was used for this environment; server was then stopped with Ctrl-C.
- `corepack pnpm lint` — PASS with existing warnings only (54 `no-non-null-assertion` warnings in shell/host-platform tests/source).
- `corepack pnpm typecheck` — PASS.
- `git diff --check` — PASS.

## Acceptance checklist

- [x] Playground package lists shell and host-platform workspace dependencies.
- [x] Clean filtered `pnpm --filter @equaltoai/playground build` succeeds without manually prebuilding shell/host-platform.
- [x] `/shell` and `/host-platform` prerender/render without missing CSS module errors.
- [x] No GC-15 non-goal changes: no component public API changes, no adapter/contract changes, no registry edits.

## Provenance

Local GPG-signed fallback was used because the lockfile update makes routed `github_commit_files` impractical for bounded file upload. Commit includes the Greater steward sign-off plus TheoryMCP trailers.
