### PR TITLE
chore: sync lesser-host v1.0.3 contracts

### DIFF
--- a/docs/lesser-host/contracts/LESSER_HOST_REF.txt
+++ b/docs/lesser-host/contracts/LESSER_HOST_REF.txt
@@ -1,2 +1,2 @@
-tag: v1.0.2
-commit: 3d0a914715293c9785013c5303d232f6d3c50f65
+tag: v1.0.3
+commit: aa2dd3f9ebd3ac3ffceb8873fb36378e6dc013ea

--- a/docs/lesser-host/contracts/openapi.yaml
+++ b/docs/lesser-host/contracts/openapi.yaml
@@ -99,6 +99,30 @@ components:
               type: string
               minLength: 1
               maxLength: 2048
+            status_code:
+              type: integer
+              minimum: 400
+              maximum: 599
+            details:
+              type: object
+              additionalProperties: true
+              description: Client-safe metadata for validation or state conflicts. Secrets, raw bearer tokens, and private signing material never appear here.
+              properties:
+                reason:
+                  type: string
+                  minLength: 1
+                  maxLength: 128
+                conversation_status:
+                  type: string
+                  enum: [unknown, pending, in_progress, completed, failed]
+                expected_status:
+                  type: string
+                  minLength: 1
+                  maxLength: 128
+                produced_declarations_present:
+                  type: boolean
+                produced_declarations_valid:
+                  type: boolean
             request_id:
               type: string
               minLength: 1
@@ -1983,7 +2007,11 @@ paths:
   /api/v1/soul/agents/register/{id}/mint-conversation/{conversationId}/complete:
     post:
       operationId: soulCompleteMintConversation
-      summary: Complete a registration-scoped mint conversation and persist declarations
+      summary: Complete or replay a registration-scoped mint conversation
+      description: |
+        Completes an active mint conversation and persists produced declarations. If the stored conversation is already
+        `completed` and has valid produced declarations, the route is idempotent and returns the completed conversation
+        without re-extracting or rewriting declarations. Other terminal states fail closed with conflict metadata.
       security:
         - sessionAuth: []
       parameters:
@@ -2881,10 +2909,13 @@ paths:
   /api/v1/soul/instance/agents/register/{id}/mint-conversation/{conversationId}/complete:
     post:
       operationId: soulInstanceCompleteRegistrationMintConversation
-      summary: Complete an instance-key registration mint conversation and persist declarations
+      summary: Complete or replay an instance-key registration mint conversation
       description: |
         Server-to-server route for managed Lesser instances. Completes a conversation inside the authenticated instance
-        boundary and persists the produced declarations for finalize preflight/finalize.
+        boundary and persists the produced declarations for finalize preflight/finalize. If the stored conversation is
+        already `completed` and has valid produced declarations, the route is idempotent and returns the completed
+        conversation without re-extracting or rewriting declarations. Failed conversations and completed conversations
+        without valid produced declarations fail closed with structured state details.
       security:
         - instanceKeyAuth: []
       parameters:
@@ -3178,7 +3209,11 @@ paths:
   /api/v1/soul/agents/{agentId}/mint-conversation/{conversationId}/complete:
     post:
       operationId: soulAgentCompleteMintConversation
-      summary: Complete an agent-scoped mint conversation and persist declarations
+      summary: Complete or replay an agent-scoped mint conversation
+      description: |
+        Completes an active mint conversation for a stable agent handle. If the stored conversation is already
+        `completed` and has valid produced declarations, the route is idempotent and returns the completed conversation
+        without re-extracting or rewriting declarations. Other terminal states fail closed with conflict metadata.
       security:
         - sessionAuth: []
       parameters:

--- a/docs/lesser-host/spec/v3/schemas/soul-instance-bootstrap.error.schema.json
+++ b/docs/lesser-host/spec/v3/schemas/soul-instance-bootstrap.error.schema.json
@@ -31,7 +31,11 @@
           "properties": {
             "boundary": { "type": "string", "enum": ["instance_domain"] },
             "field": { "type": "string", "minLength": 1, "maxLength": 128 },
-            "reason": { "type": "string", "minLength": 1, "maxLength": 128 }
+            "reason": { "type": "string", "minLength": 1, "maxLength": 128 },
+            "conversation_status": { "type": "string", "enum": ["unknown", "pending", "in_progress", "completed", "failed"] },
+            "expected_status": { "type": "string", "minLength": 1, "maxLength": 128 },
+            "produced_declarations_present": { "type": "boolean" },
+            "produced_declarations_valid": { "type": "boolean" }
           }
         },
         "request_id": { "type": "string", "minLength": 1, "maxLength": 128 }

--- a/packages/adapters/src/rest/generated/lesser-host-api.ts
+++ b/packages/adapters/src/rest/generated/lesser-host-api.ts
@@ -218,7 +218,12 @@ export interface paths {
         };
         get?: never;
         put?: never;
-        /** Complete a registration-scoped mint conversation and persist declarations */
+        /**
+         * Complete or replay a registration-scoped mint conversation
+         * @description Completes an active mint conversation and persists produced declarations. If the stored conversation is already
+         *     `completed` and has valid produced declarations, the route is idempotent and returns the completed conversation
+         *     without re-extracting or rewriting declarations. Other terminal states fail closed with conflict metadata.
+         */
         post: operations["soulCompleteMintConversation"];
         delete?: never;
         options?: never;
@@ -496,9 +501,12 @@ export interface paths {
         get?: never;
         put?: never;
         /**
-         * Complete an instance-key registration mint conversation and persist declarations
+         * Complete or replay an instance-key registration mint conversation
          * @description Server-to-server route for managed Lesser instances. Completes a conversation inside the authenticated instance
-         *     boundary and persists the produced declarations for finalize preflight/finalize.
+         *     boundary and persists the produced declarations for finalize preflight/finalize. If the stored conversation is
+         *     already `completed` and has valid produced declarations, the route is idempotent and returns the completed
+         *     conversation without re-extracting or rewriting declarations. Failed conversations and completed conversations
+         *     without valid produced declarations fail closed with structured state details.
          */
         post: operations["soulInstanceCompleteRegistrationMintConversation"];
         delete?: never;
@@ -580,7 +588,12 @@ export interface paths {
         };
         get?: never;
         put?: never;
-        /** Complete an agent-scoped mint conversation and persist declarations */
+        /**
+         * Complete or replay an agent-scoped mint conversation
+         * @description Completes an active mint conversation for a stable agent handle. If the stored conversation is already
+         *     `completed` and has valid produced declarations, the route is idempotent and returns the completed conversation
+         *     without re-extracting or rewriting declarations. Other terminal states fail closed with conflict metadata.
+         */
         post: operations["soulAgentCompleteMintConversation"];
         delete?: never;
         options?: never;
@@ -1081,6 +1094,18 @@ export interface components {
             error: {
                 code: string;
                 message: string;
+                status_code?: number;
+                /** @description Client-safe metadata for validation or state conflicts. Secrets, raw bearer tokens, and private signing material never appear here. */
+                details?: {
+                    reason?: string;
+                    /** @enum {string} */
+                    conversation_status?: "unknown" | "pending" | "in_progress" | "completed" | "failed";
+                    expected_status?: string;
+                    produced_declarations_present?: boolean;
+                    produced_declarations_valid?: boolean;
+                } & {
+                    [key: string]: unknown;
+                };
                 request_id?: string;
             };
         };
@@ -1954,6 +1979,11 @@ export interface components {
                     boundary?: "instance_domain";
                     field?: string;
                     reason?: string;
+                    /** @enum {string} */
+                    conversation_status?: "unknown" | "pending" | "in_progress" | "completed" | "failed";
+                    expected_status?: string;
+                    produced_declarations_present?: boolean;
+                    produced_declarations_valid?: boolean;
                 } & {
                     [key: string]: unknown;
                 };

--- a/registry/index.json
+++ b/registry/index.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://equalto.ai/schemas/registry-index.schema.json",
   "schemaVersion": "1.0.0",
-  "generatedAt": "2026-06-14T14:44:09.778Z",
+  "generatedAt": "2026-06-17T17:05:21.314Z",
   "ref": "greater-v0.10.6",
   "version": "0.10.6",
   "checksums": {
@@ -859,7 +859,7 @@
     "packages/adapters/src/models/unified.d.ts": "sha256-8Z2SFddm7Cszpe6EoB85lJVH0xW16xjo68PhJGuvmeQ=",
     "packages/adapters/src/models/unified.ts": "sha256-KRILzc/F51pCxnEX9cvc2IG7lns7IO48k/UK489J/Vs=",
     "packages/adapters/src/rest/generated/lesser-api.ts": "sha256-R4+G4pYedVrS/cEauHzryu+mjwduJMaU8/ME1wz2ago=",
-    "packages/adapters/src/rest/generated/lesser-host-api.ts": "sha256-l+4FR1nv9lFKXmlsxPFZHaXCmWAJZbCBn20ay6JvAxw=",
+    "packages/adapters/src/rest/generated/lesser-host-api.ts": "sha256-EDnz3Nx796uEitlzm4elc1Jv7hZdMJouDSt+VQly0hk=",
     "packages/adapters/src/soul/bootstrap.ts": "sha256-d463JIAlIQs5JE6eaewiGChBCqfQmIwXxhnGjWbWVIU=",
     "packages/adapters/src/soul/bootstrapSigningPlan.ts": "sha256-6fzPYUdPR9k/hQDuz9jmsPg8angSevxWctnopcx3+zE=",
     "packages/adapters/src/soul/client.ts": "sha256-AmLlG5YoBhg6PK0PXZe65Gl6GkFpJjBmFNbEt1A9Gnc=",
@@ -5807,8 +5807,8 @@
         },
         {
           "path": "src/rest/generated/lesser-host-api.ts",
-          "checksum": "sha256-l+4FR1nv9lFKXmlsxPFZHaXCmWAJZbCBn20ay6JvAxw=",
-          "size": 212560
+          "checksum": "sha256-EDnz3Nx796uEitlzm4elc1Jv7hZdMJouDSt+VQly0hk=",
+          "size": 214672
         },
         {
           "path": "src/soul/bootstrap.ts",


### PR DESCRIPTION
## Summary

- Sync pinned Lesser Host contracts from `v1.0.2` to released `lesser-host v1.0.3` (`aa2dd3f9ebd3ac3ffceb8873fb36378e6dc013ea`).
- Regenerate Greater's lesser-host REST OpenAPI types so `packages/adapters/src/rest/generated/lesser-host-api.ts` includes the new optional structured error metadata and updated mint-conversation complete route documentation.
- Regenerate `registry/index.json` so adapter source checksums match the changed file set.

## Contract-sync notes

- Change type: additive/semantic-refinement lesser-host contract sync.
- Lesser Host changes tracked here: optional `status_code`/`details` on error envelopes, conversation-state details on bootstrap errors, and idempotent completed+valid-declaration replay documentation for mint-conversation complete routes.
- Confirmed Lesser `v1.5.4` OpenAPI and GraphQL snapshots are byte-identical to Greater's current pinned Lesser snapshot; this PR intentionally leaves `docs/lesser/contracts/LESSER_REF.txt` unchanged to keep scope host-only.
- No UI behavior changes. No Sim changes. No deployment or release.
- This is **not required to unblock backend deployment for the Sim/Lesser GraphQL path**, but it **is required to keep Greater's lesser-host adapter current** with the released backend contract.

## Greater surface impact

- Component API impact: none.
- Theming token impact: none.
- Accessibility impact: none.
- Registry/generated artifact impact: `registry/index.json` regenerated; strict registry checksum validation passed.
- Mastodon/Fediverse compatibility: unchanged; this is Lesser Host adapter-only.
- AGPL/dependency impact: none; no dependency changes.
- Changeset: not added; repo guidance says changesets are optional and this PR is generated contract-sync only.

## Validation

- `corepack pnpm generate:openapi:lesser-host` ✅
- `corepack pnpm generate-registry` ✅
- `corepack pnpm --filter @equaltoai/greater-components-adapters typecheck` ✅
- `corepack pnpm --filter @equaltoai/greater-components-adapters test` ✅ — 34 files passed; 567 passed / 6 skipped
- `corepack pnpm check` ✅
- `corepack pnpm test` ✅ — all workspace package tests passed (existing warnings only)
- `corepack pnpm generate-registry:validate` ✅
- `corepack pnpm validate:registry` ✅ — 1444 checksums verified
- `git diff --check origin/staging...HEAD` ✅

## Promotion rehearsal

Synthetic merge rehearsal completed cleanly:

- `candidate -> staging`: clean (`8ad1f9dc` synthetic merge)
- `staging -> premain`: clean (`8048d837` synthetic merge)
- `staging -> main`: clean (`cfb3c22b` synthetic merge)
- `premain -> main`: clean (`a676d839` synthetic merge)

No hosted/off-chain publish gate weakening. This PR is contract-sync only.