### PR TITLE
fix: fail closed on hosted checkpoint list drift

### DIFF
--- a/packages/adapters/src/__tests__/HostedSoulBootstrapClient.test.ts
+++ b/packages/adapters/src/__tests__/HostedSoulBootstrapClient.test.ts
@@ -57,6 +57,8 @@ const disallowedHostedConfigHeaderNames = [
 	'x-instance-key',
 ] as const;
 
+const missingRuntimeSigningCheckpoints = Symbol('missingRuntimeSigningCheckpoints');
+
 function jsonResponse(body: unknown, status = 200): Response {
 	return new Response(JSON.stringify(body), {
 		status,
@@ -159,6 +161,22 @@ function createHostedPublishSurface(
 		principalAddress: null,
 		signingCheckpoints,
 	});
+}
+
+function createHostedPublishSurfaceWithRuntimeSigningCheckpoints(
+	signingCheckpoints: unknown
+): SoulBootstrapSurface {
+	const surface = createHostedPublishSurface();
+	const runtimeState = { ...surface.state } as Record<string, unknown>;
+	if (signingCheckpoints === missingRuntimeSigningCheckpoints) {
+		delete runtimeState['signingCheckpoints'];
+	} else {
+		runtimeState['signingCheckpoints'] = signingCheckpoints;
+	}
+	return {
+		...surface,
+		state: runtimeState,
+	} as SoulBootstrapSurface;
 }
 
 describe('HostedSoulBootstrapClient', () => {
@@ -272,6 +290,18 @@ describe('HostedSoulBootstrapClient', () => {
 				canonicalJson: '{"selfDescription":{"summary":"ready"},"capabilities":[]}',
 			},
 		]);
+		const malformedDeclarationJson = createHostedPublishSurface([
+			{
+				...completedCheckpoint,
+				canonicalJson: '{not-json',
+			},
+		]);
+		const missingDeclarationJson = createHostedPublishSurface([
+			{
+				...completedCheckpoint,
+				canonicalJson: null,
+			},
+		]);
 		const legacyConversationCheckpoint = createHostedPublishSurface([
 			{
 				...completedCheckpoint,
@@ -287,6 +317,10 @@ describe('HostedSoulBootstrapClient', () => {
 		expect(isHostedSoulBootstrapPublishReady(publishActionWithoutEvidence)).toBe(false);
 		expect(getHostedSoulBootstrapTerminalDeclarationEvidence(invalidDeclaration)).toBeNull();
 		expect(isHostedSoulBootstrapPublishReady(invalidDeclaration)).toBe(false);
+		expect(getHostedSoulBootstrapTerminalDeclarationEvidence(malformedDeclarationJson)).toBeNull();
+		expect(isHostedSoulBootstrapPublishReady(malformedDeclarationJson)).toBe(false);
+		expect(getHostedSoulBootstrapTerminalDeclarationEvidence(missingDeclarationJson)).toBeNull();
+		expect(isHostedSoulBootstrapPublishReady(missingDeclarationJson)).toBe(false);
 		expect(
 			getHostedSoulBootstrapTerminalDeclarationEvidence(
 				project44SoulBootstrapFixtures.hostedGenesisComplete,
@@ -301,6 +335,65 @@ describe('HostedSoulBootstrapClient', () => {
 		expect(
 			isHostedSoulBootstrapPublishReady(project44SoulBootstrapFixtures.hostedGenesisComplete)
 		).toBe(true);
+	});
+
+	it('fails closed for runtime-null, missing, or malformed signing checkpoint lists', () => {
+		const runtimeListCases: Array<[string, SoulBootstrapSurface]> = [
+			['null', createHostedPublishSurfaceWithRuntimeSigningCheckpoints(null)],
+			[
+				'missing',
+				createHostedPublishSurfaceWithRuntimeSigningCheckpoints(missingRuntimeSigningCheckpoints),
+			],
+			[
+				'object',
+				createHostedPublishSurfaceWithRuntimeSigningCheckpoints({
+					0: project44SoulBootstrapSigning.hostedConversation,
+					length: 1,
+				}),
+			],
+			['string', createHostedPublishSurfaceWithRuntimeSigningCheckpoints('not-a-list')],
+			[
+				'array with malformed entries',
+				createHostedPublishSurfaceWithRuntimeSigningCheckpoints([
+					null,
+					'not-a-checkpoint',
+					{
+						name: 'hosted_conversation',
+						status: 'completed',
+						canonicalJson: project44SoulBootstrapSigning.hostedConversation.canonicalJson,
+					},
+				]),
+			],
+		];
+
+		for (const [caseName, surface] of runtimeListCases) {
+			expect(
+				() =>
+					getHostedSoulBootstrapTerminalDeclarationEvidence(surface, {
+						conversationId: project44SoulBootstrapIds.conversationId,
+					}),
+				caseName
+			).not.toThrow();
+			expect(
+				getHostedSoulBootstrapTerminalDeclarationEvidence(surface, {
+					conversationId: project44SoulBootstrapIds.conversationId,
+				}),
+				caseName
+			).toBeNull();
+			expect(
+				() =>
+					isHostedSoulBootstrapPublishReady(surface, {
+						conversationId: project44SoulBootstrapIds.conversationId,
+					}),
+				caseName
+			).not.toThrow();
+			expect(
+				isHostedSoulBootstrapPublishReady(surface, {
+					conversationId: project44SoulBootstrapIds.conversationId,
+				}),
+				caseName
+			).toBe(false);
+		}
 	});
 
 	it('exposes typed restart-required recovery and restart metadata', async () => {

--- a/packages/adapters/src/soul/hostedBootstrap.ts
+++ b/packages/adapters/src/soul/hostedBootstrap.ts
@@ -186,6 +186,8 @@ export type HostedSoulBootstrapTerminalDeclarationEvidenceSource =
 	| null
 	| undefined;
 
+type RuntimeHostedSoulBootstrapState = HostedSoulBootstrapState & Record<string, unknown>;
+
 export interface HostedSoulBootstrapTerminalDeclarationEvidenceOptions {
 	/**
 	 * Optional conversation id the publish action is about to submit. When present, evidence is
@@ -286,14 +288,14 @@ export function getHostedSoulBootstrapTerminalDeclarationEvidence(
 		return null;
 	}
 
-	for (const checkpoint of state.signingCheckpoints) {
-		const checkpointName = normalizeTerminalDeclarationCheckpointName(checkpoint.name);
-		if (!checkpointName || !isCompletedTerminalDeclarationStatus(checkpoint.status)) {
+	for (const checkpoint of normalizeTerminalDeclarationSigningCheckpoints(state)) {
+		const checkpointName = normalizeTerminalDeclarationCheckpointName(checkpoint['name']);
+		if (!checkpointName || !isCompletedTerminalDeclarationStatus(checkpoint['status'])) {
 			continue;
 		}
 
-		const canonicalDeclarationJson = trimToValue(checkpoint.canonicalJson);
-		const hostRequestId = trimToValue(checkpoint.hostRequestId);
+		const canonicalDeclarationJson = trimToValue(checkpoint['canonicalJson']);
+		const hostRequestId = trimToValue(checkpoint['hostRequestId']);
 		const declaration = canonicalDeclarationJson
 			? parseHostedTerminalDeclaration(canonicalDeclarationJson)
 			: null;
@@ -309,7 +311,7 @@ export function getHostedSoulBootstrapTerminalDeclarationEvidence(
 			hostRequestId,
 			hostRegistrationId,
 			hostConversationId,
-			completedAt: trimToValue(checkpoint.completedAt),
+			completedAt: trimToValue(checkpoint['completedAt']),
 		};
 	}
 
@@ -540,7 +542,7 @@ function createHostRequestMetadata(
 
 function resolveTerminalDeclarationState(
 	source: HostedSoulBootstrapTerminalDeclarationEvidenceSource
-): HostedSoulBootstrapState | null {
+): RuntimeHostedSoulBootstrapState | null {
 	if (isHostedSoulBootstrapStateCandidate(source)) {
 		return source;
 	}
@@ -560,7 +562,7 @@ function resolveTerminalDeclarationState(
 
 function resolveTerminalDeclarationNextAction(
 	source: HostedSoulBootstrapTerminalDeclarationEvidenceSource,
-	state: HostedSoulBootstrapState
+	state: RuntimeHostedSoulBootstrapState
 ): SoulBootstrapNextAction | null {
 	if (isObjectRecord(source)) {
 		const record = source as Record<string, unknown>;
@@ -572,20 +574,31 @@ function resolveTerminalDeclarationNextAction(
 			return sourceState['typedNextAction'] as SoulBootstrapNextAction;
 		}
 	}
-	return state.typedNextAction ?? null;
+	return typeof state.typedNextAction === 'string' ? state.typedNextAction : null;
 }
 
-function isHostedSoulBootstrapStateCandidate(value: unknown): value is HostedSoulBootstrapState {
-	return (
-		isObjectRecord(value) &&
-		typeof value['bootstrapMode'] === 'string' &&
-		Array.isArray(value['signingCheckpoints'])
-	);
+function isHostedSoulBootstrapStateCandidate(
+	value: unknown
+): value is RuntimeHostedSoulBootstrapState {
+	return isObjectRecord(value) && typeof value['bootstrapMode'] === 'string';
+}
+
+function normalizeTerminalDeclarationSigningCheckpoints(
+	state: RuntimeHostedSoulBootstrapState
+): readonly Record<string, unknown>[] {
+	const signingCheckpoints = state['signingCheckpoints'];
+	if (!Array.isArray(signingCheckpoints)) {
+		return [];
+	}
+	return signingCheckpoints.filter(isObjectRecord);
 }
 
 function normalizeTerminalDeclarationCheckpointName(
-	name: string
+	name: unknown
 ): HostedSoulBootstrapTerminalDeclarationCheckpointName | null {
+	if (typeof name !== 'string') {
+		return null;
+	}
 	const normalized = name.trim().toLowerCase();
 	if (normalized === 'hosted_conversation' || normalized === 'conversation') {
 		return normalized;
@@ -593,7 +606,10 @@ function normalizeTerminalDeclarationCheckpointName(
 	return null;
 }
 
-function isCompletedTerminalDeclarationStatus(status: string): boolean {
+function isCompletedTerminalDeclarationStatus(status: unknown): boolean {
+	if (typeof status !== 'string') {
+		return false;
+	}
 	return status.trim().toLowerCase() === 'completed';
 }
 

--- a/registry/index.json
+++ b/registry/index.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://equalto.ai/schemas/registry-index.schema.json",
   "schemaVersion": "1.0.0",
-  "generatedAt": "2026-06-17T17:44:12.178Z",
+  "generatedAt": "2026-06-18T03:39:04.974Z",
   "ref": "greater-v0.10.7",
   "version": "0.10.7",
   "checksums": {
@@ -864,7 +864,7 @@
     "packages/adapters/src/soul/bootstrapSigningPlan.ts": "sha256-6fzPYUdPR9k/hQDuz9jmsPg8angSevxWctnopcx3+zE=",
     "packages/adapters/src/soul/client.ts": "sha256-AmLlG5YoBhg6PK0PXZe65Gl6GkFpJjBmFNbEt1A9Gnc=",
     "packages/adapters/src/soul/ens.ts": "sha256-CI8WkwLMw8ZXNPrN+LpQdK81vud8ecgQc3xOXFMvK2o=",
-    "packages/adapters/src/soul/hostedBootstrap.ts": "sha256-RBcwE0+XA40Y7Wz03CbTctJ691jUVIv63FLiVcAcLwQ=",
+    "packages/adapters/src/soul/hostedBootstrap.ts": "sha256-bd3pPfP+XUipoWQSekWjj4s/AcjrNH5UcXTQU9isWQA=",
     "packages/adapters/src/soul/index.ts": "sha256-fYiH2yu+rg4rLG3di36TLlScHqliKneS2SZtIZGCVa0=",
     "packages/adapters/src/SseClient.d.ts": "sha256-fxMEJHoDY/ae3mkTtv9yw5N1jfD5wLSrJ4ixrJ+TYoU=",
     "packages/adapters/src/SseClient.ts": "sha256-XJ1v33MnEkm1CRobboaQ0hOpTvFjDOkd1GX6UocQ2Q4=",
@@ -5832,8 +5832,8 @@
         },
         {
           "path": "src/soul/hostedBootstrap.ts",
-          "checksum": "sha256-RBcwE0+XA40Y7Wz03CbTctJ691jUVIv63FLiVcAcLwQ=",
-          "size": 28587
+          "checksum": "sha256-bd3pPfP+XUipoWQSekWjj4s/AcjrNH5UcXTQU9isWQA=",
+          "size": 29147
         },
         {
           "path": "src/soul/index.ts",


### PR DESCRIPTION
## Milestone

Project 44 M9.2 — Greater contract conformance for hosted bootstrap runtime nullability.

## Classification

Adapter contract-conformance bug fix (hosted bootstrap helpers).

## Summary

- Normalizes `state.signingCheckpoints` at the terminal-evidence helper boundary before iteration.
- Fails closed for runtime-null, missing, non-array, and malformed checkpoint-list values.
- Keeps hosted publish readiness blocked unless terminal declaration evidence includes valid canonical declaration JSON and a Host request id.
- Adds regression tests for runtime-null/missing/malformed list cases and invalid/missing canonical declaration JSON.

## Project 44 contract impact

- Does this change Host route semantics? no.
- Does this change Lesser GraphQL schema? no.
- Does this change Lesser state/recovery semantics? no.
- Does this change Greater adapter behavior? yes — hosted terminal-evidence helpers now normalize runtime list drift and fail closed rather than relying on generated non-null array assumptions.
- Does this change Sim action mapping or messaging? no.
- Which golden fixtures were updated or asserted unchanged? Greater-side hosted terminal declaration/publish-readiness fixtures are asserted unchanged; new runtime-null/missing/malformed `signingCheckpoints` fixtures assert fail-closed behavior.
- Which cross-repo contract tests cover it? Greater adapter Vitest coverage in `HostedSoulBootstrapClient.test.ts`; Sim should consume after Greater release/update and keep publish blocked without terminal evidence.

## Contract-sync audit

- Change type: adapter-only runtime normalization against existing pinned contracts; no snapshot regeneration required.
- Lesser pin: `docs/lesser/contracts/LESSER_REF.txt` is already `v1.5.3` at `1a9888ebf2ce93764240dee2189a221830b50521`.
- Lesser Host pin: `docs/lesser-host/contracts/LESSER_HOST_REF.txt` is `v1.0.3` at `aa2dd3f9ebd3ac3ffceb8873fb36378e6dc013ea`, which supersedes the assignment's v1.0.2 floor. No downgrade/regeneration needed.
- Generated artifacts / registry: no contract snapshots or generated adapter files changed; `generate-registry:validate` passed.

## Surfaces affected

- `packages/adapters/src/soul/hostedBootstrap.ts`
- `packages/adapters/src/__tests__/HostedSoulBootstrapClient.test.ts`

## Component/API/theming/accessibility impact

- Component API/theming: none.
- Accessibility: none (non-UI adapter helper change).
- Registry integrity: registry validation passed; no hand-edited registry artifacts.
- Mastodon/Fediverse compatibility: unaffected.
- AGPL/dependency impact: no dependency changes.

## Semver / changeset

- Semver: patch-level adapter behavior hardening.
- Changeset: not added; repo-local AGENTS.md says changesets are optional for staging PRs unless explicitly desired.

## Validation

- `node --version` → `v24.15.0`
- `corepack pnpm exec eslint packages/adapters/src/soul/hostedBootstrap.ts packages/adapters/src/__tests__/HostedSoulBootstrapClient.test.ts` → passed
- `corepack pnpm --filter @equaltoai/greater-components-adapters test` → passed (34 files, 568 passed, 6 skipped)
- `corepack pnpm --filter @equaltoai/greater-components-adapters typecheck` → passed
- `corepack pnpm generate-registry:validate` → passed

## Release-flow / Sim follow-up

Target is `staging`. After merge and normal Greater release promotion, Sim should update/consume the released Greater adapter and verify its Project 44 hosted publish gate remains blocked when terminal declaration evidence is absent or malformed.