### PR TITLE
Promote staging→main: align Manual Release workflow with canonical lesser/host/body release.yml

### DIFF
--- a/.github/workflows/manual-release.yml
+++ b/.github/workflows/manual-release.yml
@@ -6,8 +6,8 @@ on:
       - 'greater-v*'
   workflow_dispatch:
     inputs:
-      tag_name:
-        description: 'Existing signed release tag to publish (greater-vX.Y.Z)'
+      version:
+        description: 'Release version tag (example: greater-v1.2.3)'
         required: true
         type: string
 
@@ -17,58 +17,70 @@ permissions:
 jobs:
   publish:
     name: Publish immutable release assets
+    # Prevent duplicate releases when a workflow_dispatch run creates + pushes a tag.
+    if: ${{ github.event_name != 'push' || github.actor != 'github-actions[bot]' }}
     runs-on: ubuntu-latest
+    env:
+      RELEASE_VERSION: ${{ github.event_name == 'workflow_dispatch' && inputs.version || github.ref_name }}
 
     steps:
-      - name: Resolve release tag
-        id: release
-        env:
-          EVENT_NAME: ${{ github.event_name }}
-          REF: ${{ github.ref }}
-          REF_NAME: ${{ github.ref_name }}
-          DISPATCH_TAG: ${{ inputs.tag_name }}
-        run: |
-          set -euo pipefail
-
-          if [[ "${EVENT_NAME}" == "workflow_dispatch" ]]; then
-            if [[ "${REF}" != "refs/heads/main" ]]; then
-              echo "::error::Manual release dispatch must be run from the main branch."
-              exit 1
-            fi
-            tag_name="${DISPATCH_TAG}"
-          else
-            tag_name="${REF_NAME}"
-          fi
-
-          if [[ ! "${tag_name}" =~ ^greater-v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
-            echo "::error::Release tag must match greater-vX.Y.Z: ${tag_name}"
-            exit 1
-          fi
-
-          echo "tag_name=${tag_name}" >> "${GITHUB_OUTPUT}"
-
-      - name: Checkout release tag
+      - name: Checkout
         uses: actions/checkout@v5
         with:
           fetch-depth: 0
-          ref: ${{ steps.release.outputs.tag_name }}
 
-      - name: Assert tag is anchored on main
-        env:
-          TAG_NAME: ${{ steps.release.outputs.tag_name }}
+      - name: Validate release version
         run: |
           set -euo pipefail
-          git fetch origin main --force --tags
 
-          tag_commit="$(git rev-list -n 1 "${TAG_NAME}")"
+          if [[ ! "${RELEASE_VERSION}" =~ ^greater-v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "::error::Release tag must match greater-vX.Y.Z: ${RELEASE_VERSION}"
+            exit 1
+          fi
+
+      - name: Create and push tag (workflow_dispatch)
+        if: ${{ github.event_name == 'workflow_dispatch' }}
+        run: |
+          set -euo pipefail
+
+          if [[ "${GITHUB_REF_NAME}" != "main" ]]; then
+            echo "workflow_dispatch releases must be run from the main branch (got '${GITHUB_REF_NAME}')" >&2
+            exit 1
+          fi
+          if [[ ! "${RELEASE_VERSION}" =~ ^greater-v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "release version must match 'greater-vX.Y.Z' (example: greater-v1.2.3); got '${RELEASE_VERSION}'" >&2
+            exit 1
+          fi
+
+          git fetch --tags --force
+          if git rev-parse -q --verify "refs/tags/${RELEASE_VERSION}" >/dev/null; then
+            existing_sha="$(git rev-list -n 1 "${RELEASE_VERSION}")"
+            if [[ "${existing_sha}" != "${GITHUB_SHA}" ]]; then
+              echo "tag '${RELEASE_VERSION}' already exists at ${existing_sha}; refusing to retag ${GITHUB_SHA}" >&2
+              exit 1
+            fi
+            echo "tag '${RELEASE_VERSION}' already exists at ${existing_sha}"
+            exit 0
+          fi
+
+          git tag "${RELEASE_VERSION}" "${GITHUB_SHA}"
+          git push origin "refs/tags/${RELEASE_VERSION}"
+
+      - name: Assert tag is anchored on main
+        run: |
+          set -euo pipefail
+          git fetch --no-tags origin "+refs/heads/main:refs/remotes/origin/main"
+          git fetch --tags --force origin "refs/tags/${RELEASE_VERSION}:refs/tags/${RELEASE_VERSION}" || git fetch --tags --force origin
+
+          tag_commit="$(git rev-list -n 1 "${RELEASE_VERSION}")"
           head_commit="$(git rev-parse HEAD)"
           if [[ "${tag_commit}" != "${head_commit}" ]]; then
-            echo "::error::Checked-out HEAD (${head_commit}) does not match ${TAG_NAME} (${tag_commit})."
+            echo "::error::Checked-out HEAD (${head_commit}) does not match ${RELEASE_VERSION} (${tag_commit})."
             exit 1
           fi
 
           if ! git merge-base --is-ancestor "${tag_commit}" origin/main; then
-            echo "::error::${TAG_NAME} must point to a commit reachable from origin/main."
+            echo "::error::${RELEASE_VERSION} must point to a commit reachable from origin/main."
             exit 1
           fi
 
@@ -90,7 +102,7 @@ jobs:
 
       - name: Verify release tag and registry metadata
         env:
-          TAG_NAME: ${{ steps.release.outputs.tag_name }}
+          TAG_NAME: ${{ env.RELEASE_VERSION }}
         run: |
           set -euo pipefail
           version="$(node -p "require('./package.json').version")"
@@ -103,7 +115,7 @@ jobs:
       - name: Create draft release if needed
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          TAG_NAME: ${{ steps.release.outputs.tag_name }}
+          TAG_NAME: ${{ env.RELEASE_VERSION }}
         run: |
           set -euo pipefail
           if ! gh release view "${TAG_NAME}" >/dev/null 2>&1; then
@@ -119,7 +131,7 @@ jobs:
       - name: Upload release assets
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          TAG_NAME: ${{ steps.release.outputs.tag_name }}
+          TAG_NAME: ${{ env.RELEASE_VERSION }}
         run: |
           set -euo pipefail
           mapfile -t existing_assets < <(gh release view "${TAG_NAME}" --json assets --jq '.assets[].name' 2>/dev/null || true)
@@ -144,7 +156,7 @@ jobs:
       - name: Publish release
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          TAG_NAME: ${{ steps.release.outputs.tag_name }}
+          TAG_NAME: ${{ env.RELEASE_VERSION }}
         run: |
           set -euo pipefail
           gh release edit "${TAG_NAME}" --draft=false


### PR DESCRIPTION
Staging→main promotion (operator-merged).

Promotes the greater **Manual Release workflow fix** (#847) to main so the canonical release process is available on main.

Fixes the divergence that broke the manual release:
- `workflow_dispatch` now takes a **`version`** input and **creates + pushes the `greater-vX.Y.Z` tag** at the main SHA (was: required a pre-existing tag and checked it out → failed).
- Added the duplicate-run guard + main-branch + ancestry assertions, matching lesser/host/body `release.yml`.
- Preserved greater specifics: `greater-v*` prefix, `pnpm release:artifacts`, registry + immutable draft→publish.

**After merge, to cut the release:** run **Manual Release** from `main` with `version=greater-vX.Y.Z` — no pre-created tag needed.

Note: greater's default branch is still `staging` (others are `main`); optional repo-admin change to default→main for dispatch parity. Prepared by factory; merge to main + release are operator-owned.