### PR TITLE
Promote staging→main: greater v0.11.0 release version bump (P49 M4)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "greater-components",
-  "version": "0.10.8",
+  "version": "0.11.0",
   "private": true,
   "description": "Fediverse UI components built with Svelte 5, TypeScript, and pnpm workspaces",
   "repository": {

--- a/packages/adapters/package.json
+++ b/packages/adapters/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@equaltoai/greater-components-adapters",
   "private": true,
-  "version": "0.10.8",
+  "version": "0.11.0",
   "type": "module",
   "description": "Transport adapters and state management for Greater Components",
   "license": "AGPL-3.0-only",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@equaltoai/greater-components-cli",
   "private": true,
-  "version": "0.10.8",
+  "version": "0.11.0",
   "description": "CLI for adding Greater Components to your project",
   "type": "module",
   "bin": {

--- a/packages/content/package.json
+++ b/packages/content/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@equaltoai/greater-components-content",
-  "version": "0.10.8",
+  "version": "0.11.0",
   "type": "module",
   "description": "Content rendering components (CodeBlock, MarkdownRenderer) for Greater Components",
   "license": "AGPL-3.0-only",

--- a/packages/faces/agent/manifest.json
+++ b/packages/faces/agent/manifest.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../../../schemas/module-manifest.schema.json",
   "name": "@equaltoai/greater-components-agent-face",
-  "version": "0.10.8",
+  "version": "0.11.0",
   "description": "Agent-first face compositions and route-shell boundaries for Greater Components.",
   "components": {
     "AgentGenesisWorkspace": {

--- a/packages/faces/agent/package.json
+++ b/packages/faces/agent/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@equaltoai/greater-components-agent-face",
-  "version": "0.10.8",
+  "version": "0.11.0",
   "type": "module",
   "description": "Agent-first face compositions and route-shell boundaries for Greater Components",
   "license": "AGPL-3.0-only",

--- a/packages/faces/artist/manifest.json
+++ b/packages/faces/artist/manifest.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../../../schemas/module-manifest.schema.json",
   "name": "@equaltoai/greater-components-artist",
-  "version": "0.10.8",
+  "version": "0.11.0",
   "description": "Artist portfolio and gallery UI components for visual artists and creative professionals",
   "components": {
     "Artwork": {

--- a/packages/faces/artist/package.json
+++ b/packages/faces/artist/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@equaltoai/greater-components-artist",
   "private": true,
-  "version": "0.10.8",
+  "version": "0.11.0",
   "type": "module",
   "description": "Artist portfolio and gallery UI components for Greater Components",
   "license": "AGPL-3.0-only",

--- a/packages/faces/blog/manifest.json
+++ b/packages/faces/blog/manifest.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../../../schemas/module-manifest.schema.json",
   "name": "@equaltoai/greater-components-blog",
-  "version": "0.10.8",
+  "version": "0.11.0",
   "description": "Blog/Medium-style UI components for long-form publishing applications",
   "components": {
     "Article": {

--- a/packages/faces/blog/package.json
+++ b/packages/faces/blog/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@equaltoai/greater-components-blog",
   "private": true,
-  "version": "0.10.8",
+  "version": "0.11.0",
   "type": "module",
   "description": "Blog/Medium-style UI components for Greater Components",
   "license": "AGPL-3.0-only",

--- a/packages/faces/community/manifest.json
+++ b/packages/faces/community/manifest.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../../../schemas/module-manifest.schema.json",
   "name": "@equaltoai/greater-components-community",
-  "version": "0.10.8",
+  "version": "0.11.0",
   "description": "Community/Reddit-style UI components for forum-based discussion applications",
   "components": {
     "Community": {

--- a/packages/faces/community/package.json
+++ b/packages/faces/community/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@equaltoai/greater-components-community",
   "private": true,
-  "version": "0.10.8",
+  "version": "0.11.0",
   "type": "module",
   "description": "Community/Reddit-style UI components for Greater Components",
   "license": "AGPL-3.0-only",

--- a/packages/faces/social/manifest.json
+++ b/packages/faces/social/manifest.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../../../schemas/module-manifest.schema.json",
   "name": "@equaltoai/greater-components-social",
-  "version": "0.10.8",
+  "version": "0.11.0",
   "description": "Social/Twitter-style UI components for ActivityPub/Fediverse applications",
   "components": {
     "Status": {

--- a/packages/faces/social/package.json
+++ b/packages/faces/social/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@equaltoai/greater-components-social",
   "private": true,
-  "version": "0.10.8",
+  "version": "0.11.0",
   "type": "module",
   "description": "Social/Twitter-style UI components for Greater Components (formerly fediverse)",
   "license": "AGPL-3.0-only",

--- a/packages/greater-components/package.json
+++ b/packages/greater-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@equaltoai/greater-components",
-  "version": "0.10.8",
+  "version": "0.11.0",
   "type": "module",
   "description": "Aggregate Greater Components library for EqualToAI",
   "license": "AGPL-3.0-only",

--- a/packages/headless/package.json
+++ b/packages/headless/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@equaltoai/greater-components-headless",
   "private": true,
-  "version": "0.10.8",
+  "version": "0.11.0",
   "type": "module",
   "description": "Headless UI primitives for Greater Components - behavior without styling",
   "license": "AGPL-3.0-only",

--- a/packages/host-platform/package.json
+++ b/packages/host-platform/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@equaltoai/greater-components-host-platform",
-  "version": "0.10.8",
+  "version": "0.11.0",
   "type": "module",
   "description": "Hosted-platform data-display components for Greater Components (FleetCard, CostGauge, ActivitySparkline)",
   "license": "AGPL-3.0-only",

--- a/packages/icons/package.json
+++ b/packages/icons/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@equaltoai/greater-components-icons",
   "private": true,
-  "version": "0.10.8",
+  "version": "0.11.0",
   "type": "module",
   "description": "Icon components for Greater Components",
   "license": "AGPL-3.0-only",

--- a/packages/primitives/package.json
+++ b/packages/primitives/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@equaltoai/greater-components-primitives",
-  "version": "0.10.8",
+  "version": "0.11.0",
   "type": "module",
   "description": "Primitive UI components for Greater Components",
   "license": "AGPL-3.0-only",

--- a/packages/shared/admin/manifest.json
+++ b/packages/shared/admin/manifest.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../../../schemas/module-manifest.schema.json",
   "name": "@equaltoai/greater-components-admin",
-  "version": "0.10.8",
+  "version": "0.11.0",
   "description": "Admin dashboard components for ActivityPub instance management",
   "components": {
     "Root": {

--- a/packages/shared/admin/package.json
+++ b/packages/shared/admin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@equaltoai/greater-components-admin",
-  "version": "0.10.8",
+  "version": "0.11.0",
   "type": "module",
   "description": "Admin dashboard components for Greater Components",
   "license": "AGPL-3.0-only",

--- a/packages/shared/agent/manifest.json
+++ b/packages/shared/agent/manifest.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../../../schemas/module-manifest.schema.json",
   "name": "@equaltoai/greater-components-agent",
-  "version": "0.10.8",
+  "version": "0.11.0",
   "description": "Agent-first workflow surfaces, contracts, package boundaries, and rollout shape metadata for Greater Components.",
   "components": {
     "AgentIdentityCard": {

--- a/packages/shared/agent/package.json
+++ b/packages/shared/agent/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@equaltoai/greater-components-agent",
-  "version": "0.10.8",
+  "version": "0.11.0",
   "type": "module",
   "description": "Agent-first workflow surfaces, contracts, boundary metadata, and rollout shape for Greater Components",
   "license": "AGPL-3.0-only",

--- a/packages/shared/auth/manifest.json
+++ b/packages/shared/auth/manifest.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../../../schemas/module-manifest.schema.json",
   "name": "@equaltoai/greater-components-auth",
-  "version": "0.10.8",
+  "version": "0.11.0",
   "description": "Authentication components for ActivityPub/Fediverse applications",
   "components": {
     "Root": {

--- a/packages/shared/auth/package.json
+++ b/packages/shared/auth/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@equaltoai/greater-components-auth",
-  "version": "0.10.8",
+  "version": "0.11.0",
   "type": "module",
   "description": "Authentication components for Greater Components",
   "license": "AGPL-3.0-only",

--- a/packages/shared/chat/manifest.json
+++ b/packages/shared/chat/manifest.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../../../schemas/module-manifest.schema.json",
   "name": "@equaltoai/greater-components-chat",
-  "version": "0.10.8",
+  "version": "0.11.0",
   "description": "AI chat interface components with streaming responses, tool calls, and settings",
   "components": {
     "Container": {

--- a/packages/shared/chat/package.json
+++ b/packages/shared/chat/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@equaltoai/greater-components-chat",
-  "version": "0.10.8",
+  "version": "0.11.0",
   "type": "module",
   "description": "AI chat interface components for Greater Components",
   "license": "AGPL-3.0-only",

--- a/packages/shared/compose/manifest.json
+++ b/packages/shared/compose/manifest.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../../../schemas/module-manifest.schema.json",
   "name": "@equaltoai/greater-components-compose",
-  "version": "0.10.8",
+  "version": "0.11.0",
   "description": "Post/content composer components for ActivityPub/Fediverse applications",
   "components": {
     "Root": {

--- a/packages/shared/compose/package.json
+++ b/packages/shared/compose/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@equaltoai/greater-components-compose",
-  "version": "0.10.8",
+  "version": "0.11.0",
   "type": "module",
   "description": "Post/content composer components for Greater Components",
   "license": "AGPL-3.0-only",

--- a/packages/shared/messaging/manifest.json
+++ b/packages/shared/messaging/manifest.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../../../schemas/module-manifest.schema.json",
   "name": "@equaltoai/greater-components-messaging",
-  "version": "0.10.8",
+  "version": "0.11.0",
   "description": "Direct messaging components for ActivityPub/Fediverse applications",
   "components": {
     "Root": {

--- a/packages/shared/messaging/package.json
+++ b/packages/shared/messaging/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@equaltoai/greater-components-messaging",
-  "version": "0.10.8",
+  "version": "0.11.0",
   "type": "module",
   "description": "Direct messaging components for Greater Components",
   "license": "AGPL-3.0-only",

--- a/packages/shared/notifications/manifest.json
+++ b/packages/shared/notifications/manifest.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../../../schemas/module-manifest.schema.json",
   "name": "@equaltoai/greater-components-notifications",
-  "version": "0.10.8",
+  "version": "0.11.0",
   "description": "Notification components for ActivityPub/Fediverse applications",
   "components": {
     "Root": {

--- a/packages/shared/notifications/package.json
+++ b/packages/shared/notifications/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@equaltoai/greater-components-notifications",
-  "version": "0.10.8",
+  "version": "0.11.0",
   "type": "module",
   "description": "Notification components for Greater Components",
   "license": "AGPL-3.0-only",

--- a/packages/shared/search/manifest.json
+++ b/packages/shared/search/manifest.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../../../schemas/module-manifest.schema.json",
   "name": "@equaltoai/greater-components-search",
-  "version": "0.10.8",
+  "version": "0.11.0",
   "description": "Search components for ActivityPub/Fediverse applications with federated search support",
   "components": {
     "Root": {

--- a/packages/shared/search/package.json
+++ b/packages/shared/search/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@equaltoai/greater-components-search",
-  "version": "0.10.8",
+  "version": "0.11.0",
   "type": "module",
   "description": "Search components for Greater Components",
   "license": "AGPL-3.0-only",

--- a/packages/shared/soul/manifest.json
+++ b/packages/shared/soul/manifest.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../../../schemas/module-manifest.schema.json",
   "name": "@equaltoai/greater-components-soul",
-  "version": "0.10.8",
+  "version": "0.11.0",
   "description": "Reachability, contact-preferences, and anchor-assurance UI for lesser-soul v3.",
   "components": {
     "ChannelsDisplay": {

--- a/packages/shared/soul/package.json
+++ b/packages/shared/soul/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@equaltoai/greater-components-soul",
-  "version": "0.10.8",
+  "version": "0.11.0",
   "type": "module",
   "description": "Reachability and contact-preferences components for lesser-soul v3",
   "license": "AGPL-3.0-only",

--- a/packages/shell/package.json
+++ b/packages/shell/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@equaltoai/greater-components-shell",
-  "version": "0.10.8",
+  "version": "0.11.0",
   "type": "module",
   "description": "App shell layout components for Greater Components (Shell, Sidebar, Topbar, Panel, StatCard, SummaryStrip, PageFrame, PageTitle, Breadcrumb, Callout)",
   "license": "AGPL-3.0-only",

--- a/packages/testing/package.json
+++ b/packages/testing/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@equaltoai/greater-components-testing",
   "private": true,
-  "version": "0.10.8",
+  "version": "0.11.0",
   "type": "module",
   "description": "Shared testing utilities for accessibility, keyboard navigation, and visual regression testing",
   "license": "AGPL-3.0-only",

--- a/packages/tokens/package.json
+++ b/packages/tokens/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@equaltoai/greater-components-tokens",
   "private": true,
-  "version": "0.10.8",
+  "version": "0.11.0",
   "type": "module",
   "description": "Design tokens for Greater Components",
   "license": "AGPL-3.0-only",

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@equaltoai/greater-components-utils",
   "private": true,
-  "version": "0.10.8",
+  "version": "0.11.0",
   "type": "module",
   "description": "Utility functions for Greater Components",
   "license": "AGPL-3.0-only",

--- a/registry/index.json
+++ b/registry/index.json
@@ -1,9 +1,9 @@
 {
   "$schema": "https://equalto.ai/schemas/registry-index.schema.json",
   "schemaVersion": "1.0.0",
-  "generatedAt": "2026-06-21T17:30:18.168Z",
-  "ref": "greater-v0.10.8",
-  "version": "0.10.8",
+  "generatedAt": "2026-06-21T19:19:41.372Z",
+  "ref": "greater-v0.11.0",
+  "version": "0.11.0",
   "checksums": {
     "packages/primitives/src/assets/greater-default-profile.png": "sha256-fiYnr2MUUA1ZEBJHvY1Ppn00rF9WSgA8IAxwb0umSeU=",
     "packages/primitives/src/assets.d.ts": "sha256-mcuvYSPf1CA84g8LB5UTkxkmJIqwt8oxWdhiebocyfI=",
@@ -1453,7 +1453,7 @@
   "components": {
     "primitives": {
       "name": "primitives",
-      "version": "0.10.8",
+      "version": "0.11.0",
       "description": "Primitive UI components for Greater Components",
       "type": "primitives",
       "files": [
@@ -2104,21 +2104,21 @@
         }
       ],
       "dependencies": [
-        { "name": "icons", "version": "0.10.8" },
-        { "name": "tokens", "version": "0.10.8" },
-        { "name": "utils", "version": "0.10.8" }
+        { "name": "icons", "version": "0.11.0" },
+        { "name": "tokens", "version": "0.11.0" },
+        { "name": "utils", "version": "0.11.0" }
       ],
       "peerDependencies": [
-        { "name": "@equaltoai/greater-components-icons", "version": "0.10.8" },
-        { "name": "@equaltoai/greater-components-utils", "version": "0.10.8" },
-        { "name": "@equaltoai/greater-components-tokens", "version": "0.10.8" },
+        { "name": "@equaltoai/greater-components-icons", "version": "0.11.0" },
+        { "name": "@equaltoai/greater-components-utils", "version": "0.11.0" },
+        { "name": "@equaltoai/greater-components-tokens", "version": "0.11.0" },
         { "name": "svelte", "version": "^5.55.1" }
       ],
       "tags": []
     },
     "headless": {
       "name": "headless",
-      "version": "0.10.8",
+      "version": "0.11.0",
       "description": "Headless UI primitives for Greater Components - behavior without styling",
       "type": "primitives",
       "files": [
@@ -2268,7 +2268,7 @@
     },
     "icons": {
       "name": "icons",
-      "version": "0.10.8",
+      "version": "0.11.0",
       "description": "Icon components for Greater Components",
       "type": "primitives",
       "files": [
@@ -5329,7 +5329,7 @@
     },
     "tokens": {
       "name": "tokens",
-      "version": "0.10.8",
+      "version": "0.11.0",
       "description": "Design tokens for Greater Components",
       "type": "utilities",
       "files": [
@@ -5400,7 +5400,7 @@
     },
     "utils": {
       "name": "utils",
-      "version": "0.10.8",
+      "version": "0.11.0",
       "description": "Utility functions for Greater Components",
       "type": "utilities",
       "files": [
@@ -5591,7 +5591,7 @@
     },
     "adapters": {
       "name": "adapters",
-      "version": "0.10.8",
+      "version": "0.11.0",
       "description": "Transport adapters and state management for Greater Components",
       "type": "adapters",
       "files": [
@@ -6020,7 +6020,7 @@
     },
     "content": {
       "name": "content",
-      "version": "0.10.8",
+      "version": "0.11.0",
       "description": "Content rendering components (CodeBlock, MarkdownRenderer) for Greater Components",
       "type": "utilities",
       "files": [
@@ -6040,7 +6040,7 @@
           "size": 1119
         }
       ],
-      "dependencies": [{ "name": "primitives", "version": "0.10.8" }],
+      "dependencies": [{ "name": "primitives", "version": "0.11.0" }],
       "peerDependencies": [
         { "name": "hast-util-sanitize", "version": "^5.0.2" },
         { "name": "rehype-sanitize", "version": "^6.0.0" },
@@ -6050,15 +6050,15 @@
         { "name": "remark-rehype", "version": "^11.1.2" },
         { "name": "shiki", "version": "^4.0.2" },
         { "name": "unified", "version": "^11.0.5" },
-        { "name": "@equaltoai/greater-components-primitives", "version": "0.10.8" },
-        { "name": "@equaltoai/greater-components-tokens", "version": "0.10.8" },
+        { "name": "@equaltoai/greater-components-primitives", "version": "0.11.0" },
+        { "name": "@equaltoai/greater-components-tokens", "version": "0.11.0" },
         { "name": "svelte", "version": "^5.55.1" }
       ],
       "tags": []
     },
     "shell": {
       "name": "shell",
-      "version": "0.10.8",
+      "version": "0.11.0",
       "description": "App shell layout components for Greater Components (Shell, Sidebar, Topbar, Panel, StatCard, SummaryStrip, PageFrame, PageTitle, Breadcrumb, Callout)",
       "type": "components",
       "files": [
@@ -6199,20 +6199,20 @@
         }
       ],
       "dependencies": [
-        { "name": "headless", "version": "0.10.8" },
-        { "name": "utils", "version": "0.10.8" }
+        { "name": "headless", "version": "0.11.0" },
+        { "name": "utils", "version": "0.11.0" }
       ],
       "peerDependencies": [
-        { "name": "@equaltoai/greater-components-headless", "version": "0.10.8" },
-        { "name": "@equaltoai/greater-components-utils", "version": "0.10.8" },
-        { "name": "@equaltoai/greater-components-tokens", "version": "0.10.8" },
+        { "name": "@equaltoai/greater-components-headless", "version": "0.11.0" },
+        { "name": "@equaltoai/greater-components-utils", "version": "0.11.0" },
+        { "name": "@equaltoai/greater-components-tokens", "version": "0.11.0" },
         { "name": "svelte", "version": "^5.55.1" }
       ],
       "tags": []
     },
     "host-platform": {
       "name": "host-platform",
-      "version": "0.10.8",
+      "version": "0.11.0",
       "description": "Hosted-platform data-display components for Greater Components (FleetCard, CostGauge, ActivitySparkline)",
       "type": "components",
       "files": [
@@ -6302,10 +6302,10 @@
           "size": 5481
         }
       ],
-      "dependencies": [{ "name": "utils", "version": "0.10.8" }],
+      "dependencies": [{ "name": "utils", "version": "0.11.0" }],
       "peerDependencies": [
-        { "name": "@equaltoai/greater-components-utils", "version": "0.10.8" },
-        { "name": "@equaltoai/greater-components-tokens", "version": "0.10.8" },
+        { "name": "@equaltoai/greater-components-utils", "version": "0.11.0" },
+        { "name": "@equaltoai/greater-components-tokens", "version": "0.11.0" },
         { "name": "svelte", "version": "^5.55.1" }
       ],
       "tags": []
@@ -6314,7 +6314,7 @@
   "faces": {
     "social": {
       "name": "social",
-      "version": "0.10.8",
+      "version": "0.11.0",
       "description": "Social/Twitter-style UI components for ActivityPub/Fediverse applications",
       "exports": [
         "Status",
@@ -6982,32 +6982,32 @@
         "tokens": "@equaltoai/greater-components/tokens/theme.css"
       },
       "dependencies": [
-        { "name": "adapters", "version": "0.10.8" },
-        { "name": "admin", "version": "0.10.8" },
-        { "name": "auth", "version": "0.10.8" },
-        { "name": "compose", "version": "0.10.8" },
-        { "name": "headless", "version": "0.10.8" },
-        { "name": "icons", "version": "0.10.8" },
-        { "name": "messaging", "version": "0.10.8" },
-        { "name": "notifications", "version": "0.10.8" },
-        { "name": "primitives", "version": "0.10.8" },
-        { "name": "search", "version": "0.10.8" },
-        { "name": "tokens", "version": "0.10.8" },
-        { "name": "utils", "version": "0.10.8" }
+        { "name": "adapters", "version": "0.11.0" },
+        { "name": "admin", "version": "0.11.0" },
+        { "name": "auth", "version": "0.11.0" },
+        { "name": "compose", "version": "0.11.0" },
+        { "name": "headless", "version": "0.11.0" },
+        { "name": "icons", "version": "0.11.0" },
+        { "name": "messaging", "version": "0.11.0" },
+        { "name": "notifications", "version": "0.11.0" },
+        { "name": "primitives", "version": "0.11.0" },
+        { "name": "search", "version": "0.11.0" },
+        { "name": "tokens", "version": "0.11.0" },
+        { "name": "utils", "version": "0.11.0" }
       ],
       "peerDependencies": [
-        { "name": "@equaltoai/greater-components-adapters", "version": "0.10.8" },
-        { "name": "@equaltoai/greater-components-admin", "version": "0.10.8" },
-        { "name": "@equaltoai/greater-components-auth", "version": "0.10.8" },
-        { "name": "@equaltoai/greater-components-compose", "version": "0.10.8" },
-        { "name": "@equaltoai/greater-components-headless", "version": "0.10.8" },
-        { "name": "@equaltoai/greater-components-icons", "version": "0.10.8" },
-        { "name": "@equaltoai/greater-components-messaging", "version": "0.10.8" },
-        { "name": "@equaltoai/greater-components-notifications", "version": "0.10.8" },
-        { "name": "@equaltoai/greater-components-primitives", "version": "0.10.8" },
-        { "name": "@equaltoai/greater-components-search", "version": "0.10.8" },
-        { "name": "@equaltoai/greater-components-tokens", "version": "0.10.8" },
-        { "name": "@equaltoai/greater-components-utils", "version": "0.10.8" },
+        { "name": "@equaltoai/greater-components-adapters", "version": "0.11.0" },
+        { "name": "@equaltoai/greater-components-admin", "version": "0.11.0" },
+        { "name": "@equaltoai/greater-components-auth", "version": "0.11.0" },
+        { "name": "@equaltoai/greater-components-compose", "version": "0.11.0" },
+        { "name": "@equaltoai/greater-components-headless", "version": "0.11.0" },
+        { "name": "@equaltoai/greater-components-icons", "version": "0.11.0" },
+        { "name": "@equaltoai/greater-components-messaging", "version": "0.11.0" },
+        { "name": "@equaltoai/greater-components-notifications", "version": "0.11.0" },
+        { "name": "@equaltoai/greater-components-primitives", "version": "0.11.0" },
+        { "name": "@equaltoai/greater-components-search", "version": "0.11.0" },
+        { "name": "@equaltoai/greater-components-tokens", "version": "0.11.0" },
+        { "name": "@equaltoai/greater-components-utils", "version": "0.11.0" },
         { "name": "@graphql-typed-document-node/core", "version": "^3.2.0" },
         { "name": "@tanstack/svelte-virtual", "version": "^3.13.23" },
         { "name": "svelte", "version": "^5.55.1" }
@@ -7082,7 +7082,7 @@
     },
     "blog": {
       "name": "blog",
-      "version": "0.10.8",
+      "version": "0.11.0",
       "description": "Blog/Medium-style UI components for long-form publishing applications",
       "exports": [
         "Article",
@@ -7313,21 +7313,21 @@
         "tokens": "@equaltoai/greater-components/tokens/theme.css"
       },
       "dependencies": [
-        { "name": "content", "version": "0.10.8" },
-        { "name": "headless", "version": "0.10.8" },
-        { "name": "icons", "version": "0.10.8" },
-        { "name": "primitives", "version": "0.10.8" },
-        { "name": "utils", "version": "0.10.8" }
+        { "name": "content", "version": "0.11.0" },
+        { "name": "headless", "version": "0.11.0" },
+        { "name": "icons", "version": "0.11.0" },
+        { "name": "primitives", "version": "0.11.0" },
+        { "name": "utils", "version": "0.11.0" }
       ],
       "peerDependencies": [
-        { "name": "@equaltoai/greater-components-auth", "version": "0.10.8" },
-        { "name": "@equaltoai/greater-components-content", "version": "0.10.8" },
-        { "name": "@equaltoai/greater-components-headless", "version": "0.10.8" },
-        { "name": "@equaltoai/greater-components-icons", "version": "0.10.8" },
-        { "name": "@equaltoai/greater-components-primitives", "version": "0.10.8" },
-        { "name": "@equaltoai/greater-components-search", "version": "0.10.8" },
-        { "name": "@equaltoai/greater-components-tokens", "version": "0.10.8" },
-        { "name": "@equaltoai/greater-components-utils", "version": "0.10.8" },
+        { "name": "@equaltoai/greater-components-auth", "version": "0.11.0" },
+        { "name": "@equaltoai/greater-components-content", "version": "0.11.0" },
+        { "name": "@equaltoai/greater-components-headless", "version": "0.11.0" },
+        { "name": "@equaltoai/greater-components-icons", "version": "0.11.0" },
+        { "name": "@equaltoai/greater-components-primitives", "version": "0.11.0" },
+        { "name": "@equaltoai/greater-components-search", "version": "0.11.0" },
+        { "name": "@equaltoai/greater-components-tokens", "version": "0.11.0" },
+        { "name": "@equaltoai/greater-components-utils", "version": "0.11.0" },
         { "name": "svelte", "version": "^5.55.1" }
       ],
       "types": [
@@ -7360,7 +7360,7 @@
     },
     "community": {
       "name": "community",
-      "version": "0.10.8",
+      "version": "0.11.0",
       "description": "Community/Reddit-style UI components for forum-based discussion applications",
       "exports": [
         "Community",
@@ -7591,23 +7591,23 @@
         "tokens": "@equaltoai/greater-components/tokens/theme.css"
       },
       "dependencies": [
-        { "name": "content", "version": "0.10.8" },
-        { "name": "headless", "version": "0.10.8" },
-        { "name": "icons", "version": "0.10.8" },
-        { "name": "primitives", "version": "0.10.8" },
-        { "name": "utils", "version": "0.10.8" }
+        { "name": "content", "version": "0.11.0" },
+        { "name": "headless", "version": "0.11.0" },
+        { "name": "icons", "version": "0.11.0" },
+        { "name": "primitives", "version": "0.11.0" },
+        { "name": "utils", "version": "0.11.0" }
       ],
       "peerDependencies": [
-        { "name": "@equaltoai/greater-components-admin", "version": "0.10.8" },
-        { "name": "@equaltoai/greater-components-auth", "version": "0.10.8" },
-        { "name": "@equaltoai/greater-components-content", "version": "0.10.8" },
-        { "name": "@equaltoai/greater-components-headless", "version": "0.10.8" },
-        { "name": "@equaltoai/greater-components-icons", "version": "0.10.8" },
-        { "name": "@equaltoai/greater-components-notifications", "version": "0.10.8" },
-        { "name": "@equaltoai/greater-components-primitives", "version": "0.10.8" },
-        { "name": "@equaltoai/greater-components-search", "version": "0.10.8" },
-        { "name": "@equaltoai/greater-components-tokens", "version": "0.10.8" },
-        { "name": "@equaltoai/greater-components-utils", "version": "0.10.8" },
+        { "name": "@equaltoai/greater-components-admin", "version": "0.11.0" },
+        { "name": "@equaltoai/greater-components-auth", "version": "0.11.0" },
+        { "name": "@equaltoai/greater-components-content", "version": "0.11.0" },
+        { "name": "@equaltoai/greater-components-headless", "version": "0.11.0" },
+        { "name": "@equaltoai/greater-components-icons", "version": "0.11.0" },
+        { "name": "@equaltoai/greater-components-notifications", "version": "0.11.0" },
+        { "name": "@equaltoai/greater-components-primitives", "version": "0.11.0" },
+        { "name": "@equaltoai/greater-components-search", "version": "0.11.0" },
+        { "name": "@equaltoai/greater-components-tokens", "version": "0.11.0" },
+        { "name": "@equaltoai/greater-components-utils", "version": "0.11.0" },
         { "name": "svelte", "version": "^5.55.1" }
       ],
       "types": [
@@ -7648,7 +7648,7 @@
     },
     "artist": {
       "name": "artist",
-      "version": "0.10.8",
+      "version": "0.11.0",
       "description": "Artist portfolio and gallery UI components for visual artists and creative professionals",
       "exports": [
         "Artwork",
@@ -8481,23 +8481,23 @@
         "tokens": "@equaltoai/greater-components/tokens/theme.css"
       },
       "dependencies": [
-        { "name": "adapters", "version": "0.10.8" },
-        { "name": "headless", "version": "0.10.8" },
-        { "name": "icons", "version": "0.10.8" },
-        { "name": "primitives", "version": "0.10.8" },
-        { "name": "tokens", "version": "0.10.8" },
-        { "name": "utils", "version": "0.10.8" }
+        { "name": "adapters", "version": "0.11.0" },
+        { "name": "headless", "version": "0.11.0" },
+        { "name": "icons", "version": "0.11.0" },
+        { "name": "primitives", "version": "0.11.0" },
+        { "name": "tokens", "version": "0.11.0" },
+        { "name": "utils", "version": "0.11.0" }
       ],
       "peerDependencies": [
         { "name": "@apollo/client", "version": "^4.1.7" },
-        { "name": "@equaltoai/greater-components-adapters", "version": "0.10.8" },
-        { "name": "@equaltoai/greater-components-auth", "version": "0.10.8" },
-        { "name": "@equaltoai/greater-components-headless", "version": "0.10.8" },
-        { "name": "@equaltoai/greater-components-icons", "version": "0.10.8" },
-        { "name": "@equaltoai/greater-components-notifications", "version": "0.10.8" },
-        { "name": "@equaltoai/greater-components-primitives", "version": "0.10.8" },
-        { "name": "@equaltoai/greater-components-tokens", "version": "0.10.8" },
-        { "name": "@equaltoai/greater-components-utils", "version": "0.10.8" },
+        { "name": "@equaltoai/greater-components-adapters", "version": "0.11.0" },
+        { "name": "@equaltoai/greater-components-auth", "version": "0.11.0" },
+        { "name": "@equaltoai/greater-components-headless", "version": "0.11.0" },
+        { "name": "@equaltoai/greater-components-icons", "version": "0.11.0" },
+        { "name": "@equaltoai/greater-components-notifications", "version": "0.11.0" },
+        { "name": "@equaltoai/greater-components-primitives", "version": "0.11.0" },
+        { "name": "@equaltoai/greater-components-tokens", "version": "0.11.0" },
+        { "name": "@equaltoai/greater-components-utils", "version": "0.11.0" },
         { "name": "svelte", "version": "^5.55.1" }
       ],
       "types": [
@@ -8539,7 +8539,7 @@
     },
     "agent": {
       "name": "agent",
-      "version": "0.10.8",
+      "version": "0.11.0",
       "description": "Agent-first face compositions and route-shell boundaries for Greater Components.",
       "exports": [
         "AgentGenesisWorkspace",
@@ -8615,18 +8615,18 @@
         "tokens": "@equaltoai/greater-components/tokens/theme.css"
       },
       "dependencies": [
-        { "name": "agent", "version": "0.10.8" },
-        { "name": "chat", "version": "0.10.8" },
-        { "name": "messaging", "version": "0.10.8" },
-        { "name": "notifications", "version": "0.10.8" },
-        { "name": "soul", "version": "0.10.8" }
+        { "name": "agent", "version": "0.11.0" },
+        { "name": "chat", "version": "0.11.0" },
+        { "name": "messaging", "version": "0.11.0" },
+        { "name": "notifications", "version": "0.11.0" },
+        { "name": "soul", "version": "0.11.0" }
       ],
       "peerDependencies": [
-        { "name": "@equaltoai/greater-components-agent", "version": "0.10.8" },
-        { "name": "@equaltoai/greater-components-chat", "version": "0.10.8" },
-        { "name": "@equaltoai/greater-components-messaging", "version": "0.10.8" },
-        { "name": "@equaltoai/greater-components-notifications", "version": "0.10.8" },
-        { "name": "@equaltoai/greater-components-soul", "version": "0.10.8" },
+        { "name": "@equaltoai/greater-components-agent", "version": "0.11.0" },
+        { "name": "@equaltoai/greater-components-chat", "version": "0.11.0" },
+        { "name": "@equaltoai/greater-components-messaging", "version": "0.11.0" },
+        { "name": "@equaltoai/greater-components-notifications", "version": "0.11.0" },
+        { "name": "@equaltoai/greater-components-soul", "version": "0.11.0" },
         { "name": "svelte", "version": "^5.55.1" }
       ],
       "types": [
@@ -8655,7 +8655,7 @@
   "shared": {
     "auth": {
       "name": "auth",
-      "version": "0.10.8",
+      "version": "0.11.0",
       "description": "Authentication components for ActivityPub/Fediverse applications",
       "exports": [
         "Root",
@@ -8755,14 +8755,14 @@
         }
       ],
       "dependencies": [
-        { "name": "headless", "version": "0.10.8" },
-        { "name": "icons", "version": "0.10.8" },
-        { "name": "primitives", "version": "0.10.8" }
+        { "name": "headless", "version": "0.11.0" },
+        { "name": "icons", "version": "0.11.0" },
+        { "name": "primitives", "version": "0.11.0" }
       ],
       "peerDependencies": [
-        { "name": "@equaltoai/greater-components-headless", "version": "0.10.8" },
-        { "name": "@equaltoai/greater-components-icons", "version": "0.10.8" },
-        { "name": "@equaltoai/greater-components-primitives", "version": "0.10.8" },
+        { "name": "@equaltoai/greater-components-headless", "version": "0.11.0" },
+        { "name": "@equaltoai/greater-components-icons", "version": "0.11.0" },
+        { "name": "@equaltoai/greater-components-primitives", "version": "0.11.0" },
         { "name": "svelte", "version": "^5.55.1" }
       ],
       "types": [
@@ -8786,7 +8786,7 @@
     },
     "compose": {
       "name": "compose",
-      "version": "0.10.8",
+      "version": "0.11.0",
       "description": "Post/content composer components for ActivityPub/Fediverse applications",
       "exports": [
         "Root",
@@ -8921,16 +8921,16 @@
       ],
       "dependencies": [
         { "name": "adapters", "version": "latest" },
-        { "name": "headless", "version": "0.10.8" },
-        { "name": "icons", "version": "0.10.8" },
-        { "name": "primitives", "version": "0.10.8" },
-        { "name": "utils", "version": "0.10.8" }
+        { "name": "headless", "version": "0.11.0" },
+        { "name": "icons", "version": "0.11.0" },
+        { "name": "primitives", "version": "0.11.0" },
+        { "name": "utils", "version": "0.11.0" }
       ],
       "peerDependencies": [
-        { "name": "@equaltoai/greater-components-headless", "version": "0.10.8" },
-        { "name": "@equaltoai/greater-components-icons", "version": "0.10.8" },
-        { "name": "@equaltoai/greater-components-primitives", "version": "0.10.8" },
-        { "name": "@equaltoai/greater-components-utils", "version": "0.10.8" },
+        { "name": "@equaltoai/greater-components-headless", "version": "0.11.0" },
+        { "name": "@equaltoai/greater-components-icons", "version": "0.11.0" },
+        { "name": "@equaltoai/greater-components-primitives", "version": "0.11.0" },
+        { "name": "@equaltoai/greater-components-utils", "version": "0.11.0" },
         { "name": "svelte", "version": "^5.55.1" }
       ],
       "types": [
@@ -8947,7 +8947,7 @@
     },
     "notifications": {
       "name": "notifications",
-      "version": "0.10.8",
+      "version": "0.11.0",
       "description": "Notification components for ActivityPub/Fediverse applications",
       "exports": [
         "Root",
@@ -9041,16 +9041,16 @@
         }
       ],
       "dependencies": [
-        { "name": "adapters", "version": "0.10.8" },
-        { "name": "icons", "version": "0.10.8" },
-        { "name": "primitives", "version": "0.10.8" },
-        { "name": "utils", "version": "0.10.8" }
+        { "name": "adapters", "version": "0.11.0" },
+        { "name": "icons", "version": "0.11.0" },
+        { "name": "primitives", "version": "0.11.0" },
+        { "name": "utils", "version": "0.11.0" }
       ],
       "peerDependencies": [
-        { "name": "@equaltoai/greater-components-adapters", "version": "0.10.8" },
-        { "name": "@equaltoai/greater-components-icons", "version": "0.10.8" },
-        { "name": "@equaltoai/greater-components-primitives", "version": "0.10.8" },
-        { "name": "@equaltoai/greater-components-utils", "version": "0.10.8" },
+        { "name": "@equaltoai/greater-components-adapters", "version": "0.11.0" },
+        { "name": "@equaltoai/greater-components-icons", "version": "0.11.0" },
+        { "name": "@equaltoai/greater-components-primitives", "version": "0.11.0" },
+        { "name": "@equaltoai/greater-components-utils", "version": "0.11.0" },
         { "name": "svelte", "version": "^5.55.1" }
       ],
       "types": [
@@ -9072,7 +9072,7 @@
     },
     "search": {
       "name": "search",
-      "version": "0.10.8",
+      "version": "0.11.0",
       "description": "Search components for ActivityPub/Fediverse applications with federated search support",
       "exports": [
         "Root",
@@ -9142,16 +9142,16 @@
         }
       ],
       "dependencies": [
-        { "name": "headless", "version": "0.10.8" },
-        { "name": "icons", "version": "0.10.8" },
-        { "name": "primitives", "version": "0.10.8" },
-        { "name": "utils", "version": "0.10.8" }
+        { "name": "headless", "version": "0.11.0" },
+        { "name": "icons", "version": "0.11.0" },
+        { "name": "primitives", "version": "0.11.0" },
+        { "name": "utils", "version": "0.11.0" }
       ],
       "peerDependencies": [
-        { "name": "@equaltoai/greater-components-headless", "version": "0.10.8" },
-        { "name": "@equaltoai/greater-components-icons", "version": "0.10.8" },
-        { "name": "@equaltoai/greater-components-primitives", "version": "0.10.8" },
-        { "name": "@equaltoai/greater-components-utils", "version": "0.10.8" },
+        { "name": "@equaltoai/greater-components-headless", "version": "0.11.0" },
+        { "name": "@equaltoai/greater-components-icons", "version": "0.11.0" },
+        { "name": "@equaltoai/greater-components-primitives", "version": "0.11.0" },
+        { "name": "@equaltoai/greater-components-utils", "version": "0.11.0" },
         { "name": "svelte", "version": "^5.55.1" }
       ],
       "types": [
@@ -9168,7 +9168,7 @@
     },
     "admin": {
       "name": "admin",
-      "version": "0.10.8",
+      "version": "0.11.0",
       "description": "Admin dashboard components for ActivityPub instance management",
       "exports": [
         "Root",
@@ -9380,14 +9380,14 @@
       ],
       "dependencies": [
         { "name": "adapters", "version": "latest" },
-        { "name": "headless", "version": "0.10.8" },
-        { "name": "icons", "version": "0.10.8" },
-        { "name": "primitives", "version": "0.10.8" }
+        { "name": "headless", "version": "0.11.0" },
+        { "name": "icons", "version": "0.11.0" },
+        { "name": "primitives", "version": "0.11.0" }
       ],
       "peerDependencies": [
-        { "name": "@equaltoai/greater-components-headless", "version": "0.10.8" },
-        { "name": "@equaltoai/greater-components-icons", "version": "0.10.8" },
-        { "name": "@equaltoai/greater-components-primitives", "version": "0.10.8" },
+        { "name": "@equaltoai/greater-components-headless", "version": "0.11.0" },
+        { "name": "@equaltoai/greater-components-icons", "version": "0.11.0" },
+        { "name": "@equaltoai/greater-components-primitives", "version": "0.11.0" },
         { "name": "svelte", "version": "^5.55.1" }
       ],
       "types": [
@@ -9405,7 +9405,7 @@
     },
     "chat": {
       "name": "chat",
-      "version": "0.10.8",
+      "version": "0.11.0",
       "description": "AI chat interface components with streaming responses, tool calls, and settings",
       "exports": [
         "Container",
@@ -9506,15 +9506,15 @@
         }
       ],
       "dependencies": [
-        { "name": "content", "version": "0.10.8" },
-        { "name": "icons", "version": "0.10.8" },
-        { "name": "primitives", "version": "0.10.8" }
+        { "name": "content", "version": "0.11.0" },
+        { "name": "icons", "version": "0.11.0" },
+        { "name": "primitives", "version": "0.11.0" }
       ],
       "peerDependencies": [
-        { "name": "@equaltoai/greater-components-content", "version": "0.10.8" },
-        { "name": "@equaltoai/greater-components-headless", "version": "0.10.8" },
-        { "name": "@equaltoai/greater-components-icons", "version": "0.10.8" },
-        { "name": "@equaltoai/greater-components-primitives", "version": "0.10.8" },
+        { "name": "@equaltoai/greater-components-content", "version": "0.11.0" },
+        { "name": "@equaltoai/greater-components-headless", "version": "0.11.0" },
+        { "name": "@equaltoai/greater-components-icons", "version": "0.11.0" },
+        { "name": "@equaltoai/greater-components-primitives", "version": "0.11.0" },
         { "name": "svelte", "version": "^5.55.1" }
       ],
       "types": [
@@ -9552,7 +9552,7 @@
     },
     "messaging": {
       "name": "messaging",
-      "version": "0.10.8",
+      "version": "0.11.0",
       "description": "Direct messaging components for ActivityPub/Fediverse applications",
       "exports": [
         "Root",
@@ -9648,16 +9648,16 @@
         }
       ],
       "dependencies": [
-        { "name": "compose", "version": "0.10.8" },
-        { "name": "headless", "version": "0.10.8" },
-        { "name": "icons", "version": "0.10.8" },
-        { "name": "primitives", "version": "0.10.8" }
+        { "name": "compose", "version": "0.11.0" },
+        { "name": "headless", "version": "0.11.0" },
+        { "name": "icons", "version": "0.11.0" },
+        { "name": "primitives", "version": "0.11.0" }
       ],
       "peerDependencies": [
-        { "name": "@equaltoai/greater-components-compose", "version": "0.10.8" },
-        { "name": "@equaltoai/greater-components-headless", "version": "0.10.8" },
-        { "name": "@equaltoai/greater-components-icons", "version": "0.10.8" },
-        { "name": "@equaltoai/greater-components-primitives", "version": "0.10.8" },
+        { "name": "@equaltoai/greater-components-compose", "version": "0.11.0" },
+        { "name": "@equaltoai/greater-components-headless", "version": "0.11.0" },
+        { "name": "@equaltoai/greater-components-icons", "version": "0.11.0" },
+        { "name": "@equaltoai/greater-components-primitives", "version": "0.11.0" },
         { "name": "svelte", "version": "^5.55.1" }
       ],
       "types": [
@@ -9678,7 +9678,7 @@
     },
     "soul": {
       "name": "soul",
-      "version": "0.10.8",
+      "version": "0.11.0",
       "description": "Reachability, contact-preferences, and anchor-assurance UI for lesser-soul v3.",
       "exports": [
         "ChannelsDisplay",
@@ -9740,14 +9740,14 @@
         }
       ],
       "dependencies": [
-        { "name": "adapters", "version": "0.10.8" },
-        { "name": "primitives", "version": "0.10.8" },
-        { "name": "utils", "version": "0.10.8" }
+        { "name": "adapters", "version": "0.11.0" },
+        { "name": "primitives", "version": "0.11.0" },
+        { "name": "utils", "version": "0.11.0" }
       ],
       "peerDependencies": [
-        { "name": "@equaltoai/greater-components-adapters", "version": "0.10.8" },
-        { "name": "@equaltoai/greater-components-primitives", "version": "0.10.8" },
-        { "name": "@equaltoai/greater-components-utils", "version": "0.10.8" },
+        { "name": "@equaltoai/greater-components-adapters", "version": "0.11.0" },
+        { "name": "@equaltoai/greater-components-primitives", "version": "0.11.0" },
+        { "name": "@equaltoai/greater-components-utils", "version": "0.11.0" },
         { "name": "svelte", "version": "^5.55.1" }
       ],
       "types": [
@@ -9765,7 +9765,7 @@
     },
     "agent": {
       "name": "agent",
-      "version": "0.10.8",
+      "version": "0.11.0",
       "description": "Agent-first workflow surfaces, contracts, package boundaries, and rollout shape metadata for Greater Components.",
       "exports": [
         "AgentIdentityCard",

--- a/registry/latest.json
+++ b/registry/latest.json
@@ -1,5 +1,6 @@
 {
-  "ref": "greater-v0.10.8",
-  "version": "0.10.8",
-  "updatedAt": "2026-06-18T11:13:18.745Z"
+  "ref": "greater-v0.11.0",
+  "version": "0.11.0",
+  "commit": "8338750399399bf8870fac69bb0961592ebf4ae8",
+  "updatedAt": "2026-06-21T19:19:18.802Z"
 }


### PR DESCRIPTION
Staging→main promotion (operator-merged).

Promotes the **0.11.0 version bump** (#849) to main so the M4 release can be cut. M4 (#845) added exported adapter helper APIs — a minor bump — but didn't move the version; this sets package.json + all workspace packages + manifests + registry to **0.11.0** (registry regenerated; `verify-release-branch.sh greater-v0.11.0` PASSES).

**After merge — cut the release:** run **Manual Release** from `main` with `version=greater-v0.11.0`. All gates now pass (dispatch-from-main, tag creation, version match). It creates the tag, builds artifacts, and publishes. That release is what Sim M5 consumes.

Prepared by factory; merge to main + release are operator-owned.