### PR TITLE
Promote staging→main: tag-derived release flow (match working lesser/host/body)

### DIFF
--- a/.github/workflows/manual-release.yml
+++ b/.github/workflows/manual-release.yml
@@ -14,6 +14,9 @@ on:
 permissions:
   contents: write
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'
+
 jobs:
   publish:
     name: Publish immutable release assets
@@ -21,22 +24,13 @@ jobs:
     if: ${{ github.event_name != 'push' || github.actor != 'github-actions[bot]' }}
     runs-on: ubuntu-latest
     env:
-      RELEASE_VERSION: ${{ github.event_name == 'workflow_dispatch' && inputs.version || github.ref_name }}
+      RELEASE_VERSION: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.version || github.ref_name }}
 
     steps:
       - name: Checkout
         uses: actions/checkout@v5
         with:
           fetch-depth: 0
-
-      - name: Validate release version
-        run: |
-          set -euo pipefail
-
-          if [[ ! "${RELEASE_VERSION}" =~ ^greater-v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
-            echo "::error::Release tag must match greater-vX.Y.Z: ${RELEASE_VERSION}"
-            exit 1
-          fi
 
       - name: Create and push tag (workflow_dispatch)
         if: ${{ github.event_name == 'workflow_dispatch' }}
@@ -66,23 +60,20 @@ jobs:
           git tag "${RELEASE_VERSION}" "${GITHUB_SHA}"
           git push origin "refs/tags/${RELEASE_VERSION}"
 
-      - name: Assert tag is anchored on main
+      - name: Assert release target is on main
         run: |
           set -euo pipefail
+
           git fetch --no-tags origin "+refs/heads/main:refs/remotes/origin/main"
           git fetch --tags --force origin "refs/tags/${RELEASE_VERSION}:refs/tags/${RELEASE_VERSION}" || git fetch --tags --force origin
 
-          tag_commit="$(git rev-list -n 1 "${RELEASE_VERSION}")"
-          head_commit="$(git rev-parse HEAD)"
-          if [[ "${tag_commit}" != "${head_commit}" ]]; then
-            echo "::error::Checked-out HEAD (${head_commit}) does not match ${RELEASE_VERSION} (${tag_commit})."
+          tagged_sha="$(git rev-list -n 1 "${RELEASE_VERSION}")"
+          if ! git merge-base --is-ancestor "${tagged_sha}" origin/main; then
+            echo "release tag '${RELEASE_VERSION}' points at ${tagged_sha}, which is not an ancestor of origin/main" >&2
             exit 1
           fi
 
-          if ! git merge-base --is-ancestor "${tag_commit}" origin/main; then
-            echo "::error::${RELEASE_VERSION} must point to a commit reachable from origin/main."
-            exit 1
-          fi
+          echo "release tag '${RELEASE_VERSION}' points at ${tagged_sha}, an ancestor of origin/main"
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v6
@@ -100,14 +91,12 @@ jobs:
           pnpm audit:lockfile-integrity
           pnpm install --frozen-lockfile
 
-      - name: Verify release tag and registry metadata
-        env:
-          TAG_NAME: ${{ env.RELEASE_VERSION }}
+      - name: Prepare release metadata from tag
         run: |
           set -euo pipefail
-          version="$(node -p "require('./package.json').version")"
-          bash scripts/verify-release-branch.sh "${TAG_NAME}"
-          node scripts/prepare-github-release.js "${version}"
+          release_version="${RELEASE_VERSION#greater-v}"
+          echo "Preparing Greater release ${RELEASE_VERSION} (version ${release_version})"
+          node scripts/prepare-github-release.js "${RELEASE_VERSION}"
 
       - name: Build CLI tarball and registry artifacts
         run: pnpm release:artifacts

--- a/docs/devops/github-releases.md
+++ b/docs/devops/github-releases.md
@@ -20,15 +20,14 @@ A Greater Components release is a single immutable reference that clients can pi
 - `registry/latest.json`
 - generated package tarballs under `artifacts/`
 
-The registry files must match the version in `package.json`; version-bumping PRs must regenerate the registry before merge because no automated alignment PR remains after release-please retirement.
+The workflow derives the release version from the `greater-vX.Y.Z` tag, updates package/manifest versions ephemerally in the CI workspace, and regenerates `registry/index.json` plus `registry/latest.json` from that tag before packaging. A committed package.json pre-bump is not required and does not gate the release.
 
 ## Operator release flow
 
 1. Confirm the feature→staging PRs passed the verify set.
 2. Promote `staging → main` via PR. `main-guard.yml` must pass and show `Head: staging`.
-3. Cut/sign `greater-vX.Y.Z` on `main`.
-4. Let `.github/workflows/manual-release.yml` run on the tag, or dispatch it from `main` with `tag_name=greater-vX.Y.Z` for an existing tag.
-5. Verify the workflow asserts tag ancestry, builds artifacts, validates the registry, uploads assets, and publishes the GitHub Release.
+3. Dispatch `.github/workflows/manual-release.yml` from `main` with `version=greater-vX.Y.Z`, or push an existing `greater-vX.Y.Z` tag. Dispatch creates and pushes the tag at the dispatched `main` SHA when it does not already exist, and refuses only if that tag already points at a different SHA.
+4. Verify the workflow asserts tag ancestry, derives `X.Y.Z` from the tag, regenerates package/registry metadata ephemerally, builds artifacts, uploads assets, and publishes the GitHub Release.
 
 Local release checks mirror the workflow:
 
@@ -37,8 +36,9 @@ git fetch origin main --force --tags
 bash scripts/verify-release-branch.sh greater-vX.Y.Z
 pnpm audit:lockfile-integrity
 pnpm install --frozen-lockfile
+pnpm release:prepare greater-vX.Y.Z
 pnpm validate:package
-pnpm validate:registry --strict
+pnpm validate:registry
 pnpm audit:tarball-integrity
 pnpm release:artifacts
 ```

--- a/scripts/prepare-github-release.js
+++ b/scripts/prepare-github-release.js
@@ -2,13 +2,13 @@
 /**
  * Prepare Greater Components release metadata for a manual tag-driven release.
  *
- * - Sets root package.json version
- * - Sets packages/cli/package.json version (CLI tarball version)
- * - Updates registry/latest.json to point at `greater-vX.Y.Z`
+ * - Derives X.Y.Z from the release tag `greater-vX.Y.Z`
+ * - Sets root/workspace package.json and manifest versions ephemerally in the CI workspace
+ * - Updates registry/latest.json to point at the release tag
  * - Regenerates registry/index.json with ref override (so index.ref is the tag)
  *
  * Usage:
- *   node scripts/prepare-github-release.js 0.1.0
+ *   node scripts/prepare-github-release.js greater-v0.1.0
  */
 
 import { execSync } from 'node:child_process';
@@ -20,8 +20,7 @@ const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 const rootDir = path.join(__dirname, '..');
 
-const semverPattern = /^[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?$/;
-const isStableSemver = (v) => !v.includes('-');
+const releaseTagPattern = /^greater-v([0-9]+\.[0-9]+\.[0-9]+)$/;
 
 function die(message) {
 	console.error(message);
@@ -230,19 +229,21 @@ function registryIndexMatchesTag({ version, tag }) {
 	}
 }
 
+function parseReleaseTag(input) {
+	const releaseTag = input || process.env.RELEASE_VERSION || process.env.GITHUB_REF_NAME || '';
+	const match = releaseTag.match(releaseTagPattern);
+	if (!match) {
+		die(
+			`Invalid Greater release tag: ${releaseTag || '(missing)'}; expected greater-vX.Y.Z (example: greater-v1.2.3)`
+		);
+	}
+
+	return { tag: releaseTag, version: match[1] };
+}
+
 function main() {
 	const args = process.argv.slice(2);
-	const version = args[0];
-
-	if (!version) {
-		die('Usage: node scripts/prepare-github-release.js <version>');
-	}
-
-	if (!semverPattern.test(version)) {
-		die(`Invalid semver version: ${version}`);
-	}
-
-	const tag = `greater-v${version}`;
+	const { tag, version } = parseReleaseTag(args[0]);
 
 	const packageJsonPath = path.join(rootDir, 'package.json');
 	const cliPackageJsonPath = path.join(rootDir, 'packages', 'cli', 'package.json');
@@ -253,21 +254,19 @@ function main() {
 
 	updateWorkspacePackageVersions(version);
 
-	if (isStableSemver(version)) {
-		const existingLatest = fs.existsSync(latestPath) ? readJson(latestPath) : null;
-		const commit = resolveCommit(tag);
-		if (
-			existingLatest?.ref !== tag ||
-			existingLatest?.version !== version ||
-			(commit && existingLatest?.commit !== commit)
-		) {
-			writeJson(latestPath, {
-				ref: tag,
-				version,
-				...(commit ? { commit } : {}),
-				updatedAt: new Date().toISOString(),
-			});
-		}
+	const existingLatest = fs.existsSync(latestPath) ? readJson(latestPath) : null;
+	const commit = resolveCommit(tag);
+	if (
+		existingLatest?.ref !== tag ||
+		existingLatest?.version !== version ||
+		(commit && existingLatest?.commit !== commit)
+	) {
+		writeJson(latestPath, {
+			ref: tag,
+			version,
+			...(commit ? { commit } : {}),
+			updatedAt: new Date().toISOString(),
+		});
 	}
 
 	if (!registryIndexMatchesTag({ version, tag })) {

--- a/scripts/validate-release-versions.js
+++ b/scripts/validate-release-versions.js
@@ -157,7 +157,7 @@ function main() {
 		log('❌ Release version validation FAILED', colors.red);
 		errors.forEach((error) => log(`   - ${error}`, colors.red));
 		log('\nFix by running:', colors.yellow);
-		log(`  pnpm release:prepare ${version}`, colors.yellow);
+		log(`  pnpm release:prepare greater-v${version}`, colors.yellow);
 		process.exit(1);
 	}
 

--- a/scripts/verify-release-branch.sh
+++ b/scripts/verify-release-branch.sh
@@ -9,16 +9,8 @@ if [[ -z "${tag}" ]]; then
 	exit 1
 fi
 
-if [[ ! -f "package.json" ]]; then
-	echo "release-branch: FAIL (missing package.json)"
-	exit 1
-fi
-
-version="$(node -p "require('./package.json').version")"
-expected_tag="greater-v${version}"
-
-if [[ "${tag}" != "${expected_tag}" ]]; then
-	echo "release-branch: FAIL (tag ${tag} != ${expected_tag})"
+if [[ ! "${tag}" =~ ^greater-v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+	echo "release-branch: FAIL (tag must match greater-vX.Y.Z; got ${tag})"
 	exit 1
 fi
 
@@ -31,11 +23,15 @@ if ! git show-ref --verify --quiet "${main_ref}"; then
 	exit 1
 fi
 
-commit="$(git rev-parse HEAD)"
+if git rev-parse -q --verify "refs/tags/${tag}" >/dev/null; then
+	commit="$(git rev-list -n 1 "${tag}")"
+else
+	commit="$(git rev-parse HEAD)"
+fi
 
 if ! git merge-base --is-ancestor "${commit}" "${main_ref}"; then
-	echo "release-branch: FAIL (${expected_tag} must be tagged from ${main_branch})"
+	echo "release-branch: FAIL (${tag} must point at a commit reachable from ${main_branch})"
 	exit 1
 fi
 
-echo "release-branch: PASS (${expected_tag} is on ${main_branch})"
+echo "release-branch: PASS (${tag} target is on ${main_branch})"


### PR DESCRIPTION
Staging→main promotion (operator-merged).

Promotes the **release-flow port** (#851) that makes greater release exactly like the working lesser/host/body `release.yml`:
- `workflow_dispatch` `version` → create+push tag from main → build → publish.
- **Version is DERIVED FROM THE TAG** (`greater-vX.Y.Z` → `X.Y.Z`); metadata set ephemerally in CI.
- **Removed the package.json==tag version-match gate** (verify-release-branch.sh no longer reads package.json; workflow no longer calls it as a gate).
- Greater asset pipeline (pnpm release:artifacts, registry, immutable publish) intact.
Proven: fixture package.json=0.0.0 + tag greater-v9.8.7 → built 9.8.7. CI green.

**After merge — cut the release:** run **Manual Release** from `main` with `version=greater-v0.11.1`. No pre-bump, no match gate — it creates the tag, derives 0.11.1, builds, publishes.

Prepared by factory; merge to main + release are operator-owned.