### PR TITLE
release: promote staging for greater-v0.11.3

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -42,6 +42,9 @@ packages/tokens/src/index.ts
 # Vendored Lesser / Lesser Host contract snapshots (keep byte-for-byte from the pinned releases)
 docs/lesser/contracts/openapi.yaml
 docs/lesser/contracts/graphql-schema.graphql
+docs/lesser/contracts/hosted-soul-genesis-projection.md
+docs/lesser/contracts/examples/hosted-soul-genesis-projection-table.example.json
+docs/lesser/contracts/testdata/hosted-genesis/
 docs/lesser-host/contracts/openapi.yaml
 docs/lesser-host/contracts/soul-mint-conversation-sse.json
 docs/lesser-host/contracts/hosted-genesis-conversation.md

--- a/docs/lesser-host/contracts/LESSER_HOST_REF.txt
+++ b/docs/lesser-host/contracts/LESSER_HOST_REF.txt
@@ -1,2 +1,2 @@
-tag: v1.0.5
-commit: 2b6e111c3acf8f8aaf70ef011843eeec3cdd2373
+tag: v1.0.6
+commit: d0213786ac8dc90ceaef3ae49850b4078ab38e68

--- a/docs/lesser-host/contracts/README.md
+++ b/docs/lesser-host/contracts/README.md
@@ -4,7 +4,63 @@ This directory contains **pinned, machine-readable contract artifacts** for down
 from `lesser-host` APIs (for example, `greater-components`).
 
 - `openapi.yaml` — OpenAPI snapshot for build-time client/type generation. Do not serve this file at runtime.
-- `soul-mint-conversation-sse.json` — Canonical SSE event names and payload contracts referenced by the OpenAPI snapshot.
+- `soul-mint-conversation-sse.json` — machine-readable SSE companion contract for the soul mint-conversation stream.
+- `hosted-genesis-conversation.md` — Host-owned durable async hosted-genesis status contract for the Lesser
+  instance-key path.
 - `../spec/v3/` — JSON Schema + fixtures for lesser-soul v3 protocol surfaces implemented by `lesser-host`.
 
+## Canonical generation process
+
+The checked-in REST adapter for `lesser-host` lives at:
+
+- `web/src/lib/greater/adapters/rest/generated/lesser-host-api.ts`
+
+It is generated from `openapi.yaml` with the pinned `openapi-typescript` tool in `web/package.json`.
+
+Canonical commands:
+
+```bash
+cd web
+npm ci
+npm run generate:lesser-host-api
+npm run verify:lesser-host-contracts
+```
+
+`verify:lesser-host-contracts` is the anti-drift gate. It fails if:
+
+- required soul mint-conversation routes or schemas are missing from `docs/contracts/openapi.yaml`
+- required instance-key mint-conversation read routes and compact/full response schemas are missing from
+  `docs/contracts/openapi.yaml`
+- required instance-key bootstrap write routes, the `soul_instance.*` error envelope, hosted/off-chain finalize response
+  schema, or server-side instance-key auth semantics are missing from `docs/contracts/openapi.yaml`
+- the Lesser-used instance-key registration mint-conversation route is still documented as SSE-only instead of
+  JSON-authoritative durable status
+- the hosted-genesis durable conversation schema or example payloads are missing required status/evidence cases
+- the SSE companion contract is missing required portal/native Host UI events or incorrectly claims the Lesser
+  instance-key route as authoritative SSE
+- the checked-in generated adapter does not match a fresh regeneration
+
+CI and the governance rubric both run this verification so contract drift fails closed.
+
+The instance-key bootstrap route family under `/api/v1/soul/instance/agents/register/...` is a Host ↔ Lesser
+server-side contract. Its bearer token is the managed InstanceKey (`sha256(raw_key)` stored by Host); it is not a
+portal/control-plane session-token or browser credential contract. Greater Components syncs the generated adapter before
+Simulacrum consumes these capabilities.
+
+For hosted genesis, `POST /api/v1/soul/instance/agents/register/{id}/mint-conversation` and `GET
+/api/v1/soul/instance/agents/register/{id}/mint-conversation/{conversationId}` are JSON-authoritative durable status
+routes. `HTTP 200` / `HTTP 202` is transport success only; downstream consumers must poll/read the durable
+HostConversation status and require `declaration_ready` plus `produced_declarations` before publish.
+
 Release automation packages these artifacts as GitHub Release assets on every `v*` tag.
+
+## Soul comm mailbox contract notes
+
+The mailbox schemas under `../spec/v3/schemas/soul-comm-mailbox-*.schema.json` are the body-facing canonical contract.
+They are instance-key authenticated and keep list/get metadata separate from explicit content fetches.
+
+The portal compatibility schemas `soul-agent-comm-activity-*` and `soul-agent-comm-queue-*` are derived from canonical
+mailbox state for operator/customer portal views. Queue list items intentionally do not include full message bodies; they
+return preview/content metadata and mailbox state only.
+
+Cross-repo migration guidance for body and lesser is in `../soul-comm-mailbox-migration.md`.

--- a/docs/lesser-host/contracts/hosted-genesis-conversation.md
+++ b/docs/lesser-host/contracts/hosted-genesis-conversation.md
@@ -1,12 +1,14 @@
 # Hosted genesis durable conversation contract
 
-Project 49 locks the Host-owned durable async contract for Lesser-driven hosted/off-chain soul genesis. The observed
+Project 50 Milestone A extends the Project 49 contract by adding the Host-owned `HostedGenesisSession` DynamoDB source of truth. Project 49 locked the Host-owned durable async contract for Lesser-driven hosted/off-chain soul genesis. The observed
 failure this contract fixes was a transport-success response (`HTTP 200` plus a request id) while Host persisted the
 conversation as `in_progress` with no declarations and Lesser could not persist a `host_conversation_id`.
 
-This document is a contract artifact for Host, Lesser, Greater, and Sim. M1.1 only locks names and examples; it does
-not implement the M2 async worker/queue. M2 implements the Lesser instance-key JSON projection, hosted-genesis worker
-queue, idempotent retry semantics, and fail-closed finalize behavior described here.
+This document is a contract artifact for Host, Lesser, Greater, and Sim. Project 49 M1.1 locked names and examples.
+Project 50 Milestone A implements the Host-owned source-of-truth model/repository foundation. Project 51 M2 routes
+the Lesser instance-key runtime through `HostedGenesisSession` first: POST commits the session and idempotency/debit
+ledger before transport execution, GET/status projects from the session, completion/finalize gates read declaration
+checkpoint readiness from the session, and `SoulAgentMintConversation` is compatibility/projection input only.
 
 ## Authoritative Lesser route family
 
@@ -31,6 +33,44 @@ control-plane session tokens.
 
 SSE may remain available for portal/native Host UI routes, but SSE is not the authoritative completion mechanism for
 the Lesser instance-key path.
+
+## Host-owned source-of-truth row
+
+Milestone A introduces `HostedGenesisSession` as the Host DynamoDB/TableTheory business record for hosted/off-chain
+genesis. AppTheory MicroVM session registry, memory, disk, and lifecycle data are execution/cache state only; they are
+reconstructible from the Host row and never become the user-visible source of truth.
+
+Key shape and tenancy rules:
+
+- primary key: `PK=HOSTED_GENESIS#INSTANCE#{instance_slug}`, `SK=SESSION#{conversation_id}`
+- registration and agent GSIs also include `instance_slug` so lookups cannot cross Managed instance boundaries
+- writes after create use TableTheory optimistic-lock `version` checks; stale expected versions fail closed instead of
+  overwriting a concurrent state transition
+- status updates also carry an expected current status condition, so an otherwise current `version` cannot skip the
+  locked Host state-machine transition table
+- `created` is valid only for pre-turn Host rows and still collapses to `in_progress` on Lesser instance-key reads
+- accepted turns are tracked in a compact `turn_ledger` of turn ids, idempotency keys, request hashes, checkpoint refs,
+  and billing ledger refs only
+
+Durable fields are ids, bounded status, and checkpoint references only. The model does not carry raw prompts, raw
+message lists, provider keys, Instance API keys, wallet signatures, signing material, SSM values, AWS credentials,
+provider secrets, MicroVM endpoint tokens, or browser Host credentials. Declaration publish/finalize readiness is gated
+by `status=declaration_ready` plus a valid declaration checkpoint (`declaration_id`, `declaration_hash`,
+`checkpoint_ref`, registration/conversation/agent ids, message count, request id, and produced timestamp). Typed
+`failed` recovery actions are server-authored and limited to the locked recovery enum below.
+
+### Idempotency ledger semantics
+
+The durable `HostedGenesisSession` turn ledger is the Host source of truth for retry semantics. For a caller-provided
+`idempotency_key`, Host records the request hash and accepted `turn_id` once. A retry with the same idempotency key and
+same request hash replays the existing turn and must not append another user turn, advance `message_count` or
+`latest_turn_id`, enqueue duplicate user-visible work, or debit credits again. A retry with the same idempotency key and
+a different request hash fails closed as an idempotency conflict.
+
+SQS, AppTheory MicroVM registry/cache state, AI-worker delivery, and HTTP/SSE transport state are reconstructible
+execution details. They do not determine user-visible progress, retry, finalize readiness, or billing state. If queue
+delivery is missing or stale, status remains the compact `HostedGenesisSession` projection and retry/finalize decisions
+continue to fail closed from that Host row.
 
 ## HostConversation envelope
 
@@ -95,5 +135,11 @@ should not wait for an explicit local `created` projection before persisting `ho
    `restart_soul_bootstrap`, or `operator_action`.
 6. Idempotency is cross-boundary. `idempotency_key` and `correlation_id` are accepted on POST and echoed through
    `trace_ids` when available; callers must keep them client-safe.
-7. Human-visible evidence is compact. Responses carry ids, status, typed recovery, and declaration summary/evidence; they
+7. Legacy migration is deterministic. Existing `SOUL_REG` / `MINT_CONVERSATION` rows are dry-run planned into
+   `HostedGenesisSession` seeds without importing raw transcripts; ambiguous active rows become typed recovery states
+   rather than deriving progress from SQS.
+8. `SoulAgentMintConversation` is compatibility/projection input after Project 51 M2. It may supply legacy declaration
+   JSON or safe migration hints, but it no longer defines user-visible status, retry, billing, recovery, or finalize
+   authority for the Lesser instance-key route family.
+9. Human-visible evidence is compact. Responses carry ids, status, typed recovery, and declaration summary/evidence; they
    do not expose raw Host credentials or require raw LLM transcripts.

--- a/docs/lesser/contracts/LESSER_REF.txt
+++ b/docs/lesser/contracts/LESSER_REF.txt
@@ -1,2 +1,2 @@
-tag: v1.5.6
-commit: 25fe20d606132763ca48663a75f34405596ddaa8
+tag: v1.5.8
+commit: 4c01567104f59ae9cc1dee4ccf2e0d82739aa2ae

--- a/docs/lesser/contracts/examples/hosted-soul-genesis-projection-table.example.json
+++ b/docs/lesser/contracts/examples/hosted-soul-genesis-projection-table.example.json
@@ -1,0 +1,850 @@
+{
+  "kind": "lesser.hosted_soul_genesis_projection_table",
+  "schema_version": 1,
+  "contract_version": "p49-m1.2",
+  "date": "2026-06-21",
+  "source_brief": "/home/aron/ai-workspace/codebases/equaltoai/agents/arch/projects/project49-async-hosted-genesis/contract-and-brief.md",
+  "issues": {
+    "lesser_milestone": "https://github.com/equaltoai/lesser/issues/1173",
+    "host_m11": "https://github.com/equaltoai/lesser-host/issues/730",
+    "parent_epic": "https://github.com/equaltoai/lesser-host/issues/737",
+    "org_project": "https://github.com/orgs/equaltoai/projects/49"
+  },
+  "host_m11_alignment": {
+    "status": "no_open_host_m11_pr_observed_on_2026-06-21",
+    "locked_to_shared_names": [
+      "in_progress",
+      "assistant_turn_ready",
+      "declaration_extraction_pending",
+      "declaration_ready",
+      "failed",
+      "published",
+      "bound"
+    ],
+    "reconciliation_required_if_host_changes_names": true
+  },
+  "graphql_operations": [
+    "startHostedSoulBootstrap",
+    "sendHostedSoulGenesisMessage",
+    "completeHostedSoulGenesis",
+    "publishHostedSoul",
+    "restartSoulBootstrap"
+  ],
+  "locked_projection_fields": [
+    {
+      "persisted_field": "host_registration_id",
+      "current_graphql_field": "hostRegistrationId",
+      "m3_compact_graphql_field": "hostRegistrationId",
+      "implemented_in_current_schema": true,
+      "rule": "persist when Host registration exists"
+    },
+    {
+      "persisted_field": "host_soul_agent_id",
+      "current_graphql_field": "hostSoulAgentId",
+      "m3_compact_graphql_field": "hostSoulAgentId",
+      "implemented_in_current_schema": true,
+      "rule": "persist with Host registration"
+    },
+    {
+      "persisted_field": "host_conversation_id",
+      "current_graphql_field": "hostConversationId",
+      "m3_compact_graphql_field": "hostConversationId",
+      "implemented_in_current_schema": true,
+      "rule": "persist early before returning any post-conversation next action"
+    },
+    {
+      "persisted_field": "phase",
+      "current_graphql_field": "phase",
+      "m3_compact_graphql_field": "phase",
+      "implemented_in_current_schema": true,
+      "rule": "canonical Lesser phase from this table"
+    },
+    {
+      "persisted_field": "status",
+      "current_graphql_field": "state",
+      "m3_compact_graphql_field": "hostConversationStatus",
+      "implemented_in_current_schema": true,
+      "rule": "GraphQL state remains string-compatible; compact Host status may be added additively in M3"
+    },
+    {
+      "persisted_field": "next_action",
+      "current_graphql_field": "typedNextAction",
+      "m3_compact_graphql_field": "typedNextAction",
+      "implemented_in_current_schema": true,
+      "rule": "server authors exactly one next action per response"
+    },
+    {
+      "persisted_field": "recovery_category",
+      "current_graphql_field": "recoveryCategory",
+      "m3_compact_graphql_field": "recoveryCategory",
+      "implemented_in_current_schema": true,
+      "rule": "typed bounded recovery only"
+    },
+    {
+      "persisted_field": "recovery_action",
+      "current_graphql_field": "recoveryAction",
+      "m3_compact_graphql_field": "recoveryAction",
+      "implemented_in_current_schema": true,
+      "rule": "typed bounded recovery only"
+    },
+    {
+      "persisted_field": "signing_checkpoints[hosted_conversation.completed].canonical_json",
+      "current_graphql_field": "signingCheckpoints",
+      "m3_compact_graphql_field": "terminalDeclarationEvidence",
+      "implemented_in_current_schema": true,
+      "rule": "terminal evidence must bind active conversation id before publish"
+    },
+    {
+      "persisted_field": "publication",
+      "current_graphql_field": "publication",
+      "m3_compact_graphql_field": "publicationEvidence",
+      "implemented_in_current_schema": true,
+      "rule": "only present after Host publication and Lesser binding"
+    },
+    {
+      "persisted_field": "correlation.*",
+      "current_graphql_field": "correlation",
+      "m3_compact_graphql_field": "correlation",
+      "implemented_in_current_schema": true,
+      "rule": "carry idempotency/correlation/restart supersession ids"
+    },
+    {
+      "persisted_field": "last_host_request_id",
+      "current_graphql_field": "lastHostRequestId",
+      "m3_compact_graphql_field": "lastHostRequestId",
+      "implemented_in_current_schema": true,
+      "rule": "latest Host request id is diagnostic only, never terminal evidence by itself"
+    }
+  ],
+  "canonical_host_statuses": [
+    "no_registration",
+    "registration_active_no_conversation",
+    "in_progress",
+    "assistant_turn_ready",
+    "declaration_extraction_pending",
+    "declaration_ready",
+    "failed",
+    "published_bound"
+  ],
+  "invariants": [
+    {
+      "id": "in_progress_is_progress",
+      "rule": "Host status in_progress projects to CONVERSATION progress and never HOST_RESPONSE_INVALID or error.host_unavailable."
+    },
+    {
+      "id": "persist_conversation_id_early",
+      "rule": "Whenever Host supplies conversation_id, Lesser persists host_conversation_id before returning a next action."
+    },
+    {
+      "id": "one_server_authored_next_action",
+      "rule": "Every projection response has exactly one typedNextAction selected by Lesser; clients do not infer hidden Host state."
+    },
+    {
+      "id": "publish_requires_terminal_declaration_evidence",
+      "rule": "PUBLISH_HOSTED_SOUL is impossible without active-conversation terminal declaration evidence."
+    },
+    {
+      "id": "typed_bounded_recovery",
+      "rule": "Recovery uses REFRESH_STATE, RETRY_SAME_STEP, RESTART_SOUL_BOOTSTRAP, or OPERATOR_ACTION_REQUIRED only."
+    },
+    {
+      "id": "restart_supersedes",
+      "rule": "Restart creates a new attempt and records supersededHostRegistrationId/supersededHostConversationId instead of mutating history."
+    }
+  ],
+  "rows": [
+    {
+      "host_status": "no_registration",
+      "label": "no registration",
+      "host_status_source": "lesser_local_projection",
+      "accepted_host_statuses": [],
+      "description": "No Lesser hosted bootstrap projection and no Host registration are present for the local body.",
+      "phase": "NOT_STARTED",
+      "status": "not_started",
+      "typed_next_action_options": [
+        "START_HOSTED_BOOTSTRAP"
+      ],
+      "example_typed_next_action": "START_HOSTED_BOOTSTRAP",
+      "recovery": null,
+      "host_ids": {
+        "host_registration_id": "absent",
+        "host_soul_agent_id": "absent",
+        "host_conversation_id": "absent"
+      },
+      "terminal_declaration_evidence": "absent",
+      "publication_evidence": "absent",
+      "publish_gate": "blocked:no_host_registration",
+      "example": {
+        "host": null,
+        "lesserGraphql": {
+          "state": {
+            "username": "drone-ada",
+            "bodyId": "drone-ada",
+            "hostRegistrationId": null,
+            "hostSoulAgentId": null,
+            "hostConversationId": null,
+            "bootstrapMode": "HOSTED",
+            "authorityModel": "INSTANCE_TRUST",
+            "anchorState": "HOSTED_OFFCHAIN",
+            "phase": "NOT_STARTED",
+            "state": "not_started",
+            "typedNextAction": "START_HOSTED_BOOTSTRAP",
+            "recoveryCategory": null,
+            "recoveryAction": null,
+            "retryable": false,
+            "restartRequired": false,
+            "restartAvailable": true,
+            "signingCheckpoints": [],
+            "terminalDeclarationEvidence": null,
+            "publication": null,
+            "error": null,
+            "correlation": {
+              "correlationKey": "p49-example-correlation",
+              "beginIdempotencyKey": null,
+              "conversationIdempotencyKey": null,
+              "finalizeIdempotencyKey": null,
+              "restartIdempotencyKey": null,
+              "recoveryAttemptId": null,
+              "supersededHostRegistrationId": null,
+              "supersededHostConversationId": null,
+              "lastHostRequestId": null
+            },
+            "lastHostRequestId": null
+          },
+          "publishGate": {
+            "canPublishHostedSoul": false,
+            "reason": "blocked:no_host_registration",
+            "requiresActiveConversationTerminalDeclarationEvidence": true
+          }
+        }
+      }
+    },
+    {
+      "host_status": "registration_active_no_conversation",
+      "label": "registration active, no conversation",
+      "host_status_source": "lesser_projection_from_host_registration",
+      "accepted_host_statuses": [
+        "registration_active"
+      ],
+      "description": "Host registration and hosted soul agent id exist, but Host has not created a durable genesis conversation yet.",
+      "phase": "CONVERSATION",
+      "status": "conversation.registration_active",
+      "typed_next_action_options": [
+        "SEND_HOSTED_SOUL_GENESIS_MESSAGE"
+      ],
+      "example_typed_next_action": "SEND_HOSTED_SOUL_GENESIS_MESSAGE",
+      "recovery": null,
+      "host_ids": {
+        "host_registration_id": "required:persisted_after_startHostedSoulBootstrap",
+        "host_soul_agent_id": "required:persisted_after_startHostedSoulBootstrap",
+        "host_conversation_id": "absent_until_host_creates_conversation"
+      },
+      "terminal_declaration_evidence": "absent",
+      "publication_evidence": "absent",
+      "publish_gate": "blocked:no_host_conversation",
+      "example": {
+        "host": {
+          "registration_id": "hreg_example_001",
+          "agent_id": "hsoul_example_001",
+          "conversation_id": null,
+          "status": "registration_active",
+          "request_id": "host-req-start-001"
+        },
+        "lesserGraphql": {
+          "state": {
+            "username": "drone-ada",
+            "bodyId": "drone-ada",
+            "hostRegistrationId": "hreg_example_001",
+            "hostSoulAgentId": "hsoul_example_001",
+            "hostConversationId": null,
+            "bootstrapMode": "HOSTED",
+            "authorityModel": "INSTANCE_TRUST",
+            "anchorState": "HOSTED_OFFCHAIN",
+            "phase": "CONVERSATION",
+            "state": "conversation.registration_active",
+            "typedNextAction": "SEND_HOSTED_SOUL_GENESIS_MESSAGE",
+            "recoveryCategory": null,
+            "recoveryAction": null,
+            "retryable": false,
+            "restartRequired": false,
+            "restartAvailable": true,
+            "signingCheckpoints": [],
+            "terminalDeclarationEvidence": null,
+            "publication": null,
+            "error": null,
+            "correlation": {
+              "correlationKey": "p49-example-correlation",
+              "beginIdempotencyKey": "idem-begin-example",
+              "conversationIdempotencyKey": null,
+              "finalizeIdempotencyKey": null,
+              "restartIdempotencyKey": null,
+              "recoveryAttemptId": null,
+              "supersededHostRegistrationId": null,
+              "supersededHostConversationId": null,
+              "lastHostRequestId": "host-req-start-001"
+            },
+            "lastHostRequestId": "host-req-start-001"
+          },
+          "publishGate": {
+            "canPublishHostedSoul": false,
+            "reason": "blocked:no_host_conversation",
+            "requiresActiveConversationTerminalDeclarationEvidence": true
+          }
+        }
+      }
+    },
+    {
+      "host_status": "in_progress",
+      "label": "in_progress",
+      "host_status_source": "host_conversation_status",
+      "accepted_host_statuses": [
+        "in_progress"
+      ],
+      "description": "Host has durably created or resumed a conversation/turn, but terminal declaration evidence does not exist yet.",
+      "phase": "CONVERSATION",
+      "status": "conversation.in_progress",
+      "typed_next_action_options": [
+        "REFRESH_STATE",
+        "SEND_HOSTED_SOUL_GENESIS_MESSAGE"
+      ],
+      "example_typed_next_action": "REFRESH_STATE",
+      "recovery": {
+        "kind": "poll",
+        "category": "REFRESH_STATE",
+        "action": "REFRESH_STATE",
+        "boundedBy": "client backoff plus server-authored lastHostRequestId diagnostics"
+      },
+      "host_ids": {
+        "host_registration_id": "required:persisted",
+        "host_soul_agent_id": "required:persisted",
+        "host_conversation_id": "required:persist_early_before_returning_next_action"
+      },
+      "terminal_declaration_evidence": "absent",
+      "publication_evidence": "absent",
+      "publish_gate": "blocked:conversation_in_progress",
+      "example": {
+        "host": {
+          "registration_id": "hreg_example_001",
+          "agent_id": "hsoul_example_001",
+          "conversation_id": "hconv_example_001",
+          "status": "in_progress",
+          "latest_turn_id": "turn_user_001",
+          "message_count": 1,
+          "produced_declarations": null,
+          "request_id": "host-req-turn-001"
+        },
+        "lesserGraphql": {
+          "state": {
+            "username": "drone-ada",
+            "bodyId": "drone-ada",
+            "hostRegistrationId": "hreg_example_001",
+            "hostSoulAgentId": "hsoul_example_001",
+            "hostConversationId": "hconv_example_001",
+            "bootstrapMode": "HOSTED",
+            "authorityModel": "INSTANCE_TRUST",
+            "anchorState": "HOSTED_OFFCHAIN",
+            "phase": "CONVERSATION",
+            "state": "conversation.in_progress",
+            "typedNextAction": "REFRESH_STATE",
+            "recoveryCategory": "REFRESH_STATE",
+            "recoveryAction": "REFRESH_STATE",
+            "retryable": false,
+            "restartRequired": false,
+            "restartAvailable": true,
+            "signingCheckpoints": [],
+            "terminalDeclarationEvidence": null,
+            "publication": null,
+            "error": null,
+            "correlation": {
+              "correlationKey": "p49-example-correlation",
+              "beginIdempotencyKey": "idem-begin-example",
+              "conversationIdempotencyKey": "idem-conversation-example",
+              "finalizeIdempotencyKey": null,
+              "restartIdempotencyKey": null,
+              "recoveryAttemptId": null,
+              "supersededHostRegistrationId": null,
+              "supersededHostConversationId": null,
+              "lastHostRequestId": "host-req-turn-001"
+            },
+            "lastHostRequestId": "host-req-turn-001"
+          },
+          "publishGate": {
+            "canPublishHostedSoul": false,
+            "reason": "blocked:conversation_in_progress",
+            "requiresActiveConversationTerminalDeclarationEvidence": true
+          }
+        }
+      }
+    },
+    {
+      "host_status": "assistant_turn_ready",
+      "label": "assistant_turn_ready",
+      "host_status_source": "host_conversation_status",
+      "accepted_host_statuses": [
+        "assistant_turn_ready"
+      ],
+      "description": "Host has persisted an assistant response. Lesser must still wait for declaration completion before publish.",
+      "phase": "CONVERSATION",
+      "status": "conversation.assistant_turn_ready",
+      "typed_next_action_options": [
+        "SEND_HOSTED_SOUL_GENESIS_MESSAGE",
+        "COMPLETE_HOSTED_SOUL_GENESIS"
+      ],
+      "example_typed_next_action": "COMPLETE_HOSTED_SOUL_GENESIS",
+      "recovery": null,
+      "host_ids": {
+        "host_registration_id": "required:persisted",
+        "host_soul_agent_id": "required:persisted",
+        "host_conversation_id": "required:persist_early_before_returning_next_action"
+      },
+      "terminal_declaration_evidence": "absent",
+      "publication_evidence": "absent",
+      "publish_gate": "blocked:terminal_declaration_evidence_absent",
+      "example": {
+        "host": {
+          "registration_id": "hreg_example_001",
+          "agent_id": "hsoul_example_001",
+          "conversation_id": "hconv_example_001",
+          "status": "assistant_turn_ready",
+          "latest_turn_id": "turn_assistant_001",
+          "message_count": 2,
+          "produced_declarations": null,
+          "request_id": "host-req-turn-002"
+        },
+        "lesserGraphql": {
+          "state": {
+            "username": "drone-ada",
+            "bodyId": "drone-ada",
+            "hostRegistrationId": "hreg_example_001",
+            "hostSoulAgentId": "hsoul_example_001",
+            "hostConversationId": "hconv_example_001",
+            "bootstrapMode": "HOSTED",
+            "authorityModel": "INSTANCE_TRUST",
+            "anchorState": "HOSTED_OFFCHAIN",
+            "phase": "CONVERSATION",
+            "state": "conversation.assistant_turn_ready",
+            "typedNextAction": "COMPLETE_HOSTED_SOUL_GENESIS",
+            "recoveryCategory": null,
+            "recoveryAction": null,
+            "retryable": false,
+            "restartRequired": false,
+            "restartAvailable": true,
+            "signingCheckpoints": [],
+            "terminalDeclarationEvidence": null,
+            "publication": null,
+            "error": null,
+            "correlation": {
+              "correlationKey": "p49-example-correlation",
+              "beginIdempotencyKey": "idem-begin-example",
+              "conversationIdempotencyKey": "idem-conversation-example",
+              "finalizeIdempotencyKey": null,
+              "restartIdempotencyKey": null,
+              "recoveryAttemptId": null,
+              "supersededHostRegistrationId": null,
+              "supersededHostConversationId": null,
+              "lastHostRequestId": "host-req-turn-002"
+            },
+            "lastHostRequestId": "host-req-turn-002"
+          },
+          "publishGate": {
+            "canPublishHostedSoul": false,
+            "reason": "blocked:terminal_declaration_evidence_absent",
+            "requiresActiveConversationTerminalDeclarationEvidence": true
+          }
+        }
+      }
+    },
+    {
+      "host_status": "declaration_extraction_pending",
+      "label": "declaration_extraction_pending",
+      "host_status_source": "host_conversation_status",
+      "accepted_host_statuses": [
+        "declaration_extraction_pending"
+      ],
+      "description": "Host accepted completion/extraction but produced declarations are not durable and valid yet.",
+      "phase": "CONVERSATION",
+      "status": "conversation.declaration_extraction_pending",
+      "typed_next_action_options": [
+        "REFRESH_STATE"
+      ],
+      "example_typed_next_action": "REFRESH_STATE",
+      "recovery": {
+        "kind": "poll",
+        "category": "REFRESH_STATE",
+        "action": "REFRESH_STATE",
+        "boundedBy": "client backoff plus server-authored lastHostRequestId diagnostics"
+      },
+      "host_ids": {
+        "host_registration_id": "required:persisted",
+        "host_soul_agent_id": "required:persisted",
+        "host_conversation_id": "required:persist_early_before_returning_next_action"
+      },
+      "terminal_declaration_evidence": "absent",
+      "publication_evidence": "absent",
+      "publish_gate": "blocked:declaration_extraction_pending",
+      "example": {
+        "host": {
+          "registration_id": "hreg_example_001",
+          "agent_id": "hsoul_example_001",
+          "conversation_id": "hconv_example_001",
+          "status": "declaration_extraction_pending",
+          "latest_turn_id": "turn_assistant_001",
+          "message_count": 2,
+          "produced_declarations": null,
+          "request_id": "host-req-complete-001"
+        },
+        "lesserGraphql": {
+          "state": {
+            "username": "drone-ada",
+            "bodyId": "drone-ada",
+            "hostRegistrationId": "hreg_example_001",
+            "hostSoulAgentId": "hsoul_example_001",
+            "hostConversationId": "hconv_example_001",
+            "bootstrapMode": "HOSTED",
+            "authorityModel": "INSTANCE_TRUST",
+            "anchorState": "HOSTED_OFFCHAIN",
+            "phase": "CONVERSATION",
+            "state": "conversation.declaration_extraction_pending",
+            "typedNextAction": "REFRESH_STATE",
+            "recoveryCategory": "REFRESH_STATE",
+            "recoveryAction": "REFRESH_STATE",
+            "retryable": false,
+            "restartRequired": false,
+            "restartAvailable": true,
+            "signingCheckpoints": [],
+            "terminalDeclarationEvidence": null,
+            "publication": null,
+            "error": null,
+            "correlation": {
+              "correlationKey": "p49-example-correlation",
+              "beginIdempotencyKey": "idem-begin-example",
+              "conversationIdempotencyKey": "idem-conversation-example",
+              "finalizeIdempotencyKey": null,
+              "restartIdempotencyKey": null,
+              "recoveryAttemptId": null,
+              "supersededHostRegistrationId": null,
+              "supersededHostConversationId": null,
+              "lastHostRequestId": "host-req-complete-001"
+            },
+            "lastHostRequestId": "host-req-complete-001"
+          },
+          "publishGate": {
+            "canPublishHostedSoul": false,
+            "reason": "blocked:declaration_extraction_pending",
+            "requiresActiveConversationTerminalDeclarationEvidence": true
+          }
+        }
+      }
+    },
+    {
+      "host_status": "declaration_ready",
+      "label": "declaration_ready",
+      "host_status_source": "host_conversation_status",
+      "accepted_host_statuses": [
+        "declaration_ready",
+        "completed"
+      ],
+      "description": "Host has durable produced declarations for the active conversation. This is the first publish-eligible row.",
+      "phase": "FINALIZE",
+      "status": "conversation.declaration_ready",
+      "typed_next_action_options": [
+        "PUBLISH_HOSTED_SOUL"
+      ],
+      "example_typed_next_action": "PUBLISH_HOSTED_SOUL",
+      "recovery": null,
+      "host_ids": {
+        "host_registration_id": "required:persisted",
+        "host_soul_agent_id": "required:persisted",
+        "host_conversation_id": "required:persist_early_before_returning_next_action"
+      },
+      "terminal_declaration_evidence": "present:active_conversation",
+      "publication_evidence": "absent",
+      "publish_gate": "allowed:active_conversation_terminal_declaration_evidence",
+      "example": {
+        "host": {
+          "registration_id": "hreg_example_001",
+          "agent_id": "hsoul_example_001",
+          "conversation_id": "hconv_example_001",
+          "status": "declaration_ready",
+          "latest_turn_id": "turn_assistant_001",
+          "message_count": 2,
+          "produced_declarations": {
+            "title": "Hosted soul declaration for drone-ada",
+            "declarations_hash": "sha256:7af7a1c0f7c74c872a3a8a0a3e0af49a4a7c7f1f9b59f6827b1849d5f3f3a001"
+          },
+          "request_id": "host-req-complete-002"
+        },
+        "lesserGraphql": {
+          "state": {
+            "username": "drone-ada",
+            "bodyId": "drone-ada",
+            "hostRegistrationId": "hreg_example_001",
+            "hostSoulAgentId": "hsoul_example_001",
+            "hostConversationId": "hconv_example_001",
+            "bootstrapMode": "HOSTED",
+            "authorityModel": "INSTANCE_TRUST",
+            "anchorState": "HOSTED_OFFCHAIN",
+            "phase": "FINALIZE",
+            "state": "conversation.declaration_ready",
+            "typedNextAction": "PUBLISH_HOSTED_SOUL",
+            "recoveryCategory": null,
+            "recoveryAction": null,
+            "retryable": false,
+            "restartRequired": false,
+            "restartAvailable": true,
+            "signingCheckpoints": [
+              {
+                "name": "hosted_conversation",
+                "status": "completed",
+                "canonicalJson": "{\"conversation_id\":\"hconv_example_001\",\"declarations_hash\":\"sha256:7af7a1c0f7c74c872a3a8a0a3e0af49a4a7c7f1f9b59f6827b1849d5f3f3a001\"}",
+                "hostRequestId": "host-req-complete-002",
+                "completedAt": "2026-06-21T12:00:00Z"
+              }
+            ],
+            "terminalDeclarationEvidence": {
+              "conversationId": "hconv_example_001",
+              "hostStatus": "declaration_ready",
+              "hostRequestId": "host-req-complete-002",
+              "declarationsHash": "sha256:7af7a1c0f7c74c872a3a8a0a3e0af49a4a7c7f1f9b59f6827b1849d5f3f3a001",
+              "producedDeclarationsPreview": {
+                "title": "Hosted soul declaration for drone-ada",
+                "declarationCount": 3
+              }
+            },
+            "publication": null,
+            "error": null,
+            "correlation": {
+              "correlationKey": "p49-example-correlation",
+              "beginIdempotencyKey": "idem-begin-example",
+              "conversationIdempotencyKey": "idem-conversation-example",
+              "finalizeIdempotencyKey": "idem-finalize-example",
+              "restartIdempotencyKey": null,
+              "recoveryAttemptId": null,
+              "supersededHostRegistrationId": null,
+              "supersededHostConversationId": null,
+              "lastHostRequestId": "host-req-complete-002"
+            },
+            "lastHostRequestId": "host-req-complete-002"
+          },
+          "publishGate": {
+            "canPublishHostedSoul": true,
+            "reason": "allowed:active_conversation_terminal_declaration_evidence",
+            "requiresActiveConversationTerminalDeclarationEvidence": true
+          }
+        }
+      }
+    },
+    {
+      "host_status": "failed",
+      "label": "failed",
+      "host_status_source": "host_conversation_status",
+      "accepted_host_statuses": [
+        "failed"
+      ],
+      "description": "Host reports a typed terminal or recoverable failure. Lesser may retry or restart only through a bounded recovery action.",
+      "phase": "ERROR",
+      "status": "error.host_failed",
+      "typed_next_action_options": [
+        "RETRY_SAME_STEP",
+        "RESTART_SOUL_BOOTSTRAP"
+      ],
+      "example_typed_next_action": "RETRY_SAME_STEP",
+      "recovery": {
+        "kind": "typed",
+        "category": "RETRY_SAME_STEP",
+        "action": "RETRY_SAME_STEP",
+        "boundedBy": "Host failure retryability; restart requires a new recoveryAttemptId and supersedes ids",
+        "alternatives": [
+          "RESTART_SOUL_BOOTSTRAP",
+          "OPERATOR_ACTION_REQUIRED"
+        ]
+      },
+      "host_ids": {
+        "host_registration_id": "required:persisted",
+        "host_soul_agent_id": "required:persisted",
+        "host_conversation_id": "required:persist_early_before_returning_next_action"
+      },
+      "terminal_declaration_evidence": "absent",
+      "publication_evidence": "absent",
+      "publish_gate": "blocked:host_failure",
+      "example": {
+        "host": {
+          "registration_id": "hreg_example_001",
+          "agent_id": "hsoul_example_001",
+          "conversation_id": "hconv_example_001",
+          "status": "failed",
+          "failure": {
+            "code": "HOST_CONVERSATION_FAILED",
+            "message": "assistant turn failed before declarations were produced",
+            "retryable": true
+          },
+          "request_id": "host-req-failed-001"
+        },
+        "lesserGraphql": {
+          "state": {
+            "username": "drone-ada",
+            "bodyId": "drone-ada",
+            "hostRegistrationId": "hreg_example_001",
+            "hostSoulAgentId": "hsoul_example_001",
+            "hostConversationId": "hconv_example_001",
+            "bootstrapMode": "HOSTED",
+            "authorityModel": "INSTANCE_TRUST",
+            "anchorState": "HOSTED_OFFCHAIN",
+            "phase": "ERROR",
+            "state": "error.host_failed",
+            "typedNextAction": "RETRY_SAME_STEP",
+            "recoveryCategory": "RETRY_SAME_STEP",
+            "recoveryAction": "RETRY_SAME_STEP",
+            "retryable": true,
+            "restartRequired": false,
+            "restartAvailable": true,
+            "signingCheckpoints": [],
+            "terminalDeclarationEvidence": null,
+            "publication": null,
+            "error": {
+              "code": "HOST_CONVERSATION_FAILED",
+              "message": "Host failed before producing declaration evidence.",
+              "source": "host",
+              "statusCode": 200,
+              "hostRequestId": "host-req-failed-001",
+              "recoveryCategory": "RETRY_SAME_STEP",
+              "recoveryAction": "RETRY_SAME_STEP",
+              "retryable": true,
+              "restartRequired": false
+            },
+            "correlation": {
+              "correlationKey": "p49-example-correlation",
+              "beginIdempotencyKey": "idem-begin-example",
+              "conversationIdempotencyKey": "idem-conversation-example",
+              "finalizeIdempotencyKey": null,
+              "restartIdempotencyKey": null,
+              "recoveryAttemptId": null,
+              "supersededHostRegistrationId": null,
+              "supersededHostConversationId": null,
+              "lastHostRequestId": "host-req-failed-001"
+            },
+            "lastHostRequestId": "host-req-failed-001"
+          },
+          "publishGate": {
+            "canPublishHostedSoul": false,
+            "reason": "blocked:host_failure",
+            "requiresActiveConversationTerminalDeclarationEvidence": true
+          }
+        }
+      }
+    },
+    {
+      "host_status": "published_bound",
+      "label": "published/bound",
+      "host_status_source": "host_publication_plus_lesser_binding",
+      "accepted_host_statuses": [
+        "published",
+        "bound"
+      ],
+      "description": "Host publication evidence exists and Lesser has bound the local body to the hosted soul agent id.",
+      "phase": "COMPLETE",
+      "status": "complete.bound",
+      "typed_next_action_options": [
+        "COMPLETE"
+      ],
+      "example_typed_next_action": "COMPLETE",
+      "recovery": null,
+      "host_ids": {
+        "host_registration_id": "required:persisted",
+        "host_soul_agent_id": "required:persisted",
+        "host_conversation_id": "required:persist_early_before_returning_next_action"
+      },
+      "terminal_declaration_evidence": "present:active_conversation",
+      "publication_evidence": "present:host_publication_and_lesser_binding",
+      "publish_gate": "complete:already_published_bound",
+      "example": {
+        "host": {
+          "registration_id": "hreg_example_001",
+          "agent_id": "hsoul_example_001",
+          "conversation_id": "hconv_example_001",
+          "status": "published",
+          "produced_declarations": {
+            "title": "Hosted soul declaration for drone-ada",
+            "declarations_hash": "sha256:7af7a1c0f7c74c872a3a8a0a3e0af49a4a7c7f1f9b59f6827b1849d5f3f3a001"
+          },
+          "publication": {
+            "agentId": "hsoul_example_001",
+            "publishedVersion": 1,
+            "authorityModel": "INSTANCE_TRUST",
+            "registrationUri": "s3://lesser-hosted-souls/example/hreg_example_001/registration.json",
+            "versionedRegistrationUri": "s3://lesser-hosted-souls/example/hreg_example_001/v1/registration.json",
+            "anchorState": "hosted_offchain",
+            "publishedAt": "2026-06-21T12:05:00Z"
+          },
+          "request_id": "host-req-publish-001"
+        },
+        "lesserGraphql": {
+          "state": {
+            "username": "drone-ada",
+            "bodyId": "drone-ada",
+            "hostRegistrationId": "hreg_example_001",
+            "hostSoulAgentId": "hsoul_example_001",
+            "hostConversationId": "hconv_example_001",
+            "bootstrapMode": "HOSTED",
+            "authorityModel": "INSTANCE_TRUST",
+            "anchorState": "HOSTED_OFFCHAIN",
+            "phase": "COMPLETE",
+            "state": "complete.bound",
+            "typedNextAction": "COMPLETE",
+            "recoveryCategory": null,
+            "recoveryAction": null,
+            "retryable": false,
+            "restartRequired": false,
+            "restartAvailable": false,
+            "signingCheckpoints": [
+              {
+                "name": "hosted_conversation",
+                "status": "completed",
+                "canonicalJson": "{\"conversation_id\":\"hconv_example_001\",\"declarations_hash\":\"sha256:7af7a1c0f7c74c872a3a8a0a3e0af49a4a7c7f1f9b59f6827b1849d5f3f3a001\"}",
+                "hostRequestId": "host-req-complete-002",
+                "completedAt": "2026-06-21T12:00:00Z"
+              }
+            ],
+            "terminalDeclarationEvidence": {
+              "conversationId": "hconv_example_001",
+              "hostStatus": "declaration_ready",
+              "hostRequestId": "host-req-complete-002",
+              "declarationsHash": "sha256:7af7a1c0f7c74c872a3a8a0a3e0af49a4a7c7f1f9b59f6827b1849d5f3f3a001",
+              "producedDeclarationsPreview": {
+                "title": "Hosted soul declaration for drone-ada",
+                "declarationCount": 3
+              }
+            },
+            "publication": {
+              "agentId": "hsoul_example_001",
+              "publishedVersion": 1,
+              "authorityModel": "INSTANCE_TRUST",
+              "registrationUri": "s3://lesser-hosted-souls/example/hreg_example_001/registration.json",
+              "versionedRegistrationUri": "s3://lesser-hosted-souls/example/hreg_example_001/v1/registration.json",
+              "anchorState": "hosted_offchain",
+              "publishedAt": "2026-06-21T12:05:00Z"
+            },
+            "error": null,
+            "correlation": {
+              "correlationKey": "p49-example-correlation",
+              "beginIdempotencyKey": "idem-begin-example",
+              "conversationIdempotencyKey": "idem-conversation-example",
+              "finalizeIdempotencyKey": "idem-finalize-example",
+              "restartIdempotencyKey": null,
+              "recoveryAttemptId": null,
+              "supersededHostRegistrationId": null,
+              "supersededHostConversationId": null,
+              "lastHostRequestId": "host-req-publish-001"
+            },
+            "lastHostRequestId": "host-req-publish-001"
+          },
+          "publishGate": {
+            "canPublishHostedSoul": false,
+            "reason": "complete:already_published_bound",
+            "requiresActiveConversationTerminalDeclarationEvidence": true
+          }
+        }
+      }
+    }
+  ]
+}

--- a/docs/lesser/contracts/hosted-soul-genesis-projection.md
+++ b/docs/lesser/contracts/hosted-soul-genesis-projection.md
@@ -1,0 +1,278 @@
+# Hosted Soul Genesis GraphQL Projection Table
+
+Date: 2026-06-21
+Repo: `equaltoai/lesser`
+Project: Project 49 — Durable Async Hosted Soul Genesis
+Milestone: M1.2 — Lock Lesser GraphQL projection table for hosted genesis statuses
+Tracking issue: `equaltoai/lesser#1173`
+Parent epic: `equaltoai/lesser-host#737`
+Host dependency: `equaltoai/lesser-host#730` (M1.1)
+
+This contract locks how Lesser projects Host durable hosted-genesis state into the Lesser GraphQL soul bootstrap surface.
+It exists to prevent the observed live failure where Host returned `200 + in_progress` with a durable conversation id, but
+Lesser collapsed that progress into `phase=ERROR`, `state=error.host_unavailable`, `HOST_RESPONSE_INVALID`, and lost the
+Host conversation id.
+
+M1.2 is a contract/spec lock only. It does **not** implement the M3 resolver/state-machine, mutate Host/Greater/Sim, deploy,
+or change publish-path runtime behavior.
+
+## Source and Host alignment
+
+Authoritative project brief: `/home/aron/ai-workspace/codebases/equaltoai/agents/arch/projects/project49-async-hosted-genesis/contract-and-brief.md`.
+
+Host M1.1 owns final Host JSON field/status names. As of the M1.2 lock on 2026-06-21, no open Host M1.1 PR was observed;
+therefore this Lesser table locks to the shared names from the Project 49 brief:
+
+- `in_progress`
+- `assistant_turn_ready`
+- `declaration_extraction_pending`
+- `declaration_ready`
+- `failed`
+- `published` / `bound`
+
+If Host M1.1 lands different names, M3 must reconcile this table and fixture before implementing resolver behavior.
+No Lesser implementation should start against an unstated Host status.
+
+### Project 51 M5 Host v1.0.6 producer alignment
+
+Project 51 M5 updates the runtime producer contract against the public Host release `lesser-host@v1.0.6` and keeps
+Lesser consuming Host's AppTheory-backed `HostedGenesisSession` projection as the source of truth. AppTheory MicroVM
+registry/lifecycle state remains execution/cache state only; Lesser does not create browser-authored retry state, local
+MicroVM recovery substitutes, or LocalStorage/sessionStorage recovery authority.
+
+The Host `v1.0.6` sources inspected for this alignment are:
+
+- `docs/contracts/hosted-genesis-conversation.md`
+- `docs/spec/v3/schemas/hosted-genesis.conversation.response.schema.json`
+- `docs/spec/v3/fixtures/hosted-genesis.conversation.in-progress.example.json`
+- `docs/spec/v3/fixtures/hosted-genesis.conversation.completed-declaration-ready.example.json`
+- `docs/spec/v3/fixtures/hosted-genesis.conversation.failed.example.json`
+- `docs/runbooks/hosted-genesis-sqs-demotion.md`
+- `docs/adr/0009-app-theory-microvm-lab-gates.md`
+
+M5 locks these Lesser-side producer rules:
+
+1. `conversation.conversation_id` is persisted as soon as Host returns it, including `HTTP 202` / `status=in_progress`.
+2. Host `failure.recovery.action` is the only recovery-truth input. Lesser projects the locked actions
+   `refresh_state`, `retry_same_step`, `restart_soul_bootstrap`, and `operator_action` into bounded GraphQL
+   `typedNextAction` / `recoveryCategory` / `recoveryAction` values. Host `v1.0.6` does not expose a public
+   MicroVM resume/restart recovery action; Lesser must not invent one. Failed Host snapshots that omit a locked
+   recovery action are treated as invalid Host responses rather than deriving retry/restart behavior locally.
+3. Publish/finalize readiness requires `status=declaration_ready` plus active-conversation Host declaration evidence.
+   The Host `produced_declarations` envelope is validated for `source=host_conversation`, registration id,
+   conversation id, agent id, message count, request id, declaration id/hash, produced timestamp, and declaration
+   shape before Lesser stores a compact declaration checkpoint.
+4. Browser-visible GraphQL state remains sanitized: no Host bearer tokens, Instance API keys, raw Host routes,
+   MicroVM endpoints/tokens, provider keys/responses, wallet signatures, SSM values, raw transcripts, or raw provider
+   responses are exposed.
+
+## Existing GraphQL operations in scope
+
+The hosted operations already exist in `docs/contracts/graphql-schema.graphql` and are the only operations this table
+projects for:
+
+- `startHostedSoulBootstrap`
+- `sendHostedSoulGenesisMessage`
+- `completeHostedSoulGenesis`
+- `publishHostedSoul`
+- `restartSoulBootstrap`
+
+## Locked projection fields
+
+The published GraphQL schema currently exposes the core projection through `SoulBootstrapState`:
+`hostRegistrationId`, `hostSoulAgentId`, `hostConversationId`, `phase`, `state`, `typedNextAction`, `recoveryCategory`,
+`recoveryAction`, `signingCheckpoints`, `publication`, `correlation`, and `lastHostRequestId`.
+
+M1.2 also locks the compact M3 names that client adapters can prepare for without changing this milestone's runtime:
+
+| Persisted Lesser field | Current GraphQL projection | Compact M3 projection name | Contract rule |
+| --- | --- | --- | --- |
+| `host_registration_id` | `hostRegistrationId` | `hostRegistrationId` | Persist once Host registration exists. |
+| `host_soul_agent_id` | `hostSoulAgentId` | `hostSoulAgentId` | Persist with Host registration. |
+| `host_conversation_id` | `hostConversationId` | `hostConversationId` | Persist early before returning any post-conversation next action. |
+| `phase` | `phase` | `phase` | Canonical Lesser phase from this table. |
+| `status` | `state` | `hostConversationStatus` | `state` remains string-compatible; compact Host status may be added additively in M3. |
+| `next_action` | `typedNextAction` | `typedNextAction` | Lesser authors exactly one next action per response. |
+| `recovery_category` | `recoveryCategory` | `recoveryCategory` | Typed bounded recovery only. |
+| `recovery_action` | `recoveryAction` | `recoveryAction` | Typed bounded recovery only. |
+| `terminal_declaration_evidence` | `signingCheckpoints` entry `hosted_conversation/completed` | `terminalDeclarationEvidence` | Must bind the active `hostConversationId` before publish. |
+| `publication_evidence` | `publication` | `publicationEvidence` | Present only after Host publication and Lesser binding. |
+| correlation/request ids | `correlation`, `lastHostRequestId` | same names | Diagnostics/idempotency only; request ids are not terminal evidence. |
+| restart supersession ids | `correlation.supersededHostRegistrationId`, `correlation.supersededHostConversationId` | same names | Restart supersedes prior ids instead of mutating history. |
+
+## Projection invariants
+
+1. `in_progress` is progress: it never maps to `HOST_RESPONSE_INVALID`, `error.host_unavailable`, or `ERROR`.
+2. Whenever Host supplies `conversation_id`, Lesser persists `host_conversation_id` before returning any next action.
+3. Every response has exactly one server-authored `typedNextAction`; UI clients do not infer hidden Host state.
+4. `PUBLISH_HOSTED_SOUL` is impossible without active-conversation terminal declaration evidence.
+5. Recovery is typed and bounded: refresh/poll, retry same step, restart with supersession ids, or operator action.
+6. Restart creates a new attempt and records superseded Host ids; it does not mutate historical Host state.
+7. HTTP status is transport state only. `200`/`202` is not terminal success without explicit Host status + evidence.
+
+## Canonical Host status projection table
+
+The machine-readable fixture with full examples for every row is checked in at
+`docs/contracts/examples/hosted-soul-genesis-projection-table.example.json`.
+
+| Host status | Lesser `phase` | Lesser `state` | Allowed `typedNextAction` values | Example action | Recovery | Host ids | Terminal declaration evidence | Publish gate |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| no registration | `NOT_STARTED` | `not_started` | `START_HOSTED_BOOTSTRAP` | `START_HOSTED_BOOTSTRAP` | - | none | absent | blocked: no Host registration |
+| registration active, no conversation | `CONVERSATION` | `conversation.registration_active` | `SEND_HOSTED_SOUL_GENESIS_MESSAGE` | `SEND_HOSTED_SOUL_GENESIS_MESSAGE` | - | `hostRegistrationId`, `hostSoulAgentId`; no conversation yet | absent | blocked: no Host conversation |
+| `in_progress` | `CONVERSATION` | `conversation.in_progress` | `REFRESH_STATE` or `SEND_HOSTED_SOUL_GENESIS_MESSAGE` | `REFRESH_STATE` | poll via `REFRESH_STATE` | registration id, soul agent id, and conversation id required; conversation id persists early | absent | blocked: conversation in progress |
+| `assistant_turn_ready` | `CONVERSATION` | `conversation.assistant_turn_ready` | `SEND_HOSTED_SOUL_GENESIS_MESSAGE` or `COMPLETE_HOSTED_SOUL_GENESIS` | `COMPLETE_HOSTED_SOUL_GENESIS` | - | registration id, soul agent id, and conversation id required | absent | blocked: terminal declaration evidence absent |
+| `declaration_extraction_pending` | `CONVERSATION` | `conversation.declaration_extraction_pending` | `REFRESH_STATE` | `REFRESH_STATE` | poll via `REFRESH_STATE` | registration id, soul agent id, and conversation id required | absent | blocked: extraction pending |
+| `declaration_ready` | `FINALIZE` (or `CONVERSATION` while rendering review) | `conversation.declaration_ready` | `PUBLISH_HOSTED_SOUL` | `PUBLISH_HOSTED_SOUL` | - | registration id, soul agent id, and conversation id required | present and bound to active conversation | allowed |
+| `failed` | `ERROR` | `error.host_failed` | `RETRY_SAME_STEP` or `RESTART_SOUL_BOOTSTRAP` | `RETRY_SAME_STEP` | typed/bounded | ids preserved if Host supplied them; restart records superseded ids | absent | blocked: Host failure |
+| `published` / `bound` (published/bound) | `COMPLETE` | `complete.bound` | `COMPLETE` | `COMPLETE` | - | active ids retained for diagnosis | terminal evidence retained | complete: already published and bound |
+
+## Per-row examples
+
+The examples below are abridged GraphQL projection excerpts. The fixture contains the corresponding Host envelope,
+correlation/request ids, evidence payloads, and publication evidence.
+
+### no registration
+
+```json
+{
+  "hostRegistrationId": null,
+  "hostSoulAgentId": null,
+  "hostConversationId": null,
+  "phase": "NOT_STARTED",
+  "state": "not_started",
+  "typedNextAction": "START_HOSTED_BOOTSTRAP",
+  "recoveryCategory": null,
+  "recoveryAction": null,
+  "terminalDeclarationEvidence": null,
+  "publication": null,
+  "publishGate": { "canPublishHostedSoul": false, "reason": "blocked:no_host_registration" }
+}
+```
+
+### registration active, no conversation
+
+```json
+{
+  "hostRegistrationId": "hreg_example_001",
+  "hostSoulAgentId": "hsoul_example_001",
+  "hostConversationId": null,
+  "phase": "CONVERSATION",
+  "state": "conversation.registration_active",
+  "typedNextAction": "SEND_HOSTED_SOUL_GENESIS_MESSAGE",
+  "terminalDeclarationEvidence": null,
+  "publishGate": { "canPublishHostedSoul": false, "reason": "blocked:no_host_conversation" }
+}
+```
+
+### in_progress
+
+```json
+{
+  "hostRegistrationId": "hreg_example_001",
+  "hostSoulAgentId": "hsoul_example_001",
+  "hostConversationId": "hconv_example_001",
+  "phase": "CONVERSATION",
+  "state": "conversation.in_progress",
+  "typedNextAction": "REFRESH_STATE",
+  "recoveryCategory": "REFRESH_STATE",
+  "recoveryAction": "REFRESH_STATE",
+  "lastHostRequestId": "host-req-turn-001",
+  "terminalDeclarationEvidence": null,
+  "publishGate": { "canPublishHostedSoul": false, "reason": "blocked:conversation_in_progress" }
+}
+```
+
+### assistant_turn_ready
+
+```json
+{
+  "hostRegistrationId": "hreg_example_001",
+  "hostSoulAgentId": "hsoul_example_001",
+  "hostConversationId": "hconv_example_001",
+  "phase": "CONVERSATION",
+  "state": "conversation.assistant_turn_ready",
+  "typedNextAction": "COMPLETE_HOSTED_SOUL_GENESIS",
+  "terminalDeclarationEvidence": null,
+  "publishGate": { "canPublishHostedSoul": false, "reason": "blocked:terminal_declaration_evidence_absent" }
+}
+```
+
+### declaration_extraction_pending
+
+```json
+{
+  "hostRegistrationId": "hreg_example_001",
+  "hostSoulAgentId": "hsoul_example_001",
+  "hostConversationId": "hconv_example_001",
+  "phase": "CONVERSATION",
+  "state": "conversation.declaration_extraction_pending",
+  "typedNextAction": "REFRESH_STATE",
+  "recoveryCategory": "REFRESH_STATE",
+  "recoveryAction": "REFRESH_STATE",
+  "terminalDeclarationEvidence": null,
+  "publishGate": { "canPublishHostedSoul": false, "reason": "blocked:declaration_extraction_pending" }
+}
+```
+
+### declaration_ready
+
+```json
+{
+  "hostRegistrationId": "hreg_example_001",
+  "hostSoulAgentId": "hsoul_example_001",
+  "hostConversationId": "hconv_example_001",
+  "phase": "FINALIZE",
+  "state": "conversation.declaration_ready",
+  "typedNextAction": "PUBLISH_HOSTED_SOUL",
+  "terminalDeclarationEvidence": {
+    "conversationId": "hconv_example_001",
+    "hostStatus": "declaration_ready",
+    "hostRequestId": "host-req-complete-002",
+    "declarationsHash": "sha256:7af7a1c0f7c74c872a3a8a0a3e0af49a4a7c7f1f9b59f6827b1849d5f3f3a001"
+  },
+  "publishGate": { "canPublishHostedSoul": true, "reason": "allowed:active_conversation_terminal_declaration_evidence" }
+}
+```
+
+### failed
+
+```json
+{
+  "hostRegistrationId": "hreg_example_001",
+  "hostSoulAgentId": "hsoul_example_001",
+  "hostConversationId": "hconv_example_001",
+  "phase": "ERROR",
+  "state": "error.host_failed",
+  "typedNextAction": "RETRY_SAME_STEP",
+  "recoveryCategory": "RETRY_SAME_STEP",
+  "recoveryAction": "RETRY_SAME_STEP",
+  "error": { "code": "HOST_CONVERSATION_FAILED", "source": "host", "retryable": true },
+  "terminalDeclarationEvidence": null,
+  "publishGate": { "canPublishHostedSoul": false, "reason": "blocked:host_failure" }
+}
+```
+
+### published / bound (published/bound)
+
+```json
+{
+  "hostRegistrationId": "hreg_example_001",
+  "hostSoulAgentId": "hsoul_example_001",
+  "hostConversationId": "hconv_example_001",
+  "phase": "COMPLETE",
+  "state": "complete.bound",
+  "typedNextAction": "COMPLETE",
+  "terminalDeclarationEvidence": { "conversationId": "hconv_example_001", "hostStatus": "declaration_ready" },
+  "publication": { "agentId": "hsoul_example_001", "publishedVersion": 1, "authorityModel": "INSTANCE_TRUST" },
+  "publishGate": { "canPublishHostedSoul": false, "reason": "complete:already_published_bound" }
+}
+```
+
+## Contract audit
+
+- Mastodon REST: no impact; no `/api/v1/*` shape changes.
+- GraphQL: no schema regeneration in M1.2; this is a file-only projection contract and fixture. Future M3 schema additions
+  must be additive and regenerated through `./lesser schema`.
+- ActivityPub / federation: no actor, inbox/outbox, signing, WebFinger, object, collection, or delivery changes.
+- DynamoDB schema: no PK/SK/GSI/TableTheory-tag changes in M1.2.
+- Sibling consumers: Greater M1.3 and Sim must be able to represent every row before M3 resolver work ships.

--- a/docs/lesser/contracts/testdata/hosted-genesis/v1.0.6/hosted-genesis.conversation.completed-declaration-ready.example.json
+++ b/docs/lesser/contracts/testdata/hosted-genesis/v1.0.6/hosted-genesis.conversation.completed-declaration-ready.example.json
@@ -1,0 +1,58 @@
+{
+  "version": "1",
+  "request_id": "req_hosted_genesis_02",
+  "conversation": {
+    "registration_id": "reg_01jzhostedgenesis",
+    "conversation_id": "conv_01jzhostedgenesis",
+    "agent_id": "0x2222222222222222222222222222222222222222222222222222222222222222",
+    "status": "declaration_ready",
+    "latest_turn_id": "turn_01jzhostedgenesis_assistant",
+    "message_count": 2,
+    "produced_declarations": {
+      "declaration_id": "decl_01jzhostedgenesis",
+      "declaration_hash": "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+      "produced_at": "2026-06-18T13:12:30Z",
+      "declarations": {
+        "selfDescription": {
+          "summary": "Demo hosted soul for a managed Lesser drone.",
+          "version": "v2"
+        },
+        "capabilities": [
+          {
+            "id": "chat",
+            "statement": "Can answer operator questions using its configured Lesser tools."
+          }
+        ],
+        "boundaries": [
+          {
+            "id": "no-credential-disclosure",
+            "category": "security",
+            "statement": "Will not disclose raw credentials, seed phrases, or Instance API keys."
+          }
+        ],
+        "transparency": {
+          "authority_model": "instance_trust",
+          "anchor_state": "hosted_offchain"
+        }
+      },
+      "evidence": {
+        "source": "host_conversation",
+        "registration_id": "reg_01jzhostedgenesis",
+        "conversation_id": "conv_01jzhostedgenesis",
+        "agent_id": "0x2222222222222222222222222222222222222222222222222222222222222222",
+        "message_count": 2,
+        "model": "openai:gpt-5.4",
+        "request_id": "req_hosted_genesis_02"
+      }
+    },
+    "request_id": "req_hosted_genesis_02",
+    "trace_ids": {
+      "host_request_id": "req_hosted_genesis_02",
+      "correlation_id": "lesser-bootstrap-01",
+      "idempotency_key": "idem-hosted-genesis-01"
+    },
+    "created_at": "2026-06-18T13:10:00Z",
+    "updated_at": "2026-06-18T13:12:30Z",
+    "completed_at": "2026-06-18T13:12:30Z"
+  }
+}

--- a/docs/lesser/contracts/testdata/hosted-genesis/v1.0.6/hosted-genesis.conversation.failed.example.json
+++ b/docs/lesser/contracts/testdata/hosted-genesis/v1.0.6/hosted-genesis.conversation.failed.example.json
@@ -1,0 +1,32 @@
+{
+  "version": "1",
+  "request_id": "req_hosted_genesis_03",
+  "conversation": {
+    "registration_id": "reg_01jzhostedgenesis",
+    "conversation_id": "conv_01jzhostedgenesis",
+    "agent_id": "0x2222222222222222222222222222222222222222222222222222222222222222",
+    "status": "failed",
+    "latest_turn_id": "turn_01jzhostedgenesis_user",
+    "message_count": 1,
+    "failure": {
+      "code": "llm_unavailable",
+      "message": "Assistant turn failed before declaration extraction.",
+      "retryable": true,
+      "recovery": {
+        "action": "retry_same_step",
+        "max_attempts": 3,
+        "retry_after_seconds": 30,
+        "reason": "provider_unavailable"
+      }
+    },
+    "request_id": "req_hosted_genesis_03",
+    "trace_ids": {
+      "host_request_id": "req_hosted_genesis_03",
+      "correlation_id": "lesser-bootstrap-01",
+      "idempotency_key": "idem-hosted-genesis-02"
+    },
+    "created_at": "2026-06-18T13:10:00Z",
+    "updated_at": "2026-06-18T13:11:00Z",
+    "completed_at": "2026-06-18T13:11:00Z"
+  }
+}

--- a/docs/lesser/contracts/testdata/hosted-genesis/v1.0.6/hosted-genesis.conversation.in-progress.example.json
+++ b/docs/lesser/contracts/testdata/hosted-genesis/v1.0.6/hosted-genesis.conversation.in-progress.example.json
@@ -1,0 +1,21 @@
+{
+  "version": "1",
+  "request_id": "req_hosted_genesis_01",
+  "conversation": {
+    "registration_id": "reg_01jzhostedgenesis",
+    "conversation_id": "conv_01jzhostedgenesis",
+    "agent_id": "0x2222222222222222222222222222222222222222222222222222222222222222",
+    "status": "in_progress",
+    "latest_turn_id": "turn_01jzhostedgenesis_user",
+    "message_count": 1,
+    "request_id": "req_hosted_genesis_01",
+    "trace_ids": {
+      "host_request_id": "req_hosted_genesis_01",
+      "correlation_id": "lesser-bootstrap-01",
+      "idempotency_key": "idem-hosted-genesis-01"
+    },
+    "poll_after_seconds": 2,
+    "created_at": "2026-06-18T13:10:00Z",
+    "updated_at": "2026-06-18T13:10:01Z"
+  }
+}

--- a/packages/adapters/src/__tests__/HostedSoulBootstrapProject49Representability.test.ts
+++ b/packages/adapters/src/__tests__/HostedSoulBootstrapProject49Representability.test.ts
@@ -1,3 +1,7 @@
+import { readFileSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
 import { describe, expect, it } from 'vitest';
 
 import {
@@ -18,10 +22,82 @@ import {
 	type HostedSoulBootstrapRecoveryAction,
 	type HostedSoulBootstrapRecoveryCategory,
 	type LesserHostHostedGenesisConversation,
+	type LesserHostHostedGenesisConversationResponse,
 } from '../soul/hostedBootstrap';
 
 const activeConversationId = project44SoulBootstrapIds.conversationId;
 const hostAgentId = '0x2222222222222222222222222222222222222222222222222222222222222222';
+const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), '../../../..');
+
+type ProjectionTableFixture = {
+	rows: Array<{
+		label: string;
+		host_status: string;
+		phase: string;
+		status: string;
+		example_typed_next_action: string;
+		publish_gate: string;
+		example: {
+			lesserGraphql: {
+				state: Record<string, unknown>;
+				publishGate?: {
+					canPublishHostedSoul: boolean;
+					reason: string;
+					requiresActiveConversationTerminalDeclarationEvidence: boolean;
+				};
+			};
+		};
+	}>;
+};
+
+type ProducerFixtureCase = {
+	label: string;
+	status: LesserHostHostedGenesisConversation['status'];
+	lesserPath: string;
+	hostPath: string;
+	inProgress: boolean;
+	declarationReady: boolean;
+	canPublish: boolean;
+};
+
+const releasedHostedGenesisFixtureCases = [
+	{
+		label: 'in_progress',
+		status: 'in_progress',
+		lesserPath:
+			'docs/lesser/contracts/testdata/hosted-genesis/v1.0.6/hosted-genesis.conversation.in-progress.example.json',
+		hostPath:
+			'docs/lesser-host/spec/v3/fixtures/hosted-genesis.conversation.in-progress.example.json',
+		inProgress: true,
+		declarationReady: false,
+		canPublish: false,
+	},
+	{
+		label: 'declaration_ready',
+		status: 'declaration_ready',
+		lesserPath:
+			'docs/lesser/contracts/testdata/hosted-genesis/v1.0.6/hosted-genesis.conversation.completed-declaration-ready.example.json',
+		hostPath:
+			'docs/lesser-host/spec/v3/fixtures/hosted-genesis.conversation.completed-declaration-ready.example.json',
+		inProgress: false,
+		declarationReady: true,
+		canPublish: true,
+	},
+	{
+		label: 'failed',
+		status: 'failed',
+		lesserPath:
+			'docs/lesser/contracts/testdata/hosted-genesis/v1.0.6/hosted-genesis.conversation.failed.example.json',
+		hostPath: 'docs/lesser-host/spec/v3/fixtures/hosted-genesis.conversation.failed.example.json',
+		inProgress: false,
+		declarationReady: false,
+		canPublish: false,
+	},
+] as const satisfies readonly ProducerFixtureCase[];
+
+const lesserProjectionTable = readJsonFixture<ProjectionTableFixture>(
+	'docs/lesser/contracts/examples/hosted-soul-genesis-projection-table.example.json'
+);
 
 const liveInProgressHostConversation = {
 	registration_id: project44SoulBootstrapIds.registrationId,
@@ -143,6 +219,105 @@ const hostStatusConversations = [
 ] as const;
 
 describe('Project 49 hosted genesis representability', () => {
+	it.each(releasedHostedGenesisFixtureCases)(
+		'consumes released Lesser v1.5.8 and Host v1.0.6 $label fixtures through fail-closed helpers',
+		(row) => {
+			const lesserFixtureText = readTextFixture(row.lesserPath);
+			const hostFixtureText = readTextFixture(row.hostPath);
+			expect(lesserFixtureText).toBe(hostFixtureText);
+
+			const hostFixture = JSON.parse(
+				hostFixtureText
+			) as LesserHostHostedGenesisConversationResponse;
+			const hostConversation = hostFixture.conversation;
+
+			expect(hostConversation.status).toBe(row.status);
+			expect(
+				isHostedSoulBootstrapInProgress(hostFixture, {
+					conversationId: hostConversation.conversation_id,
+				})
+			).toBe(row.inProgress);
+			expect(
+				isHostedSoulBootstrapDeclarationReady(hostFixture, {
+					conversationId: hostConversation.conversation_id,
+				})
+			).toBe(row.declarationReady);
+			expect(
+				canPublishHostedSoulBootstrap(hostFixture, {
+					conversationId: hostConversation.conversation_id,
+				})
+			).toBe(row.canPublish);
+
+			const summary = getHostedSoulBootstrapTerminalDeclarationEvidenceSummary(hostFixture, {
+				conversationId: hostConversation.conversation_id,
+			});
+			if (row.declarationReady) {
+				expect(summary).toMatchObject({
+					source: 'lesser_host_conversation',
+					conversationId: hostConversation.conversation_id,
+					hostStatus: 'declaration_ready',
+					hostRequestId: 'req_hosted_genesis_02',
+					declarationsHash:
+						'sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+					hostRegistrationId: 'reg_01jzhostedgenesis',
+					hostSoulAgentId: '0x2222222222222222222222222222222222222222222222222222222222222222',
+					declarationId: 'decl_01jzhostedgenesis',
+					producedAt: '2026-06-18T13:12:30Z',
+				});
+			} else {
+				expect(summary).toBeNull();
+			}
+		}
+	);
+
+	it('consumes the released Lesser v1.5.8 projection table without normalizing its sibling publishGate example', () => {
+		const projectedRows = new Map(lesserProjectionTable.rows.map((row) => [row.label, row]));
+		const expectedFixtureLabelByProjectionLabel = new Map([
+			['no registration', 'no registration'],
+			['registration active, no conversation', 'registration active, no conversation'],
+			['in_progress', 'in_progress'],
+			['assistant_turn_ready', 'assistant_turn_ready'],
+			['declaration_extraction_pending', 'declaration_extraction_pending'],
+			['declaration_ready', 'declaration_ready'],
+			['failed', 'failed retry same step'],
+			['published/bound', 'published/bound'],
+		]);
+
+		for (const [projectionLabel, fixtureLabel] of expectedFixtureLabelByProjectionLabel) {
+			const projectionRow = projectedRows.get(projectionLabel);
+			const representabilityFixture = project49HostedGenesisStatusFixtures.find(
+				(row) => row.label === fixtureLabel
+			);
+			expect(projectionRow, projectionLabel).toBeDefined();
+			expect(representabilityFixture, fixtureLabel).toBeDefined();
+			if (!projectionRow || !representabilityFixture) {
+				continue;
+			}
+
+			expect(representabilityFixture.hostStatus, projectionLabel).toBe(projectionRow.host_status);
+			expect(representabilityFixture.surface.state.phase, projectionLabel).toBe(
+				projectionRow.phase
+			);
+			expect(representabilityFixture.surface.state.state, projectionLabel).toBe(
+				projectionRow.status
+			);
+			expect(representabilityFixture.surface.state.typedNextAction, projectionLabel).toBe(
+				projectionRow.example_typed_next_action
+			);
+			expect(representabilityFixture.publishReason, projectionLabel).toBe(
+				projectionRow.publish_gate
+			);
+		}
+
+		const declarationReadyRow = projectedRows.get('declaration_ready');
+		expect(declarationReadyRow?.example.lesserGraphql.publishGate).toMatchObject({
+			canPublishHostedSoul: true,
+			reason: 'allowed:active_conversation_terminal_declaration_evidence',
+			requiresActiveConversationTerminalDeclarationEvidence: true,
+		});
+		expect(declarationReadyRow?.example.lesserGraphql.state['publishGate']).toBeUndefined();
+	});
+
 	it.each(project49HostedGenesisStatusFixtures)(
 		'models $label as a Lesser-hosted soul bootstrap projection row',
 		async (row) => {
@@ -415,4 +590,12 @@ function withRuntimeStateExtras(
 			...extras,
 		} as SoulBootstrapSurface['state'],
 	};
+}
+
+function readTextFixture(relativePath: string): string {
+	return readFileSync(resolve(repoRoot, relativePath), 'utf8');
+}
+
+function readJsonFixture<T>(relativePath: string): T {
+	return JSON.parse(readTextFixture(relativePath)) as T;
 }


### PR DESCRIPTION
## Release promotion

Promotes `staging` to `main` for the Project #51 M5 Greater contract-sync release.

Included staging delta:

- #868 — sync Hosted Genesis contracts after released `lesser@v1.5.8` and `lesser-host@v1.0.6`.
- Pins Greater contract snapshots to:
  - Lesser `v1.5.8` / `4c01567104f59ae9cc1dee4ccf2e0d82739aa2ae`
  - Lesser Host `v1.0.6` / `d0213786ac8dc90ceaef3ae49850b4078ab38e68`
- Adds byte-for-byte Lesser hosted-genesis projection docs/table/testdata under `docs/lesser/contracts/`.
- Updates Host v1.0.6 markdown contract docs.
- Adds adapter tests consuming released producer fixtures.
- Registry checksum set remains unchanged; `validate:registry` passed.

## Factory review status

Factory accepted and merged #868 to `staging` under Project #51 staging-merge authority after green CI and independent byte-for-byte release artifact verification.

Review evidence:

- #868 Factory approval: https://github.com/equaltoai/greater-components/pull/868#pullrequestreview-4581362677
- #868 merge commit: `a8b40bf19ef939e9449fbb1ade7f97f6dea006d2`

## Proposed release tag after merge

Latest Greater release is `greater-v0.11.2`; this release appears to be a patch contract-sync release, so the expected next tag is:

- `greater-v0.11.3`

Greater's manual release workflow derives package/registry release metadata from the tag in CI (`scripts/prepare-github-release.js`), so this promotion PR does not include a version-bump commit.

## Known upstream producer risk

Lesser `v1.5.8` has a released example-table shape mismatch: the projection table places `publishGate` at `example.lesserGraphql.publishGate`, while the released GraphQL schema exposes it on `SoulBootstrapState.publishGate`. Greater imports/tests the released table byte-for-byte and does **not** normalize it locally.

Routed upstream: https://github.com/equaltoai/lesser/issues/1194#issuecomment-4811748849

## Boundaries

Factory is opening this promotion PR only. Factory is **not** tagging, publishing, deploying, or triggering the manual release workflow.