### PR TITLE
chore: sync lesser contracts to v1.5.12 and regenerate adapters

### DIFF
--- a/docs/lesser/contracts/LESSER_REF.txt
+++ b/docs/lesser/contracts/LESSER_REF.txt
@@ -1,2 +1,2 @@
-tag: v1.5.11
-commit: fc316bd6be62f2907218c4f8110ab893743f21a1
+tag: v1.5.12
+commit: e206610a3375e1af272aaaef1e0e260c395c013a

--- a/docs/lesser/contracts/graphql-schema.graphql
+++ b/docs/lesser/contracts/graphql-schema.graphql
@@ -4836,6 +4836,16 @@ type SoulBootstrapHostedGenesisConversation {
   updatedAt: Time
 }
 
+type HostedGenesisConversationSummary {
+  conversationId: String!
+  registrationId: String
+  status: String!
+  messageCount: Int!
+  latestTurnId: String
+  createdAt: Time
+  updatedAt: Time
+}
+
 type SoulBootstrapCorrelationState {
   correlationKey: String
   beginIdempotencyKey: String
@@ -5023,6 +5033,15 @@ input CompleteHostedSoulGenesisInput {
   correlationKey: String
 }
 
+input RecoverHostedSoulGenesisTurnInput {
+  username: String!
+  conversationId: String!
+  registrationId: String
+  correlationKey: String
+  idempotencyKey: String
+  recoveryAttemptId: String
+}
+
 input PublishHostedSoulInput {
   username: String!
   registrationId: ID
@@ -5137,6 +5156,7 @@ extend type Query {
   myDroneReviews: [ReviewDecisionCard!]!
   droneWorkflow(username: String!): AgentWorkflowSurface
   soulBootstrap(username: String!): SoulBootstrapSurface
+  listHostedGenesisConversations(username: String!): [HostedGenesisConversationSummary!]!
 }
 
 extend type Mutation {
@@ -5167,6 +5187,7 @@ extend type Mutation {
   startHostedSoulBootstrap(input: StartHostedSoulBootstrapInput!): SoulBootstrapMutationPayload!
   sendHostedSoulGenesisMessage(input: SendHostedSoulGenesisMessageInput!): SoulBootstrapMutationPayload!
   completeHostedSoulGenesis(input: CompleteHostedSoulGenesisInput!): SoulBootstrapMutationPayload!
+  recoverHostedSoulGenesisTurn(input: RecoverHostedSoulGenesisTurnInput!): SoulBootstrapMutationPayload!
   publishHostedSoul(input: PublishHostedSoulInput!): SoulBootstrapMutationPayload!
   restartSoulBootstrap(input: RestartSoulBootstrapInput!): SoulBootstrapMutationPayload!
   beginSoulBootstrap(input: BeginSoulBootstrapInput!): SoulBootstrapMutationPayload!

--- a/packages/adapters/src/graphql/generated/types.ts
+++ b/packages/adapters/src/graphql/generated/types.ts
@@ -2199,6 +2199,17 @@ export type HealthStatus =
   | 'HEALTHY'
   | 'UNKNOWN';
 
+export type HostedGenesisConversationSummary = {
+  readonly __typename: 'HostedGenesisConversationSummary';
+  readonly conversationId: Scalars['String']['output'];
+  readonly createdAt?: Maybe<Scalars['Time']['output']>;
+  readonly latestTurnId?: Maybe<Scalars['String']['output']>;
+  readonly messageCount: Scalars['Int']['output'];
+  readonly registrationId?: Maybe<Scalars['String']['output']>;
+  readonly status: Scalars['String']['output'];
+  readonly updatedAt?: Maybe<Scalars['Time']['output']>;
+};
+
 export type HourlyBandwidth = {
   readonly __typename: 'HourlyBandwidth';
   readonly hour: Scalars['Time']['output'];
@@ -2978,6 +2989,7 @@ export type Mutation = {
   readonly prepareSoulBootstrapPrincipalDeclaration: SoulBootstrapMutationPayload;
   readonly publishDraft: Article;
   readonly publishHostedSoul: SoulBootstrapMutationPayload;
+  readonly recoverHostedSoulGenesisTurn: SoulBootstrapMutationPayload;
   readonly registerAccount: RegisterAccountPayload;
   readonly registerAgent: RegisterAgentPayload;
   readonly registerPushSubscription: PushSubscription;
@@ -3617,6 +3629,11 @@ export type MutationPublishDraftArgs = {
 
 export type MutationPublishHostedSoulArgs = {
   input: PublishHostedSoulInput;
+};
+
+
+export type MutationRecoverHostedSoulGenesisTurnArgs = {
+  input: RecoverHostedSoulGenesisTurnInput;
 };
 
 
@@ -4576,6 +4593,7 @@ export type Query = {
   readonly linkTimeline: ObjectConnection;
   readonly list?: Maybe<List>;
   readonly listAccounts: ReadonlyArray<Actor>;
+  readonly listHostedGenesisConversations: ReadonlyArray<HostedGenesisConversationSummary>;
   readonly lists: ReadonlyArray<List>;
   readonly markers: MarkerSet;
   readonly media?: Maybe<Media>;
@@ -5077,6 +5095,11 @@ export type QueryListAccountsArgs = {
 };
 
 
+export type QueryListHostedGenesisConversationsArgs = {
+  username: Scalars['String']['input'];
+};
+
+
 export type QueryMarkersArgs = {
   timelines?: InputMaybe<ReadonlyArray<MarkerTimeline>>;
 };
@@ -5483,6 +5506,15 @@ export type ReconnectionPayload = {
   readonly reconnected: Scalars['Int']['output'];
   readonly severedRelationship: SeveredRelationship;
   readonly success: Scalars['Boolean']['output'];
+};
+
+export type RecoverHostedSoulGenesisTurnInput = {
+  readonly conversationId: Scalars['String']['input'];
+  readonly correlationKey?: InputMaybe<Scalars['String']['input']>;
+  readonly idempotencyKey?: InputMaybe<Scalars['String']['input']>;
+  readonly recoveryAttemptId?: InputMaybe<Scalars['String']['input']>;
+  readonly registrationId?: InputMaybe<Scalars['String']['input']>;
+  readonly username: Scalars['String']['input'];
 };
 
 export type RegisterAccountInput = {

--- a/packages/faces/social/src/adapters/graphql/generated/introspection.json
+++ b/packages/faces/social/src/adapters/graphql/generated/introspection.json
@@ -22192,6 +22192,114 @@
       },
       {
         "kind": "OBJECT",
+        "name": "HostedGenesisConversationSummary",
+        "description": null,
+        "isOneOf": null,
+        "fields": [
+          {
+            "name": "conversationId",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "createdAt",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "Time",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "latestTurnId",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "messageCount",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Int",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "registrationId",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "status",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "updatedAt",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "Time",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
         "name": "HourlyBandwidth",
         "description": null,
         "isOneOf": null,
@@ -33326,6 +33434,39 @@
             "deprecationReason": null
           },
           {
+            "name": "recoverHostedSoulGenesisTurn",
+            "description": null,
+            "args": [
+              {
+                "name": "input",
+                "description": null,
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "INPUT_OBJECT",
+                    "name": "RecoverHostedSoulGenesisTurnInput",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              }
+            ],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "SoulBootstrapMutationPayload",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "registerAccount",
             "description": null,
             "args": [
@@ -44238,6 +44379,47 @@
             "deprecationReason": null
           },
           {
+            "name": "listHostedGenesisConversations",
+            "description": null,
+            "args": [
+              {
+                "name": "username",
+                "description": null,
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              }
+            ],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "HostedGenesisConversationSummary",
+                    "ofType": null
+                  }
+                }
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "lists",
             "description": null,
             "args": [],
@@ -47694,6 +47876,98 @@
         ],
         "inputFields": null,
         "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "INPUT_OBJECT",
+        "name": "RecoverHostedSoulGenesisTurnInput",
+        "description": null,
+        "isOneOf": false,
+        "fields": null,
+        "inputFields": [
+          {
+            "name": "conversationId",
+            "description": null,
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "correlationKey",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "idempotencyKey",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "recoveryAttemptId",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "registrationId",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "username",
+            "description": null,
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "interfaces": null,
         "enumValues": null,
         "possibleTypes": null
       },

--- a/packages/faces/social/src/adapters/graphql/generated/types.ts
+++ b/packages/faces/social/src/adapters/graphql/generated/types.ts
@@ -2199,6 +2199,17 @@ export type HealthStatus =
   | 'HEALTHY'
   | 'UNKNOWN';
 
+export type HostedGenesisConversationSummary = {
+  readonly __typename: 'HostedGenesisConversationSummary';
+  readonly conversationId: Scalars['String']['output'];
+  readonly createdAt?: Maybe<Scalars['Time']['output']>;
+  readonly latestTurnId?: Maybe<Scalars['String']['output']>;
+  readonly messageCount: Scalars['Int']['output'];
+  readonly registrationId?: Maybe<Scalars['String']['output']>;
+  readonly status: Scalars['String']['output'];
+  readonly updatedAt?: Maybe<Scalars['Time']['output']>;
+};
+
 export type HourlyBandwidth = {
   readonly __typename: 'HourlyBandwidth';
   readonly hour: Scalars['Time']['output'];
@@ -2978,6 +2989,7 @@ export type Mutation = {
   readonly prepareSoulBootstrapPrincipalDeclaration: SoulBootstrapMutationPayload;
   readonly publishDraft: Article;
   readonly publishHostedSoul: SoulBootstrapMutationPayload;
+  readonly recoverHostedSoulGenesisTurn: SoulBootstrapMutationPayload;
   readonly registerAccount: RegisterAccountPayload;
   readonly registerAgent: RegisterAgentPayload;
   readonly registerPushSubscription: PushSubscription;
@@ -3617,6 +3629,11 @@ export type MutationPublishDraftArgs = {
 
 export type MutationPublishHostedSoulArgs = {
   input: PublishHostedSoulInput;
+};
+
+
+export type MutationRecoverHostedSoulGenesisTurnArgs = {
+  input: RecoverHostedSoulGenesisTurnInput;
 };
 
 
@@ -4576,6 +4593,7 @@ export type Query = {
   readonly linkTimeline: ObjectConnection;
   readonly list?: Maybe<List>;
   readonly listAccounts: ReadonlyArray<Actor>;
+  readonly listHostedGenesisConversations: ReadonlyArray<HostedGenesisConversationSummary>;
   readonly lists: ReadonlyArray<List>;
   readonly markers: MarkerSet;
   readonly media?: Maybe<Media>;
@@ -5077,6 +5095,11 @@ export type QueryListAccountsArgs = {
 };
 
 
+export type QueryListHostedGenesisConversationsArgs = {
+  username: Scalars['String']['input'];
+};
+
+
 export type QueryMarkersArgs = {
   timelines?: InputMaybe<ReadonlyArray<MarkerTimeline>>;
 };
@@ -5483,6 +5506,15 @@ export type ReconnectionPayload = {
   readonly reconnected: Scalars['Int']['output'];
   readonly severedRelationship: SeveredRelationship;
   readonly success: Scalars['Boolean']['output'];
+};
+
+export type RecoverHostedSoulGenesisTurnInput = {
+  readonly conversationId: Scalars['String']['input'];
+  readonly correlationKey?: InputMaybe<Scalars['String']['input']>;
+  readonly idempotencyKey?: InputMaybe<Scalars['String']['input']>;
+  readonly recoveryAttemptId?: InputMaybe<Scalars['String']['input']>;
+  readonly registrationId?: InputMaybe<Scalars['String']['input']>;
+  readonly username: Scalars['String']['input'];
 };
 
 export type RegisterAccountInput = {

--- a/registry/index.json
+++ b/registry/index.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://equalto.ai/schemas/registry-index.schema.json",
   "schemaVersion": "1.0.0",
-  "generatedAt": "2026-07-01T16:28:30.575Z",
+  "generatedAt": "2026-07-02T21:19:42.378Z",
   "ref": "greater-v0.11.0",
   "version": "0.11.0",
   "checksums": {
@@ -827,7 +827,7 @@
     "packages/adapters/src/graphql/client.d.ts": "sha256-pJIC62N40bdFXhryg13X0HezmJFinzT2I9n/6qK1iJo=",
     "packages/adapters/src/graphql/client.ts": "sha256-ueB6/jmcKQu54uT72TkqdTRz+yAsTGl9mrGV+jeTRHA=",
     "packages/adapters/src/graphql/generated/types.d.ts": "sha256-06CrbILnoClJ2Egs3gR2tZE271RgSroJXY7QxF46uLI=",
-    "packages/adapters/src/graphql/generated/types.ts": "sha256-R4fc0THuO3PVbQW7xvM/+/CW5U1HG+3bA3l7QeGLNhI=",
+    "packages/adapters/src/graphql/generated/types.ts": "sha256-AtfyaX+7yZ6aFmFh9emPDdpawCAIPjOoUHZSs3lgqaw=",
     "packages/adapters/src/graphql/index.d.ts": "sha256-orLx9yyDGxzzxd5wHeLg/XKql86ntzhZSG6iUj6Tjx8=",
     "packages/adapters/src/graphql/index.ts": "sha256-13y12ovgBLm5aZQ7K90w+XVxhUWIKB/eaPVEJ4kPeBI=",
     "packages/adapters/src/graphql/LesserGraphQLAdapter.d.ts": "sha256-tS4MSxFQSiPlKqIotIdGyDRMyfu7BjJ3dpPBXfjVqtU=",
@@ -950,7 +950,7 @@
     "packages/faces/social/src/adapters/cache.ts": "sha256-32jUHLAsYoK4U0JZ6hswGUlQOmwhJ5yquqhMqyfrc4I=",
     "packages/faces/social/src/adapters/graphql/client.ts": "sha256-yor+sP4J7hzK+igh2s4mujPOUZTRDN/e3nU1eccrSyo=",
     "packages/faces/social/src/adapters/graphql/generated/possible-types.ts": "sha256-jICUa0Jvj62nX0BdiBLTWoH2TII2SjAkM3ivA4dyuyA=",
-    "packages/faces/social/src/adapters/graphql/generated/types.ts": "sha256-R4fc0THuO3PVbQW7xvM/+/CW5U1HG+3bA3l7QeGLNhI=",
+    "packages/faces/social/src/adapters/graphql/generated/types.ts": "sha256-AtfyaX+7yZ6aFmFh9emPDdpawCAIPjOoUHZSs3lgqaw=",
     "packages/faces/social/src/adapters/graphql/index.ts": "sha256-SMi4iyLZqIOJKJyIpt2msJuQELlVAFJlnxBOdaL0ftY=",
     "packages/faces/social/src/adapters/graphql/queries.ts": "sha256-uiYJnwcQO+eaZUiTgyKJMxpeoluOuagazSLjQUdMR8M=",
     "packages/faces/social/src/adapters/graphql/types.ts": "sha256-0GgEc9AYxNSfWTVE9POQu0haMmO+PydpLzVw90hoDls=",
@@ -5647,8 +5647,8 @@
         },
         {
           "path": "src/graphql/generated/types.ts",
-          "checksum": "sha256-R4fc0THuO3PVbQW7xvM/+/CW5U1HG+3bA3l7QeGLNhI=",
-          "size": 2529500
+          "checksum": "sha256-AtfyaX+7yZ6aFmFh9emPDdpawCAIPjOoUHZSs3lgqaw=",
+          "size": 2530810
         },
         {
           "path": "src/graphql/index.d.ts",
@@ -6413,8 +6413,8 @@
         },
         {
           "path": "src/adapters/graphql/generated/types.ts",
-          "checksum": "sha256-R4fc0THuO3PVbQW7xvM/+/CW5U1HG+3bA3l7QeGLNhI=",
-          "size": 2529500
+          "checksum": "sha256-AtfyaX+7yZ6aFmFh9emPDdpawCAIPjOoUHZSs3lgqaw=",
+          "size": 2530810
         },
         {
           "path": "src/adapters/graphql/index.ts",


### PR DESCRIPTION
## Summary

Lesser contract sync v1.5.11 → v1.5.12. New GraphQL schema surfaces for hosted-genesis conversation management, all additive.

## Lesser v1.5.12 contract changes

**GraphQL schema** — three additive changes to the hosted-genesis surface:

- **New type**: `HostedGenesisConversationSummary` (`conversationId`, `registrationId`, `status`, `messageCount`, `latestTurnId`, `createdAt`, `updatedAt`)
- **New input**: `RecoverHostedSoulGenesisTurnInput` (`username`, `conversationId`, `registrationId`, `correlationKey`, `idempotencyKey`, `recoveryAttemptId`)
- **New query**: `listHostedGenesisConversations(username: String!): [HostedGenesisConversationSummary!]!`
- **New mutation**: `recoverHostedSoulGenesisTurn(input: RecoverHostedSoulGenesisTurnInput!): SoulBootstrapMutationPayload!`

**OpenAPI**: unchanged (byte-identical to v1.5.11).

No existing types modified or removed — pure addition.

## Regenerated artifacts

| File | Change |
|------|--------|
| `packages/adapters/src/graphql/generated/types.ts` | +32 lines (new type, input, query/mutation args) |
| `packages/faces/social/src/adapters/graphql/generated/types.ts` | +32 lines (same additions via shared codegen) |
| `packages/faces/social/src/adapters/graphql/generated/introspection.json` | +274 lines (new type introspection metadata) |
| `registry/index.json` | regenerated checksums |

## Semver impact

**`@equaltoai/greater-components-adapters`: minor** — additive new GraphQL types/query/mutation surfaced via generated adapter types. No breaking changes; existing adapter code unaffected.

**`@equaltoai/greater-components-social`: no impact** — social typecheck clean; new types are additive and not yet referenced by social face code.

## Verification evidence

| Gate | Result |
|------|--------|
| `pnpm --filter @equaltoai/greater-components-adapters typecheck` | pass |
| `pnpm --filter @equaltoai/greater-components-social typecheck` | pass |
| `pnpm --filter @equaltoai/greater-components-adapters test` | 593 passed, 6 skipped, 0 failed |
| `pnpm check:openapi-auth` | no auth gaps (OpenAPI unchanged) |
| `pnpm generate-registry:validate` | registry index valid |

## Contract-sync audit

- **Lesser**: v1.5.11 → v1.5.12 (snapshot + additive GraphQL schema change)
- **Lesser Host**: v1.0.9 (unchanged — already synced in PR #877)
- **Change type**: snapshot + adapter-additive (minor)
- **Consumer impact**: sim / host web / external Mastodon-compat — all unaffected (additive GraphQL types, no adapter API change)