### PR TITLE
Staging

### DIFF
--- a/docs/lesser/contracts/LESSER_REF.txt
+++ b/docs/lesser/contracts/LESSER_REF.txt
@@ -1,2 +1,2 @@
-tag: v1.5.11
-commit: fc316bd6be62f2907218c4f8110ab893743f21a1
+tag: v1.5.12
+commit: e206610a3375e1af272aaaef1e0e260c395c013a

--- a/docs/lesser/contracts/graphql-schema.graphql
+++ b/docs/lesser/contracts/graphql-schema.graphql
@@ -4836,6 +4836,16 @@ type SoulBootstrapHostedGenesisConversation {
   updatedAt: Time
 }
 
+type HostedGenesisConversationSummary {
+  conversationId: String!
+  registrationId: String
+  status: String!
+  messageCount: Int!
+  latestTurnId: String
+  createdAt: Time
+  updatedAt: Time
+}
+
 type SoulBootstrapCorrelationState {
   correlationKey: String
   beginIdempotencyKey: String
@@ -5023,6 +5033,15 @@ input CompleteHostedSoulGenesisInput {
   correlationKey: String
 }
 
+input RecoverHostedSoulGenesisTurnInput {
+  username: String!
+  conversationId: String!
+  registrationId: String
+  correlationKey: String
+  idempotencyKey: String
+  recoveryAttemptId: String
+}
+
 input PublishHostedSoulInput {
   username: String!
   registrationId: ID
@@ -5137,6 +5156,7 @@ extend type Query {
   myDroneReviews: [ReviewDecisionCard!]!
   droneWorkflow(username: String!): AgentWorkflowSurface
   soulBootstrap(username: String!): SoulBootstrapSurface
+  listHostedGenesisConversations(username: String!): [HostedGenesisConversationSummary!]!
 }
 
 extend type Mutation {
@@ -5167,6 +5187,7 @@ extend type Mutation {
   startHostedSoulBootstrap(input: StartHostedSoulBootstrapInput!): SoulBootstrapMutationPayload!
   sendHostedSoulGenesisMessage(input: SendHostedSoulGenesisMessageInput!): SoulBootstrapMutationPayload!
   completeHostedSoulGenesis(input: CompleteHostedSoulGenesisInput!): SoulBootstrapMutationPayload!
+  recoverHostedSoulGenesisTurn(input: RecoverHostedSoulGenesisTurnInput!): SoulBootstrapMutationPayload!
   publishHostedSoul(input: PublishHostedSoulInput!): SoulBootstrapMutationPayload!
   restartSoulBootstrap(input: RestartSoulBootstrapInput!): SoulBootstrapMutationPayload!
   beginSoulBootstrap(input: BeginSoulBootstrapInput!): SoulBootstrapMutationPayload!

--- a/packages/adapters/src/graphql/generated/types.ts
+++ b/packages/adapters/src/graphql/generated/types.ts
@@ -2199,6 +2199,17 @@ export type HealthStatus =
   | 'HEALTHY'
   | 'UNKNOWN';
 
+export type HostedGenesisConversationSummary = {
+  readonly __typename: 'HostedGenesisConversationSummary';
+  readonly conversationId: Scalars['String']['output'];
+  readonly createdAt?: Maybe<Scalars['Time']['output']>;
+  readonly latestTurnId?: Maybe<Scalars['String']['output']>;
+  readonly messageCount: Scalars['Int']['output'];
+  readonly registrationId?: Maybe<Scalars['String']['output']>;
+  readonly status: Scalars['String']['output'];
+  readonly updatedAt?: Maybe<Scalars['Time']['output']>;
+};
+
 export type HourlyBandwidth = {
   readonly __typename: 'HourlyBandwidth';
   readonly hour: Scalars['Time']['output'];
@@ -2978,6 +2989,7 @@ export type Mutation = {
   readonly prepareSoulBootstrapPrincipalDeclaration: SoulBootstrapMutationPayload;
   readonly publishDraft: Article;
   readonly publishHostedSoul: SoulBootstrapMutationPayload;
+  readonly recoverHostedSoulGenesisTurn: SoulBootstrapMutationPayload;
   readonly registerAccount: RegisterAccountPayload;
   readonly registerAgent: RegisterAgentPayload;
   readonly registerPushSubscription: PushSubscription;
@@ -3617,6 +3629,11 @@ export type MutationPublishDraftArgs = {
 
 export type MutationPublishHostedSoulArgs = {
   input: PublishHostedSoulInput;
+};
+
+
+export type MutationRecoverHostedSoulGenesisTurnArgs = {
+  input: RecoverHostedSoulGenesisTurnInput;
 };
 
 
@@ -4576,6 +4593,7 @@ export type Query = {
   readonly linkTimeline: ObjectConnection;
   readonly list?: Maybe<List>;
   readonly listAccounts: ReadonlyArray<Actor>;
+  readonly listHostedGenesisConversations: ReadonlyArray<HostedGenesisConversationSummary>;
   readonly lists: ReadonlyArray<List>;
   readonly markers: MarkerSet;
   readonly media?: Maybe<Media>;
@@ -5077,6 +5095,11 @@ export type QueryListAccountsArgs = {
 };
 
 
+export type QueryListHostedGenesisConversationsArgs = {
+  username: Scalars['String']['input'];
+};
+
+
 export type QueryMarkersArgs = {
   timelines?: InputMaybe<ReadonlyArray<MarkerTimeline>>;
 };
@@ -5483,6 +5506,15 @@ export type ReconnectionPayload = {
   readonly reconnected: Scalars['Int']['output'];
   readonly severedRelationship: SeveredRelationship;
   readonly success: Scalars['Boolean']['output'];
+};
+
+export type RecoverHostedSoulGenesisTurnInput = {
+  readonly conversationId: Scalars['String']['input'];
+  readonly correlationKey?: InputMaybe<Scalars['String']['input']>;
+  readonly idempotencyKey?: InputMaybe<Scalars['String']['input']>;
+  readonly recoveryAttemptId?: InputMaybe<Scalars['String']['input']>;
+  readonly registrationId?: InputMaybe<Scalars['String']['input']>;
+  readonly username: Scalars['String']['input'];
 };
 
 export type RegisterAccountInput = {

--- a/packages/faces/social/src/adapters/graphql/generated/introspection.json
+++ b/packages/faces/social/src/adapters/graphql/generated/introspection.json
@@ -22192,6 +22192,114 @@
       },
       {
         "kind": "OBJECT",
+        "name": "HostedGenesisConversationSummary",
+        "description": null,
+        "isOneOf": null,
+        "fields": [
+          {
+            "name": "conversationId",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "createdAt",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "Time",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "latestTurnId",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "messageCount",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Int",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "registrationId",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "status",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "updatedAt",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "Time",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
         "name": "HourlyBandwidth",
         "description": null,
         "isOneOf": null,
@@ -33326,6 +33434,39 @@
             "deprecationReason": null
           },
           {
+            "name": "recoverHostedSoulGenesisTurn",
+            "description": null,
+            "args": [
+              {
+                "name": "input",
+                "description": null,
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "INPUT_OBJECT",
+                    "name": "RecoverHostedSoulGenesisTurnInput",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              }
+            ],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "SoulBootstrapMutationPayload",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "registerAccount",
             "description": null,
             "args": [
@@ -44238,6 +44379,47 @@
             "deprecationReason": null
           },
           {
+            "name": "listHostedGenesisConversations",
+            "description": null,
+            "args": [
+              {
+                "name": "username",
+                "description": null,
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              }
+            ],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "HostedGenesisConversationSummary",
+                    "ofType": null
+                  }
+                }
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "lists",
             "description": null,
             "args": [],
@@ -47694,6 +47876,98 @@
         ],
         "inputFields": null,
         "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "INPUT_OBJECT",
+        "name": "RecoverHostedSoulGenesisTurnInput",
+        "description": null,
+        "isOneOf": false,
+        "fields": null,
+        "inputFields": [
+          {
+            "name": "conversationId",
+            "description": null,
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "correlationKey",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "idempotencyKey",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "recoveryAttemptId",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "registrationId",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "username",
+            "description": null,
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "interfaces": null,
         "enumValues": null,
         "possibleTypes": null
       },

--- a/packages/faces/social/src/adapters/graphql/generated/types.ts
+++ b/packages/faces/social/src/adapters/graphql/generated/types.ts
@@ -2199,6 +2199,17 @@ export type HealthStatus =
   | 'HEALTHY'
   | 'UNKNOWN';
 
+export type HostedGenesisConversationSummary = {
+  readonly __typename: 'HostedGenesisConversationSummary';
+  readonly conversationId: Scalars['String']['output'];
+  readonly createdAt?: Maybe<Scalars['Time']['output']>;
+  readonly latestTurnId?: Maybe<Scalars['String']['output']>;
+  readonly messageCount: Scalars['Int']['output'];
+  readonly registrationId?: Maybe<Scalars['String']['output']>;
+  readonly status: Scalars['String']['output'];
+  readonly updatedAt?: Maybe<Scalars['Time']['output']>;
+};
+
 export type HourlyBandwidth = {
   readonly __typename: 'HourlyBandwidth';
   readonly hour: Scalars['Time']['output'];
@@ -2978,6 +2989,7 @@ export type Mutation = {
   readonly prepareSoulBootstrapPrincipalDeclaration: SoulBootstrapMutationPayload;
   readonly publishDraft: Article;
   readonly publishHostedSoul: SoulBootstrapMutationPayload;
+  readonly recoverHostedSoulGenesisTurn: SoulBootstrapMutationPayload;
   readonly registerAccount: RegisterAccountPayload;
   readonly registerAgent: RegisterAgentPayload;
   readonly registerPushSubscription: PushSubscription;
@@ -3617,6 +3629,11 @@ export type MutationPublishDraftArgs = {
 
 export type MutationPublishHostedSoulArgs = {
   input: PublishHostedSoulInput;
+};
+
+
+export type MutationRecoverHostedSoulGenesisTurnArgs = {
+  input: RecoverHostedSoulGenesisTurnInput;
 };
 
 
@@ -4576,6 +4593,7 @@ export type Query = {
   readonly linkTimeline: ObjectConnection;
   readonly list?: Maybe<List>;
   readonly listAccounts: ReadonlyArray<Actor>;
+  readonly listHostedGenesisConversations: ReadonlyArray<HostedGenesisConversationSummary>;
   readonly lists: ReadonlyArray<List>;
   readonly markers: MarkerSet;
   readonly media?: Maybe<Media>;
@@ -5077,6 +5095,11 @@ export type QueryListAccountsArgs = {
 };
 
 
+export type QueryListHostedGenesisConversationsArgs = {
+  username: Scalars['String']['input'];
+};
+
+
 export type QueryMarkersArgs = {
   timelines?: InputMaybe<ReadonlyArray<MarkerTimeline>>;
 };
@@ -5483,6 +5506,15 @@ export type ReconnectionPayload = {
   readonly reconnected: Scalars['Int']['output'];
   readonly severedRelationship: SeveredRelationship;
   readonly success: Scalars['Boolean']['output'];
+};
+
+export type RecoverHostedSoulGenesisTurnInput = {
+  readonly conversationId: Scalars['String']['input'];
+  readonly correlationKey?: InputMaybe<Scalars['String']['input']>;
+  readonly idempotencyKey?: InputMaybe<Scalars['String']['input']>;
+  readonly recoveryAttemptId?: InputMaybe<Scalars['String']['input']>;
+  readonly registrationId?: InputMaybe<Scalars['String']['input']>;
+  readonly username: Scalars['String']['input'];
 };
 
 export type RegisterAccountInput = {

--- a/registry/index.json
+++ b/registry/index.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://equalto.ai/schemas/registry-index.schema.json",
   "schemaVersion": "1.0.0",
-  "generatedAt": "2026-07-01T16:28:30.575Z",
+  "generatedAt": "2026-07-02T21:19:42.378Z",
   "ref": "greater-v0.11.0",
   "version": "0.11.0",
   "checksums": {
@@ -827,7 +827,7 @@
     "packages/adapters/src/graphql/client.d.ts": "sha256-pJIC62N40bdFXhryg13X0HezmJFinzT2I9n/6qK1iJo=",
     "packages/adapters/src/graphql/client.ts": "sha256-ueB6/jmcKQu54uT72TkqdTRz+yAsTGl9mrGV+jeTRHA=",
     "packages/adapters/src/graphql/generated/types.d.ts": "sha256-06CrbILnoClJ2Egs3gR2tZE271RgSroJXY7QxF46uLI=",
-    "packages/adapters/src/graphql/generated/types.ts": "sha256-R4fc0THuO3PVbQW7xvM/+/CW5U1HG+3bA3l7QeGLNhI=",
+    "packages/adapters/src/graphql/generated/types.ts": "sha256-AtfyaX+7yZ6aFmFh9emPDdpawCAIPjOoUHZSs3lgqaw=",
     "packages/adapters/src/graphql/index.d.ts": "sha256-orLx9yyDGxzzxd5wHeLg/XKql86ntzhZSG6iUj6Tjx8=",
     "packages/adapters/src/graphql/index.ts": "sha256-13y12ovgBLm5aZQ7K90w+XVxhUWIKB/eaPVEJ4kPeBI=",
     "packages/adapters/src/graphql/LesserGraphQLAdapter.d.ts": "sha256-tS4MSxFQSiPlKqIotIdGyDRMyfu7BjJ3dpPBXfjVqtU=",
@@ -950,7 +950,7 @@
     "packages/faces/social/src/adapters/cache.ts": "sha256-32jUHLAsYoK4U0JZ6hswGUlQOmwhJ5yquqhMqyfrc4I=",
     "packages/faces/social/src/adapters/graphql/client.ts": "sha256-yor+sP4J7hzK+igh2s4mujPOUZTRDN/e3nU1eccrSyo=",
     "packages/faces/social/src/adapters/graphql/generated/possible-types.ts": "sha256-jICUa0Jvj62nX0BdiBLTWoH2TII2SjAkM3ivA4dyuyA=",
-    "packages/faces/social/src/adapters/graphql/generated/types.ts": "sha256-R4fc0THuO3PVbQW7xvM/+/CW5U1HG+3bA3l7QeGLNhI=",
+    "packages/faces/social/src/adapters/graphql/generated/types.ts": "sha256-AtfyaX+7yZ6aFmFh9emPDdpawCAIPjOoUHZSs3lgqaw=",
     "packages/faces/social/src/adapters/graphql/index.ts": "sha256-SMi4iyLZqIOJKJyIpt2msJuQELlVAFJlnxBOdaL0ftY=",
     "packages/faces/social/src/adapters/graphql/queries.ts": "sha256-uiYJnwcQO+eaZUiTgyKJMxpeoluOuagazSLjQUdMR8M=",
     "packages/faces/social/src/adapters/graphql/types.ts": "sha256-0GgEc9AYxNSfWTVE9POQu0haMmO+PydpLzVw90hoDls=",
@@ -5647,8 +5647,8 @@
         },
         {
           "path": "src/graphql/generated/types.ts",
-          "checksum": "sha256-R4fc0THuO3PVbQW7xvM/+/CW5U1HG+3bA3l7QeGLNhI=",
-          "size": 2529500
+          "checksum": "sha256-AtfyaX+7yZ6aFmFh9emPDdpawCAIPjOoUHZSs3lgqaw=",
+          "size": 2530810
         },
         {
           "path": "src/graphql/index.d.ts",
@@ -6413,8 +6413,8 @@
         },
         {
           "path": "src/adapters/graphql/generated/types.ts",
-          "checksum": "sha256-R4fc0THuO3PVbQW7xvM/+/CW5U1HG+3bA3l7QeGLNhI=",
-          "size": 2529500
+          "checksum": "sha256-AtfyaX+7yZ6aFmFh9emPDdpawCAIPjOoUHZSs3lgqaw=",
+          "size": 2530810
         },
         {
           "path": "src/adapters/graphql/index.ts",


### PR DESCRIPTION
<!--
Thanks for contributing to greater-components!

Before opening this PR, please make sure every applicable box below is
checked. The parity checklist is enforced by the Greater steward — PRs
that ship a new component or surface MUST land docs, tests, playground
example, and registry update in the same PR train (see Project 39
G4.1 / #661).
-->

## Summary

<!-- 1–3 sentences: what does this PR do and why? -->

## Classification

<!-- Pick one: component-addition / api-evolution / adapter-change /
     accessibility / theming / cli-registry / release-automation /
     docs / dependency-maintenance / bug-fix / release-coordination -->

## Component-milestone parity checklist

> Required for every PR that adds a new component, prop, public type, or
> export subpath. If your change does NOT touch a component surface,
> mark each row N/A and add a one-line reason in **Notes**.

- [ ] **Source** — Svelte component(s) + CSS + types added under
      `packages/<package>/src/`.
- [ ] **Types** — public type contracts exported via `types.ts` /
      package `./types` subpath.
- [ ] **Tests** — unit + a11y tests in `packages/<package>/tests/`
      covering: landmarks / accessible names, keyboard contract,
      status / state semantics, strict-CSP (no inline `style`),
      unique-id-across-instances.
- [ ] **Docs** — `docs/component-inventory.md` and
      `docs/api-reference.md` updated with the new component(s) and
      prop unions.
- [ ] **Playground** — demo route under
      `apps/playground/src/routes/<feature>/+page.svelte` exercising
      every state / variant.
- [ ] **CLI registry** — `packages/cli/src/registry/index.ts` entry
      added or updated.
- [ ] **Generated registry** — `pnpm generate-registry` run and
      `registry/index.json` committed. **No hand-edits.**
- [ ] **Greater-components barrel** — root barrel
      (`packages/greater-components/package.json` + `scripts/build.js`)
      updated to expose the new package / subpath.
- [ ] **Docs workflow** — `.github/workflows/docs.yml` updated to
      build the new package before the playground / docs apps (if a new
      workspace package is introduced).

## Stewardship guarantees

- [ ] **Strict-CSP safe** — no inline event handlers, no `style` attrs
      set at runtime, no module-level browser globals.
- [ ] **SSR-safe** — components render correctly in SvelteKit SSR.
- [ ] **WCAG 2.1 AA** — every interactive element is keyboard reachable
      with visible focus, status is never color-only, ARIA roles match
      their contract (e.g. `role="meter"` has accessible name + valid
      range, `role="log"` only used when announcements are intended).
- [ ] **Theming preserved** — existing `--gr-*` tokens unchanged; only
      additive `--gr-*` / `--gr-<pkg>-*` tokens introduced.
- [ ] **No npm publication** — greater-components is shadcn-style CLI
      distribution only; this PR does not introduce npm publish steps.
- [ ] **No AGPL-incompatible dependencies** — any new dependency is
      license-vetted.

## Semver / release-note impact

> Changesets are retired. Declare user-visible impact here so manual
> version-bumping PRs and release notes can stay accurate.

- [ ] Semver impact below is accurate (**major** for breaking changes,
      **minor** for additive component/API work, **patch** for fixes,
      **none** for docs/test/CI-only work).
- [ ] Breaking changes include migration notes and explicit consumer
      coordination.

## Semver impact

<!-- major / minor / patch / none -->

## Consumer impact

- **sim:** <preserved / breaking / explicit drop>
- **lesser-host web:** <preserved / breaking / explicit drop>
- **lesser UIs:** <preserved / breaking / explicit drop>
- **external Mastodon-compat:** <preserved / breaking / explicit drop>

## Validation

- [ ] `pnpm install` (frozen lockfile)
- [ ] `pnpm lint`
- [ ] `pnpm format:check`
- [ ] `pnpm typecheck`
- [ ] `pnpm test`
- [ ] `pnpm build`
- [ ] `pnpm test:a11y` (where applicable)
- [ ] `pnpm validate:registry`, `validate:cli`, `validate:exports`,
      `validate:dist`, `validate:deps`, `validate:tokens`, `validate:ids`,
      `validate:csp`, `validate:versions`, `check:openapi-auth`
- [ ] `node scripts/check-dco.js --base origin/staging --head HEAD`

## Cross-repo coordination

<!-- Required / none. If required, name the counterpart steward
     (lesser, host, sim) and what they need to do. -->

## Release-flow plan (handoff after merge to staging)

- [ ] Merged to staging
- [ ] Operator promotion staging → main (if this train is released)
- [ ] Manual tag cut from main
- [ ] Manual Release workflow publishes CLI tarball + registry + GitHub Release

## Notes

<!-- Optional context: open questions, design alternatives considered,
     N/A justifications for any parity-checklist boxes. -->
