### PR TITLE
fix(chat): guard window access in ChatContainer onDestroy for SSR safety

### DIFF
--- a/packages/shared/chat/src/ChatContainer.svelte
+++ b/packages/shared/chat/src/ChatContainer.svelte
@@ -188,14 +188,15 @@
 	}
 
 	// Set up global keyboard listener
+	// onDestroy runs during Svelte 5 SSR close-render, so guard browser globals
 	onMount(() => {
-		if (enableKeyboardShortcuts) {
+		if (enableKeyboardShortcuts && typeof window !== 'undefined') {
 			window.addEventListener('keydown', handleKeydown);
 		}
 	});
 
 	onDestroy(() => {
-		if (enableKeyboardShortcuts) {
+		if (enableKeyboardShortcuts && typeof window !== 'undefined') {
 			window.removeEventListener('keydown', handleKeydown);
 		}
 	});

--- a/packages/shared/chat/tests/ChatContainer.test.ts
+++ b/packages/shared/chat/tests/ChatContainer.test.ts
@@ -165,6 +165,30 @@ describe('ChatContainer.svelte', () => {
 
 			expect(onStopStreaming).not.toHaveBeenCalled();
 		});
+
+		it('guards window access with typeof check for SSR safety', () => {
+			// The onDestroy callback runs during Svelte 5 SSR close-render.
+			// If window is referenced without a typeof guard, Node SSR throws
+			// ReferenceError: window is not defined. This test verifies the
+			// guard exists by simulating a no-window environment.
+			//
+			// See: Simulacrum steward report — SSR crash in ChatContainer
+			// (delivery-b7d608ee1eeb2f31, 2026-07-03)
+
+			const originalWindow = globalThis.window;
+			// @ts-expect-error — intentionally removing window to simulate Node SSR
+			delete globalThis.window;
+
+			try {
+				// Rendering should not throw even when window is undefined.
+				// The component's onDestroy must check typeof window before calling
+				// window.removeEventListener.
+				expect(() => render(ChatContainerHarness)).not.toThrow();
+			} finally {
+				// Restore window for subsequent tests
+				globalThis.window = originalWindow;
+			}
+		});
 	});
 
 	describe('Auto-scroll', () => {

--- a/registry/index.json
+++ b/registry/index.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://equalto.ai/schemas/registry-index.schema.json",
   "schemaVersion": "1.0.0",
-  "generatedAt": "2026-07-02T22:07:55.275Z",
+  "generatedAt": "2026-07-03T02:05:58.905Z",
   "ref": "greater-v0.11.0",
   "version": "0.11.0",
   "checksums": {
@@ -1397,7 +1397,7 @@
     "packages/shared/admin/src/TrustGraph/Root.svelte": "sha256-RnKfjO2Vn2aZFXkeMITY9bBE7jPF/5KHVBvBo2XHaq8=",
     "packages/shared/admin/src/TrustGraph/Visualization.svelte": "sha256-rxTSgA4+sYykDxVNBr1yAcOLFt1nFs8oR26R0ukrNAU=",
     "packages/shared/admin/src/Users.svelte": "sha256-eJnq6ySKkUKIFYdke6qok7zSM/e0BasyO9rUiN7gmGg=",
-    "packages/shared/chat/src/ChatContainer.svelte": "sha256-RffmulXXyC6NRUZYjDAUF+BX4JzLZXAhv5neTCEdb58=",
+    "packages/shared/chat/src/ChatContainer.svelte": "sha256-2jiPhT9sABOQ4CN2ZxuL+q94xL81kZvXXctp/QS4LRI=",
     "packages/shared/chat/src/ChatHeader.svelte": "sha256-KlBPVy0gdgTJ0mgn4/InoGnwSxyuJvwsP0DS2q0kxYg=",
     "packages/shared/chat/src/ChatInput.svelte": "sha256-lU6LPsynBURd6Mb4hNJ4SiRIQ5EtrFVChV4KbrvWGOo=",
     "packages/shared/chat/src/ChatMessage.svelte": "sha256-PpUf+DIw5R0FvGV4g9b4qHU8hrZQceQ9al/ha3R1y20=",
@@ -9431,8 +9431,8 @@
       "files": [
         {
           "path": "src/ChatContainer.svelte",
-          "checksum": "sha256-RffmulXXyC6NRUZYjDAUF+BX4JzLZXAhv5neTCEdb58=",
-          "size": 8738
+          "checksum": "sha256-2jiPhT9sABOQ4CN2ZxuL+q94xL81kZvXXctp/QS4LRI=",
+          "size": 8882
         },
         {
           "path": "src/ChatHeader.svelte",


### PR DESCRIPTION
## Summary

Fixes an SSR crash in `ChatContainer.svelte` reported by the Simulacrum steward. The `onDestroy` lifecycle callback referenced `window` directly, which throws `ReferenceError: window is not defined` during Svelte 5 SSR close-render in Node/Lambda.

## Problem

`ChatContainer.svelte` registered keyboard shortcut listeners in `onMount`/`onDestroy` that referenced `window` without a `typeof` guard:

```svelte
onMount(() => {
    if (enableKeyboardShortcuts) {
        window.addEventListener("keydown", handleKeydown);  // crashes in SSR
    }
});

onDestroy(() => {
    if (enableKeyboardShortcuts) {
        window.removeEventListener("keydown", handleKeydown);  // crashes in SSR
    }
});
```

The Svelte 5 SSR compiler executes `onDestroy` callbacks during the `#close_render` phase. In Node SSR (Lambda), `window` is not defined, so `window.removeEventListener` throws `ReferenceError: window is not defined`.

This was latent until Simulacrum's genesis conversation page (`/souls/genesis`) became the first FaceTheory route to render `Chat.Container` during SSR.

## Fix

Added `typeof window !== "undefined"` guards to both `onMount` and `onDestroy`:

```svelte
onMount(() => {
    if (enableKeyboardShortcuts && typeof window !== "undefined") {
        window.addEventListener("keydown", handleKeydown);
    }
});

onDestroy(() => {
    if (enableKeyboardShortcuts && typeof window !== "undefined") {
        window.removeEventListener("keydown", handleKeydown);
    }
});
```

## Audit

Scanned all `.svelte` components in `packages/` for the same pattern (`onDestroy` + browser globals without `typeof` guard). **ChatContainer.svelte is the only component with this bug.** Other components that reference `document` or `window` (AutocompleteMenu, ImageEditor, SearchBar) use `$effect` which does not run during SSR, or already have `typeof` guards (BackupCodes, TwoFactorSetup, WalletConnect).

## Test

Added SSR safety test that renders ChatContainer with `window` deleted from `globalThis` to simulate Node SSR. Verifies the component does not throw `ReferenceError`.

## Semver impact

**patch** — bug fix matching documented SSR-safe behavior. No API change.

## Verification

| Gate | Result |
|------|--------|
| Chat tests (232 total) | 232 passed, 0 failed |
| Registry validate | valid |

## Reported by

Simulacrum steward via TheoryMCP email (delivery-b7d608ee1eeb2f31, 2026-07-03)
- Sim repo: equaltoai/simulacrum
- Sim PR: https://github.com/equaltoai/simulacrum/pull/234
- Sim local fix commit: b33d132
- Greater version: v0.11.8