### PR TITLE
fix(messaging): close the contentus M5 messaging-surface quartet (#929-#932)

### DIFF
--- a/packages/adapters/README.md
+++ b/packages/adapters/README.md
@@ -2,6 +2,17 @@
 
 Transport adapters and state management for Greater Components.
 
+## Messaging binding
+
+`createLesserMessagesHandlers` accepts the exported structural `LesserMessagesAdapter` interface.
+`LesserGraphQLAdapter` implements that interface for existing Apollo consumers, while source-installed
+consumers may supply another implementation without installing Apollo, GraphQL, or
+`@graphql-typed-document-node/core` merely to typecheck the binding.
+
+The binding's dependency-free operation documents select only the messaging fields it consumes and
+remain aligned with the pinned Lesser v1.5.33 contract. This is an adapter-only compatibility fix;
+the pinned snapshots do not change.
+
 ## Installation
 
 ```bash

--- a/packages/adapters/src/__tests__/createLesserMessagesHandlers.no-apollo.test.ts
+++ b/packages/adapters/src/__tests__/createLesserMessagesHandlers.no-apollo.test.ts
@@ -1,8 +1,8 @@
-import { spawnSync } from 'node:child_process';
-import { cpSync, existsSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { cpSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
-import { dirname, join } from 'node:path';
+import { dirname, isAbsolute, join, relative } from 'node:path';
 import { fileURLToPath } from 'node:url';
+import ts from 'typescript';
 import { afterEach, describe, expect, it } from 'vitest';
 
 const scratchDirectories: string[] = [];
@@ -13,17 +13,71 @@ afterEach(() => {
 	}
 });
 
-describe('createLesserMessagesHandlers non-Apollo consumer', () => {
-	it('typechecks the vendored binding without GraphQL client packages installed', () => {
-		const scratch = mkdtempSync(join(tmpdir(), 'greater-messages-no-apollo-'));
-		scratchDirectories.push(scratch);
+function isWithin(root: string, candidate: string): boolean {
+	const pathFromRoot = relative(root, candidate);
+	return pathFromRoot === '' || (!pathFromRoot.startsWith('..') && !isAbsolute(pathFromRoot));
+}
 
-		const adaptersSource = dirname(dirname(fileURLToPath(import.meta.url)));
-		cpSync(adaptersSource, join(scratch, 'vendor'), { recursive: true });
+function compileHermetically(scratch: string, consumerPath: string): readonly ts.Diagnostic[] {
+	const options: ts.CompilerOptions = {
+		target: ts.ScriptTarget.ES2022,
+		module: ts.ModuleKind.NodeNext,
+		moduleResolution: ts.ModuleResolutionKind.NodeNext,
+		strict: true,
+		noEmit: true,
+		types: [],
+	};
+	const host = ts.createCompilerHost(options);
 
-		writeFileSync(
-			join(scratch, 'consumer.ts'),
-			`import {
+	// Only relative/absolute imports that resolve inside the fixture are legal.
+	// This prevents NodeNext from walking to any ancestor node_modules directory;
+	// TypeScript's standard libraries continue to load through the normal host.
+	host.resolveModuleNames = (moduleNames, containingFile) =>
+		moduleNames.map((moduleName) => {
+			if (!moduleName.startsWith('.') && !isAbsolute(moduleName)) return undefined;
+			const resolved = ts.resolveModuleName(
+				moduleName,
+				containingFile,
+				options,
+				host
+			).resolvedModule;
+			return resolved && isWithin(scratch, resolved.resolvedFileName) ? resolved : undefined;
+		});
+
+	const program = ts.createProgram({ rootNames: [consumerPath], options, host });
+	return ts.getPreEmitDiagnostics(program);
+}
+
+function formatDiagnostics(diagnostics: readonly ts.Diagnostic[]): string {
+	return ts.formatDiagnosticsWithColorAndContext(diagnostics, {
+		getCanonicalFileName: (fileName) => fileName,
+		getCurrentDirectory: () => process.cwd(),
+		getNewLine: () => '\n',
+	});
+}
+
+function createFixture(): { parent: string; scratch: string; consumerPath: string } {
+	const parent = mkdtempSync(join(tmpdir(), 'greater-messages-no-apollo-'));
+	scratchDirectories.push(parent);
+	const scratch = join(parent, 'consumer');
+	mkdirSync(scratch);
+
+	// Deliberately plant the exact ancestor decoy that made the old assertion
+	// spuriously green. The hermetic resolver must never consult it.
+	const decoyDirectory = join(parent, 'node_modules', '@apollo', 'client');
+	mkdirSync(decoyDirectory, { recursive: true });
+	writeFileSync(join(decoyDirectory, 'index.d.ts'), 'export interface ApolloDecoy {}\n');
+	writeFileSync(
+		join(decoyDirectory, 'package.json'),
+		'{"name":"@apollo/client","types":"index.d.ts"}\n'
+	);
+
+	const adaptersSource = dirname(dirname(fileURLToPath(import.meta.url)));
+	cpSync(adaptersSource, join(scratch, 'vendor'), { recursive: true });
+	const consumerPath = join(scratch, 'consumer.ts');
+	writeFileSync(
+		consumerPath,
+		`import {
 	createLesserMessagesHandlers,
 	type LesserMessagesAdapter,
 } from './vendor/messaging/createLesserMessagesHandlers.js';
@@ -40,34 +94,47 @@ const adapter: LesserMessagesAdapter = {
 	}),
 };
 
+class ParameterDriftProbe implements LesserMessagesAdapter {
+	query = adapter.query;
+	mutate = adapter.mutate;
+	getConversations = adapter.getConversations;
+	// This must remain an error: method bivariance must not accept a narrower parameter.
+	// @ts-expect-error deliberate compile-time parameter drift probe
+	getConversation(id: 'only-this-literal') {
+		return Promise.resolve(null);
+	}
+	markConversationAsRead = adapter.markConversationAsRead;
+	search = adapter.search;
+	subscribeToConversationUpdates = adapter.subscribeToConversationUpdates;
+}
+
+void ParameterDriftProbe;
 createLesserMessagesHandlers({ adapter });
 `
-		);
+	);
 
+	return { parent, scratch, consumerPath };
+}
+
+describe('createLesserMessagesHandlers non-Apollo consumer', () => {
+	it('typechecks with a resolver pinned away from ancestor node_modules', () => {
+		const { scratch, consumerPath } = createFixture();
+		const diagnostics = compileHermetically(scratch, consumerPath);
+
+		expect(formatDiagnostics(diagnostics)).toBe('');
+	});
+
+	it('rejects an Apollo type leak even when an ancestor decoy could satisfy it', () => {
+		const { scratch, consumerPath } = createFixture();
+		const bindingPath = join(scratch, 'vendor', 'messaging', 'createLesserMessagesHandlers.ts');
 		writeFileSync(
-			join(scratch, 'tsconfig.json'),
-			JSON.stringify({
-				compilerOptions: {
-					target: 'ES2022',
-					module: 'NodeNext',
-					moduleResolution: 'NodeNext',
-					strict: true,
-					noEmit: true,
-					types: [],
-					lib: ['ES2022', 'DOM'],
-				},
-				files: ['consumer.ts'],
-			})
+			bindingPath,
+			`import type { ApolloDecoy } from '@apollo/client';\ntype ApolloLeak = ApolloDecoy;\nvoid (undefined as unknown as ApolloLeak);\n${readFileSync(bindingPath, 'utf8')}`
 		);
 
-		const tscPath = join(process.cwd(), '../../node_modules/typescript/bin/tsc');
-		const result = spawnSync(process.execPath, [tscPath, '-p', join(scratch, 'tsconfig.json')], {
-			cwd: scratch,
-			encoding: 'utf8',
-		});
+		const diagnostics = compileHermetically(scratch, consumerPath);
+		const output = formatDiagnostics(diagnostics);
 
-		expect(result.status, `${result.stdout}${result.stderr}`).toBe(0);
-		expect(result.stdout).toBe('');
-		expect(existsSync(join(scratch, 'node_modules'))).toBe(false);
+		expect(output).toContain("Cannot find module '@apollo/client'");
 	});
 });

--- a/packages/adapters/src/__tests__/createLesserMessagesHandlers.no-apollo.test.ts
+++ b/packages/adapters/src/__tests__/createLesserMessagesHandlers.no-apollo.test.ts
@@ -1,0 +1,73 @@
+import { spawnSync } from 'node:child_process';
+import { cpSync, existsSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { afterEach, describe, expect, it } from 'vitest';
+
+const scratchDirectories: string[] = [];
+
+afterEach(() => {
+	for (const directory of scratchDirectories.splice(0)) {
+		rmSync(directory, { recursive: true, force: true });
+	}
+});
+
+describe('createLesserMessagesHandlers non-Apollo consumer', () => {
+	it('typechecks the vendored binding without GraphQL client packages installed', () => {
+		const scratch = mkdtempSync(join(tmpdir(), 'greater-messages-no-apollo-'));
+		scratchDirectories.push(scratch);
+
+		const adaptersSource = dirname(dirname(fileURLToPath(import.meta.url)));
+		cpSync(adaptersSource, join(scratch, 'vendor'), { recursive: true });
+
+		writeFileSync(
+			join(scratch, 'consumer.ts'),
+			`import {
+	createLesserMessagesHandlers,
+	type LesserMessagesAdapter,
+} from './vendor/messaging/createLesserMessagesHandlers.js';
+
+const adapter: LesserMessagesAdapter = {
+	query: async () => ({} as never),
+	mutate: async () => ({} as never),
+	getConversations: async () => [],
+	getConversation: async () => null,
+	markConversationAsRead: async () => undefined,
+	search: async () => ({ accounts: [] }),
+	subscribeToConversationUpdates: () => ({
+		subscribe: () => ({ unsubscribe() {} }),
+	}),
+};
+
+createLesserMessagesHandlers({ adapter });
+`
+		);
+
+		writeFileSync(
+			join(scratch, 'tsconfig.json'),
+			JSON.stringify({
+				compilerOptions: {
+					target: 'ES2022',
+					module: 'NodeNext',
+					moduleResolution: 'NodeNext',
+					strict: true,
+					noEmit: true,
+					types: [],
+					lib: ['ES2022', 'DOM'],
+				},
+				files: ['consumer.ts'],
+			})
+		);
+
+		const tscPath = join(process.cwd(), '../../node_modules/typescript/bin/tsc');
+		const result = spawnSync(process.execPath, [tscPath, '-p', join(scratch, 'tsconfig.json')], {
+			cwd: scratch,
+			encoding: 'utf8',
+		});
+
+		expect(result.status, `${result.stdout}${result.stderr}`).toBe(0);
+		expect(result.stdout).toBe('');
+		expect(existsSync(join(scratch, 'node_modules'))).toBe(false);
+	});
+});

--- a/packages/adapters/src/__tests__/createLesserMessagesHandlers.test.ts
+++ b/packages/adapters/src/__tests__/createLesserMessagesHandlers.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { print } from 'graphql';
 import { createLesserMessagesHandlers } from '../messaging/createLesserMessagesHandlers.js';
 import {
 	AcceptMessageRequestDocument,
@@ -8,7 +9,7 @@ import {
 	DeleteConversationDocument,
 	DeleteMessageDocument,
 	SendMessageDocument,
-} from '../graphql/generated/types.js';
+} from '../messaging/messagingOperations.js';
 
 describe('createLesserMessagesHandlers', () => {
 	const adapter = {
@@ -23,6 +24,20 @@ describe('createLesserMessagesHandlers', () => {
 
 	beforeEach(() => {
 		vi.clearAllMocks();
+	});
+
+	it('uses valid dependency-free GraphQL operation documents', () => {
+		for (const document of [
+			ConversationMessagesDocument,
+			CreateConversationDocument,
+			SendMessageDocument,
+			AcceptMessageRequestDocument,
+			DeclineMessageRequestDocument,
+			DeleteConversationDocument,
+			DeleteMessageDocument,
+		]) {
+			expect(print(document)).toMatch(/^(query|mutation) /);
+		}
 	});
 
 	it('fetches conversations by folder', async () => {

--- a/packages/adapters/src/graphql/LesserGraphQLAdapter.ts
+++ b/packages/adapters/src/graphql/LesserGraphQLAdapter.ts
@@ -20,6 +20,7 @@ type MutationOptionsFor<
 import type { TypedDocumentNode } from '@graphql-typed-document-node/core';
 import { print } from 'graphql';
 import { extractServerErrorCodes } from '../authExpiry.js';
+import type { LesserMessagesAdapter } from '../messaging/createLesserMessagesHandlers.js';
 
 import {
 	createGraphQLClient,
@@ -647,7 +648,7 @@ export function isDraftReviewShareConflict(error: unknown): boolean {
 	return codes.some((code) => DRAFT_REVIEW_CONFLICT_CODES.includes(code));
 }
 
-export class LesserGraphQLAdapter {
+export class LesserGraphQLAdapter implements LesserMessagesAdapter {
 	private readonly client: GraphQLClientInstance;
 	private readonly httpEndpoint: string;
 	private readonly baseHeaders: Record<string, string>;

--- a/packages/adapters/src/index.ts
+++ b/packages/adapters/src/index.ts
@@ -245,7 +245,7 @@ export type {
 
 // Messaging handlers (Lesser → shared/messaging)
 export { createLesserMessagesHandlers } from './messaging/index.js';
-export type { LesserMessagesHandlersConfig } from './messaging/index.js';
+export type { LesserMessagesAdapter, LesserMessagesHandlersConfig } from './messaging/index.js';
 
 // Reactive Stores (Svelte 5 Runes)
 export {

--- a/packages/adapters/src/messaging/createLesserMessagesHandlers.ts
+++ b/packages/adapters/src/messaging/createLesserMessagesHandlers.ts
@@ -1,5 +1,3 @@
-import type { LesserGraphQLAdapter } from '../graphql/LesserGraphQLAdapter.js';
-import type { ActorSummaryFragment, ObjectFieldsFragment } from '../graphql/generated/types.js';
 import {
 	AcceptMessageRequestDocument,
 	ConversationMessagesDocument,
@@ -8,7 +6,13 @@ import {
 	DeleteConversationDocument,
 	DeleteMessageDocument,
 	SendMessageDocument,
-} from '../graphql/generated/types.js';
+} from './messagingOperations.js';
+import type {
+	LesserMessageActor,
+	LesserMessageConversation,
+	LesserMessageObject,
+	MessagesDocumentNode,
+} from './messagingOperations.js';
 
 export type ConversationFolder = 'INBOX' | 'REQUESTS';
 export type DmRequestState = 'PENDING' | 'ACCEPTED' | 'DECLINED';
@@ -89,30 +93,52 @@ export interface MessagesHandlers {
 	onSubscribeToConversationUpdates?: (callbacks: MessagesRealtimeCallbacks) => () => void;
 }
 
+export interface LesserMessagesAdapter {
+	query<
+		TData extends Record<string, unknown>,
+		TVariables extends Record<string, unknown> = Record<string, unknown>,
+	>(
+		document: MessagesDocumentNode<TData, TVariables>,
+		variables?: TVariables
+	): Promise<TData>;
+	mutate<
+		TData extends Record<string, unknown>,
+		TVariables extends Record<string, unknown> = Record<string, unknown>,
+	>(
+		document: MessagesDocumentNode<TData, TVariables>,
+		variables?: TVariables
+	): Promise<TData>;
+	getConversations(variables: {
+		folder?: ConversationFolder;
+		first?: number;
+		after?: string;
+	}): Promise<ReadonlyArray<LesserMessageConversation>>;
+	getConversation(id: string): Promise<LesserMessageConversation | null | undefined>;
+	markConversationAsRead(id: string): Promise<unknown>;
+	search(variables: {
+		query: string;
+		type: 'accounts';
+		first?: number;
+	}): Promise<{ accounts: ReadonlyArray<LesserMessageActor> }>;
+	subscribeToConversationUpdates(): {
+		subscribe(observer: {
+			next: (value: { data?: { conversationUpdates?: { id: string } | null } | null }) => void;
+			error: (error: unknown) => void;
+			complete: () => void;
+		}): { unsubscribe(): void };
+	};
+}
+
 export interface LesserMessagesHandlersConfig {
-	adapter: LesserGraphQLAdapter;
+	adapter: LesserMessagesAdapter;
 	pageSize?: number;
 	messagePageSize?: number;
 	searchLimit?: number;
 }
 
-type LesserConversationLike = {
-	id: string;
-	unread: boolean;
-	updatedAt: string;
-	accounts: ReadonlyArray<ActorSummaryFragment>;
-	lastStatus?: ObjectFieldsFragment | null | undefined;
-	viewerMetadata: {
-		requestState: DmRequestState;
-		requestedAt?: string | null | undefined;
-		acceptedAt?: string | null | undefined;
-		declinedAt?: string | null | undefined;
-	};
-};
+type LesserConversationLike = LesserMessageConversation;
 
-function getCanonicalParticipantId(
-	actor: Pick<ActorSummaryFragment, 'id' | 'username' | 'domain'>
-) {
+function getCanonicalParticipantId(actor: Pick<LesserMessageActor, 'id' | 'username' | 'domain'>) {
 	if (actor.domain) {
 		return actor.id;
 	}
@@ -136,11 +162,11 @@ function getCanonicalParticipantId(
 	return actor.id;
 }
 
-function getParticipantHandle(actor: Pick<ActorSummaryFragment, 'username' | 'domain'>): string {
+function getParticipantHandle(actor: Pick<LesserMessageActor, 'username' | 'domain'>): string {
 	return actor.domain ? `${actor.username}@${actor.domain}` : actor.username;
 }
 
-function mapActorToParticipant(actor: ActorSummaryFragment): MessageParticipant {
+function mapActorToParticipant(actor: LesserMessageActor): MessageParticipant {
 	return {
 		id: getCanonicalParticipantId(actor),
 		actorId: actor.id,
@@ -152,7 +178,7 @@ function mapActorToParticipant(actor: ActorSummaryFragment): MessageParticipant 
 }
 
 function mapObjectToDirectMessage(
-	object: ObjectFieldsFragment,
+	object: LesserMessageObject,
 	conversationId: string
 ): DirectMessage {
 	return {

--- a/packages/adapters/src/messaging/createLesserMessagesHandlers.ts
+++ b/packages/adapters/src/messaging/createLesserMessagesHandlers.ts
@@ -94,33 +94,33 @@ export interface MessagesHandlers {
 }
 
 export interface LesserMessagesAdapter {
-	query<
+	query: <
 		TData extends Record<string, unknown>,
 		TVariables extends Record<string, unknown> = Record<string, unknown>,
 	>(
 		document: MessagesDocumentNode<TData, TVariables>,
 		variables?: TVariables
-	): Promise<TData>;
-	mutate<
+	) => Promise<TData>;
+	mutate: <
 		TData extends Record<string, unknown>,
 		TVariables extends Record<string, unknown> = Record<string, unknown>,
 	>(
 		document: MessagesDocumentNode<TData, TVariables>,
 		variables?: TVariables
-	): Promise<TData>;
-	getConversations(variables: {
+	) => Promise<TData>;
+	getConversations: (variables: {
 		folder?: ConversationFolder;
 		first?: number;
 		after?: string;
-	}): Promise<ReadonlyArray<LesserMessageConversation>>;
-	getConversation(id: string): Promise<LesserMessageConversation | null | undefined>;
-	markConversationAsRead(id: string): Promise<unknown>;
-	search(variables: {
+	}) => Promise<ReadonlyArray<LesserMessageConversation>>;
+	getConversation: (id: string) => Promise<LesserMessageConversation | null | undefined>;
+	markConversationAsRead: (id: string) => Promise<unknown>;
+	search: (variables: {
 		query: string;
 		type: 'accounts';
 		first?: number;
-	}): Promise<{ accounts: ReadonlyArray<LesserMessageActor> }>;
-	subscribeToConversationUpdates(): {
+	}) => Promise<{ accounts: ReadonlyArray<LesserMessageActor> }>;
+	subscribeToConversationUpdates: () => {
 		subscribe(observer: {
 			next: (value: { data?: { conversationUpdates?: { id: string } | null } | null }) => void;
 			error: (error: unknown) => void;

--- a/packages/adapters/src/messaging/index.ts
+++ b/packages/adapters/src/messaging/index.ts
@@ -1,2 +1,5 @@
 export { createLesserMessagesHandlers } from './createLesserMessagesHandlers.js';
-export type { LesserMessagesHandlersConfig } from './createLesserMessagesHandlers.js';
+export type {
+	LesserMessagesAdapter,
+	LesserMessagesHandlersConfig,
+} from './createLesserMessagesHandlers.js';

--- a/packages/adapters/src/messaging/messagingOperations.ts
+++ b/packages/adapters/src/messaging/messagingOperations.ts
@@ -1,0 +1,320 @@
+/**
+ * GraphQL AST and response shapes used by the messaging binding.
+ *
+ * These deliberately model only the structural GraphQL document contract that the binding needs.
+ * Keeping this module dependency-free lets source-installed consumers provide a non-Apollo adapter
+ * without pulling Apollo or GraphQL's type packages into their typecheck.
+ */
+
+interface NameNode {
+	readonly kind: 'Name';
+	readonly value: string;
+}
+
+interface VariableNode {
+	readonly kind: 'Variable';
+	readonly name: NameNode;
+}
+
+interface NamedTypeNode {
+	readonly kind: 'NamedType';
+	readonly name: NameNode;
+}
+
+interface ListTypeNode {
+	readonly kind: 'ListType';
+	readonly type: TypeNode;
+}
+
+interface NonNullTypeNode {
+	readonly kind: 'NonNullType';
+	readonly type: NamedTypeNode | ListTypeNode;
+}
+
+type TypeNode = NamedTypeNode | ListTypeNode | NonNullTypeNode;
+
+interface ArgumentNode {
+	readonly kind: 'Argument';
+	readonly name: NameNode;
+	readonly value: VariableNode;
+}
+
+interface FieldNode {
+	readonly kind: 'Field';
+	readonly name: NameNode;
+	readonly arguments?: readonly ArgumentNode[];
+	readonly selectionSet?: SelectionSetNode;
+}
+
+interface SelectionSetNode {
+	readonly kind: 'SelectionSet';
+	readonly selections: readonly FieldNode[];
+}
+
+interface VariableDefinitionNode {
+	readonly kind: 'VariableDefinition';
+	readonly variable: VariableNode;
+	readonly type: TypeNode;
+}
+
+export interface MessagesDocumentNode<
+	TData extends Record<string, unknown>,
+	TVariables extends Record<string, unknown>,
+> {
+	/** Opaque GraphQL Document kind; the runtime value is `Document`. */
+	readonly kind: never;
+	/** Opaque executable definitions owned by this binding. */
+	readonly definitions: readonly never[];
+	readonly __apiType?: (variables: TVariables) => TData;
+}
+
+export interface LesserMessageActor {
+	id: string;
+	username: string;
+	domain?: string | null;
+	displayName?: string | null;
+	avatar?: string | null;
+}
+
+export interface LesserMessageObject {
+	id: string;
+	content: string;
+	createdAt: string;
+	sensitive: boolean;
+	spoilerText?: string | null;
+	actor: LesserMessageActor;
+	attachments: ReadonlyArray<{
+		url: string;
+		type: string;
+		preview?: string | null;
+		description?: string | null;
+	}>;
+}
+
+export interface LesserMessageConversation {
+	id: string;
+	unread: boolean;
+	updatedAt: string;
+	accounts: ReadonlyArray<LesserMessageActor>;
+	lastStatus?: LesserMessageObject | null;
+	viewerMetadata: {
+		requestState: 'PENDING' | 'ACCEPTED' | 'DECLINED';
+		requestedAt?: string | null;
+		acceptedAt?: string | null;
+		declinedAt?: string | null;
+	};
+}
+
+export type ConversationMessagesVariables = Record<string, unknown> & {
+	conversationId: string;
+	first?: number;
+	after?: string;
+};
+
+export type ConversationMessagesData = Record<string, unknown> & {
+	conversationMessages: {
+		edges: ReadonlyArray<{ node: LesserMessageObject }>;
+	};
+};
+
+export type SendMessageVariables = Record<string, unknown> & {
+	conversationId: string;
+	content: string;
+	mediaIds?: string[];
+};
+
+export type SendMessageData = Record<string, unknown> & {
+	sendMessage: { message: LesserMessageObject };
+};
+
+export type CreateConversationVariables = Record<string, unknown> & { participantId: string };
+export type CreateConversationData = Record<string, unknown> & {
+	createConversation: LesserMessageConversation;
+};
+
+export type ConversationIdVariables = Record<string, unknown> & { conversationId: string };
+export type AcceptMessageRequestData = Record<string, unknown> & {
+	acceptMessageRequest: LesserMessageConversation;
+};
+export type DeclineMessageRequestData = Record<string, unknown> & {
+	declineMessageRequest: boolean;
+};
+export type DeleteConversationData = Record<string, unknown> & { deleteConversation: boolean };
+
+export type MessageIdVariables = Record<string, unknown> & { messageId: string };
+export type DeleteMessageData = Record<string, unknown> & { deleteMessage: boolean };
+
+const name = (value: string): NameNode => ({ kind: 'Name', value });
+const variable = (value: string): VariableNode => ({ kind: 'Variable', name: name(value) });
+const namedType = (value: string): NamedTypeNode => ({ kind: 'NamedType', name: name(value) });
+const listType = (type: TypeNode): ListTypeNode => ({ kind: 'ListType', type });
+const nonNull = (type: NamedTypeNode | ListTypeNode): NonNullTypeNode => ({
+	kind: 'NonNullType',
+	type,
+});
+const variableDefinition = (value: string, type: TypeNode): VariableDefinitionNode => ({
+	kind: 'VariableDefinition',
+	variable: variable(value),
+	type,
+});
+const argument = (value: string): ArgumentNode => ({
+	kind: 'Argument',
+	name: name(value),
+	value: variable(value),
+});
+const selectionSet = (selections: readonly FieldNode[]): SelectionSetNode => ({
+	kind: 'SelectionSet',
+	selections,
+});
+const field = (
+	value: string,
+	options: { arguments?: readonly ArgumentNode[]; selections?: readonly FieldNode[] } = {}
+): FieldNode => ({
+	kind: 'Field',
+	name: name(value),
+	...(options.arguments ? { arguments: options.arguments } : {}),
+	...(options.selections ? { selectionSet: selectionSet(options.selections) } : {}),
+});
+
+const actorFields = [
+	field('id'),
+	field('username'),
+	field('domain'),
+	field('displayName'),
+	field('avatar'),
+];
+
+const messageFields = [
+	field('id'),
+	field('content'),
+	field('createdAt'),
+	field('sensitive'),
+	field('spoilerText'),
+	field('actor', { selections: actorFields }),
+	field('attachments', {
+		selections: [field('url'), field('type'), field('preview'), field('description')],
+	}),
+];
+
+const conversationFields = [
+	field('id'),
+	field('unread'),
+	field('updatedAt'),
+	field('accounts', { selections: actorFields }),
+	field('lastStatus', { selections: messageFields }),
+	field('viewerMetadata', {
+		selections: [
+			field('requestState'),
+			field('requestedAt'),
+			field('acceptedAt'),
+			field('declinedAt'),
+		],
+	}),
+];
+
+function operation<
+	TData extends Record<string, unknown>,
+	TVariables extends Record<string, unknown>,
+>(
+	operationType: 'query' | 'mutation',
+	operationName: string,
+	variables: readonly VariableDefinitionNode[],
+	rootField: FieldNode
+): MessagesDocumentNode<TData, TVariables> {
+	return {
+		kind: 'Document',
+		definitions: [
+			{
+				kind: 'OperationDefinition',
+				operation: operationType,
+				name: name(operationName),
+				variableDefinitions: variables,
+				selectionSet: selectionSet([rootField]),
+			},
+		],
+	} as unknown as MessagesDocumentNode<TData, TVariables>;
+}
+
+export const ConversationMessagesDocument = operation<
+	ConversationMessagesData,
+	ConversationMessagesVariables
+>(
+	'query',
+	'ConversationMessages',
+	[
+		variableDefinition('conversationId', nonNull(namedType('ID'))),
+		variableDefinition('first', namedType('Int')),
+		variableDefinition('after', namedType('Cursor')),
+	],
+	field('conversationMessages', {
+		arguments: [argument('conversationId'), argument('first'), argument('after')],
+		selections: [field('edges', { selections: [field('node', { selections: messageFields })] })],
+	})
+);
+
+export const SendMessageDocument = operation<SendMessageData, SendMessageVariables>(
+	'mutation',
+	'SendMessage',
+	[
+		variableDefinition('conversationId', nonNull(namedType('ID'))),
+		variableDefinition('content', nonNull(namedType('String'))),
+		variableDefinition('mediaIds', listType(nonNull(namedType('ID')))),
+	],
+	field('sendMessage', {
+		arguments: [argument('conversationId'), argument('content'), argument('mediaIds')],
+		selections: [field('message', { selections: messageFields })],
+	})
+);
+
+export const CreateConversationDocument = operation<
+	CreateConversationData,
+	CreateConversationVariables
+>(
+	'mutation',
+	'CreateConversation',
+	[variableDefinition('participantId', nonNull(namedType('ID')))],
+	field('createConversation', {
+		arguments: [argument('participantId')],
+		selections: conversationFields,
+	})
+);
+
+export const AcceptMessageRequestDocument = operation<
+	AcceptMessageRequestData,
+	ConversationIdVariables
+>(
+	'mutation',
+	'AcceptMessageRequest',
+	[variableDefinition('conversationId', nonNull(namedType('ID')))],
+	field('acceptMessageRequest', {
+		arguments: [argument('conversationId')],
+		selections: conversationFields,
+	})
+);
+
+export const DeclineMessageRequestDocument = operation<
+	DeclineMessageRequestData,
+	ConversationIdVariables
+>(
+	'mutation',
+	'DeclineMessageRequest',
+	[variableDefinition('conversationId', nonNull(namedType('ID')))],
+	field('declineMessageRequest', { arguments: [argument('conversationId')] })
+);
+
+export const DeleteConversationDocument = operation<
+	DeleteConversationData,
+	ConversationIdVariables
+>(
+	'mutation',
+	'DeleteConversation',
+	[variableDefinition('conversationId', nonNull(namedType('ID')))],
+	field('deleteConversation', { arguments: [argument('conversationId')] })
+);
+
+export const DeleteMessageDocument = operation<DeleteMessageData, MessageIdVariables>(
+	'mutation',
+	'DeleteMessage',
+	[variableDefinition('messageId', nonNull(namedType('ID')))],
+	field('deleteMessage', { arguments: [argument('messageId')] })
+);

--- a/packages/shared/messaging/README.md
+++ b/packages/shared/messaging/README.md
@@ -20,6 +20,31 @@ Message `content` is treated as server-rendered HTML and passed through Greater'
 sanitizer before rendering. Conversation cards intentionally show a sanitized plain-text excerpt so
 the single-line preview cannot introduce nested block or interactive markup.
 
+### Folder routing and request actions
+
+`Conversations` exposes a bindable `folder` prop instead of a mount-only initial value so URL state
+and tab changes can stay synchronized. Omitting it preserves the existing context-owned Inbox
+behavior and single-button card markup.
+
+```svelte
+<script lang="ts">
+	import * as Messaging from '@equaltoai/greater-components/shared/messaging';
+
+	let folder: Messaging.ConversationFolder = $state('REQUESTS');
+</script>
+
+<Messaging.Conversations bind:folder>
+	{#snippet actions(conversation)}
+		<button type="button" onclick={() => acceptRequest(conversation.id)}>Accept</button>
+		<button type="button" onclick={() => declineRequest(conversation.id)}>Decline</button>
+	{/snippet}
+</Messaging.Conversations>
+```
+
+When `actions` is supplied, the card selection button and action controls are siblings, avoiding
+nested interactive elements while keeping the entire default card as the selection button when the
+snippet is omitted.
+
 ## Standalone package
 
 ```ts

--- a/packages/shared/messaging/README.md
+++ b/packages/shared/messaging/README.md
@@ -16,6 +16,10 @@ Direct messaging components for Greater Components.
 </Messaging.Root>
 ```
 
+Message `content` is treated as server-rendered HTML and passed through Greater's allow-list
+sanitizer before rendering. Conversation cards intentionally show a sanitized plain-text excerpt so
+the single-line preview cannot introduce nested block or interactive markup.
+
 ## Standalone package
 
 ```ts

--- a/packages/shared/messaging/README.md
+++ b/packages/shared/messaging/README.md
@@ -45,6 +45,10 @@ When `actions` is supplied, the card selection button and action controls are si
 nested interactive elements while keeping the entire default card as the selection button when the
 snippet is omitted.
 
+`UnreadIndicator` counts conversations whose `unreadCount` is positive. Its accessible label names
+that unit explicitly (for example, “2 conversations with unread messages”); Lesser's pinned contract
+exposes unread activity per conversation rather than a per-message unread total.
+
 ## Standalone package
 
 ```ts

--- a/packages/shared/messaging/package.json
+++ b/packages/shared/messaging/package.json
@@ -36,7 +36,8 @@
     "@equaltoai/greater-components-compose": "workspace:*",
     "@equaltoai/greater-components-headless": "workspace:*",
     "@equaltoai/greater-components-icons": "workspace:*",
-    "@equaltoai/greater-components-primitives": "workspace:*"
+    "@equaltoai/greater-components-primitives": "workspace:*",
+    "@equaltoai/greater-components-utils": "workspace:*"
   },
   "devDependencies": {
     "@sveltejs/vite-plugin-svelte": "^7.0.0",

--- a/packages/shared/messaging/package.json
+++ b/packages/shared/messaging/package.json
@@ -45,7 +45,6 @@
   "devDependencies": {
     "@sveltejs/vite-plugin-svelte": "^7.0.0",
     "@testing-library/svelte": "^5.3.1",
-    "@types/hast": "^3.0.4",
     "@types/node": "^25.6.0",
     "@vitest/coverage-v8": "^4.1.4",
     "jsdom": "^29.0.2",

--- a/packages/shared/messaging/package.json
+++ b/packages/shared/messaging/package.json
@@ -37,11 +37,15 @@
     "@equaltoai/greater-components-headless": "workspace:*",
     "@equaltoai/greater-components-icons": "workspace:*",
     "@equaltoai/greater-components-primitives": "workspace:*",
-    "@equaltoai/greater-components-utils": "workspace:*"
+    "@equaltoai/greater-components-utils": "workspace:*",
+    "rehype-parse": "^9.0.1",
+    "rehype-stringify": "^10.0.1",
+    "unified": "^11.0.5"
   },
   "devDependencies": {
     "@sveltejs/vite-plugin-svelte": "^7.0.0",
     "@testing-library/svelte": "^5.3.1",
+    "@types/hast": "^3.0.4",
     "@types/node": "^25.6.0",
     "@vitest/coverage-v8": "^4.1.4",
     "jsdom": "^29.0.2",

--- a/packages/shared/messaging/src/Conversations.svelte
+++ b/packages/shared/messaging/src/Conversations.svelte
@@ -3,17 +3,25 @@
 -->
 <script lang="ts">
 	import { sanitizeForPreview } from '@equaltoai/greater-components-utils';
+	import { untrack, type Snippet } from 'svelte';
 	import { getMessagesContext } from './context.svelte.js';
 	import { getConversationName, formatMessageTime } from './utils.js';
-	import type { Conversation } from './context.svelte.js';
+	import type { Conversation, ConversationFolder } from './context.svelte.js';
 	import ConversationWorkflowSummary from './ConversationWorkflowSummary.svelte';
 
 	interface Props {
 		currentUserId?: string;
+		folder?: ConversationFolder;
+		actions?: Snippet<[conversation: Conversation]>;
 		class?: string;
 	}
 
-	let { currentUserId = 'me', class: className = '' }: Props = $props();
+	let {
+		currentUserId = 'me',
+		folder = $bindable(),
+		actions,
+		class: className = '',
+	}: Props = $props();
 
 	const {
 		state: messagesState,
@@ -22,10 +30,37 @@
 		fetchConversations,
 		startRealtime,
 	} = getMessagesContext();
+	let lastControlledFolder: ConversationFolder | undefined;
+
+	const activeFolder = $derived(folder ?? messagesState.folder);
+
+	function requestFolder(nextFolder: ConversationFolder) {
+		void fetchConversations(nextFolder);
+	}
+
+	$effect(() => {
+		const nextFolder = folder;
+		if (nextFolder === lastControlledFolder) {
+			return;
+		}
+		lastControlledFolder = nextFolder;
+
+		if (nextFolder !== undefined && nextFolder !== untrack(() => messagesState.folder)) {
+			requestFolder(nextFolder);
+		}
+	});
 
 	function handleConversationClick(conversation: Conversation) {
 		selectConversation(conversation);
 		handlers.onConversationClick?.(conversation);
+	}
+
+	function handleFolderClick(nextFolder: ConversationFolder) {
+		if (folder !== undefined) {
+			lastControlledFolder = nextFolder;
+			folder = nextFolder;
+		}
+		requestFolder(nextFolder);
 	}
 
 	function getMessagePreview(conversation: Conversation): string {
@@ -38,27 +73,64 @@
 	}
 </script>
 
+{#snippet conversationContent(conversation: Conversation)}
+	<div class="messages-conversations__avatar">
+		{#if conversation.participants[0]?.avatar}
+			<img src={conversation.participants[0].avatar} alt="" />
+		{:else}
+			<div class="messages-conversations__avatar-placeholder">
+				{conversation.participants[0]?.displayName[0]?.toUpperCase()}
+			</div>
+		{/if}
+	</div>
+
+	<div class="messages-conversations__content">
+		<div class="messages-conversations__name">
+			{getConversationName(conversation, currentUserId)}
+		</div>
+		{#if conversation.workflowSummary}
+			<ConversationWorkflowSummary summary={conversation.workflowSummary} compact />
+		{/if}
+		{#if conversation.lastMessage}
+			<div class="messages-conversations__preview">
+				{getMessagePreview(conversation)}
+			</div>
+		{/if}
+	</div>
+
+	<div class="messages-conversations__meta">
+		{#if conversation.lastMessage}
+			<time class="messages-conversations__time">
+				{formatMessageTime(conversation.lastMessage.createdAt)}
+			</time>
+		{/if}
+		{#if conversation.unreadCount > 0}
+			<span class="messages-conversations__badge">{conversation.unreadCount}</span>
+		{/if}
+	</div>
+{/snippet}
+
 <div class={`messages-conversations ${className}`}>
 	<div class="messages-conversations__header">
 		<h2 class="messages-conversations__title">Messages</h2>
 		<div class="messages-conversations__tabs" role="tablist" aria-label="Message folders">
 			<button
 				class="messages-conversations__tab"
-				class:messages-conversations__tab--active={messagesState.folder === 'INBOX'}
+				class:messages-conversations__tab--active={activeFolder === 'INBOX'}
 				type="button"
 				role="tab"
-				aria-selected={messagesState.folder === 'INBOX'}
-				onclick={() => fetchConversations('INBOX')}
+				aria-selected={activeFolder === 'INBOX'}
+				onclick={() => handleFolderClick('INBOX')}
 			>
 				Inbox
 			</button>
 			<button
 				class="messages-conversations__tab"
-				class:messages-conversations__tab--active={messagesState.folder === 'REQUESTS'}
+				class:messages-conversations__tab--active={activeFolder === 'REQUESTS'}
 				type="button"
 				role="tab"
-				aria-selected={messagesState.folder === 'REQUESTS'}
-				onclick={() => fetchConversations('REQUESTS')}
+				aria-selected={activeFolder === 'REQUESTS'}
+				onclick={() => handleFolderClick('REQUESTS')}
 			>
 				Requests
 				{#if messagesState.requestCount > 0}
@@ -95,53 +167,45 @@
 			<svg viewBox="0 0 24 24" fill="currentColor">
 				<path d="M20 2H4c-1.1 0-2 .9-2 2v18l4-4h14c1.1 0 2-.9 2-2V4c0-1.1-.9-2-2-2z" />
 			</svg>
-			<p>{messagesState.folder === 'REQUESTS' ? 'No message requests' : 'No messages yet'}</p>
+			<p>{activeFolder === 'REQUESTS' ? 'No message requests' : 'No messages yet'}</p>
 		</div>
 	{:else}
 		<div class="messages-conversations__list">
 			{#each messagesState.conversations as conversation (conversation.id)}
-				<button
-					class="messages-conversations__item"
-					class:messages-conversations__item--selected={messagesState.selectedConversation?.id ===
-						conversation.id}
-					class:messages-conversations__item--unread={conversation.unreadCount > 0}
-					onclick={() => handleConversationClick(conversation)}
-				>
-					<div class="messages-conversations__avatar">
-						{#if conversation.participants[0]?.avatar}
-							<img src={conversation.participants[0].avatar} alt="" />
-						{:else}
-							<div class="messages-conversations__avatar-placeholder">
-								{conversation.participants[0]?.displayName[0]?.toUpperCase()}
-							</div>
-						{/if}
-					</div>
-
-					<div class="messages-conversations__content">
-						<div class="messages-conversations__name">
-							{getConversationName(conversation, currentUserId)}
+				{#if actions}
+					<div
+						class="messages-conversations__item messages-conversations__item--with-actions"
+						class:messages-conversations__item--selected={messagesState.selectedConversation?.id ===
+							conversation.id}
+						class:messages-conversations__item--unread={conversation.unreadCount > 0}
+						style="grid-template-columns: minmax(0, 1fr) auto;"
+					>
+						<button
+							type="button"
+							class="messages-conversations__item-main"
+							style="display: grid; grid-template-columns: auto minmax(0, 1fr) auto; gap: inherit; min-width: 0; padding: 0; border: 0; background: transparent; color: inherit; font: inherit; text-align: inherit; cursor: pointer;"
+							onclick={() => handleConversationClick(conversation)}
+						>
+							{@render conversationContent(conversation)}
+						</button>
+						<div
+							class="messages-conversations__actions"
+							style="display: flex; align-items: center;"
+						>
+							{@render actions(conversation)}
 						</div>
-						{#if conversation.workflowSummary}
-							<ConversationWorkflowSummary summary={conversation.workflowSummary} compact />
-						{/if}
-						{#if conversation.lastMessage}
-							<div class="messages-conversations__preview">
-								{getMessagePreview(conversation)}
-							</div>
-						{/if}
 					</div>
-
-					<div class="messages-conversations__meta">
-						{#if conversation.lastMessage}
-							<time class="messages-conversations__time">
-								{formatMessageTime(conversation.lastMessage.createdAt)}
-							</time>
-						{/if}
-						{#if conversation.unreadCount > 0}
-							<span class="messages-conversations__badge">{conversation.unreadCount}</span>
-						{/if}
-					</div>
-				</button>
+				{:else}
+					<button
+						class="messages-conversations__item"
+						class:messages-conversations__item--selected={messagesState.selectedConversation?.id ===
+							conversation.id}
+						class:messages-conversations__item--unread={conversation.unreadCount > 0}
+						onclick={() => handleConversationClick(conversation)}
+					>
+						{@render conversationContent(conversation)}
+					</button>
+				{/if}
 			{/each}
 		</div>
 	{/if}

--- a/packages/shared/messaging/src/Conversations.svelte
+++ b/packages/shared/messaging/src/Conversations.svelte
@@ -2,10 +2,10 @@
   Messages.Conversations - Conversations List
 -->
 <script lang="ts">
-	import { sanitizeForPreview } from '@equaltoai/greater-components-utils';
 	import { untrack, type Snippet } from 'svelte';
 	import { getMessagesContext } from './context.svelte.js';
 	import { getConversationName, formatMessageTime } from './utils.js';
+	import { sanitizeMessagePreview } from './sanitize.js';
 	import type { Conversation, ConversationFolder } from './context.svelte.js';
 	import ConversationWorkflowSummary from './ConversationWorkflowSummary.svelte';
 
@@ -31,6 +31,7 @@
 		startRealtime,
 	} = getMessagesContext();
 	let lastControlledFolder: ConversationFolder | undefined;
+	let lastContextFolder: ConversationFolder | undefined;
 
 	const activeFolder = $derived(folder ?? messagesState.folder);
 
@@ -39,14 +40,29 @@
 	}
 
 	$effect(() => {
-		const nextFolder = folder;
-		if (nextFolder === lastControlledFolder) {
+		const nextControlledFolder = folder;
+		const nextContextFolder = messagesState.folder;
+		const controlledFolderChanged = nextControlledFolder !== lastControlledFolder;
+		const contextFolderChanged = nextContextFolder !== lastContextFolder;
+
+		if (controlledFolderChanged) {
+			lastControlledFolder = nextControlledFolder;
+			lastContextFolder = nextContextFolder;
+			if (
+				nextControlledFolder !== undefined &&
+				nextControlledFolder !== untrack(() => messagesState.folder)
+			) {
+				requestFolder(nextControlledFolder);
+			}
 			return;
 		}
-		lastControlledFolder = nextFolder;
 
-		if (nextFolder !== undefined && nextFolder !== untrack(() => messagesState.folder)) {
-			requestFolder(nextFolder);
+		if (contextFolderChanged) {
+			lastContextFolder = nextContextFolder;
+			if (nextControlledFolder !== undefined && nextControlledFolder !== nextContextFolder) {
+				lastControlledFolder = nextContextFolder;
+				folder = nextContextFolder;
+			}
 		}
 	});
 
@@ -69,7 +85,7 @@
 		if (message.sensitive) {
 			return message.spoilerText?.trim() || 'Sensitive message';
 		}
-		return sanitizeForPreview(message.content, 200);
+		return sanitizeMessagePreview(message.content, 200);
 	}
 </script>
 
@@ -178,20 +194,15 @@
 						class:messages-conversations__item--selected={messagesState.selectedConversation?.id ===
 							conversation.id}
 						class:messages-conversations__item--unread={conversation.unreadCount > 0}
-						style="grid-template-columns: minmax(0, 1fr) auto;"
 					>
 						<button
 							type="button"
 							class="messages-conversations__item-main"
-							style="display: grid; grid-template-columns: auto minmax(0, 1fr) auto; gap: inherit; min-width: 0; padding: 0; border: 0; background: transparent; color: inherit; font: inherit; text-align: inherit; cursor: pointer;"
 							onclick={() => handleConversationClick(conversation)}
 						>
 							{@render conversationContent(conversation)}
 						</button>
-						<div
-							class="messages-conversations__actions"
-							style="display: flex; align-items: center;"
-						>
+						<div class="messages-conversations__actions">
 							{@render actions(conversation)}
 						</div>
 					</div>
@@ -210,3 +221,29 @@
 		</div>
 	{/if}
 </div>
+
+<style>
+	:global(.messages-conversations__item--with-actions) {
+		display: grid;
+		grid-template-columns: minmax(0, 1fr) auto;
+	}
+
+	:global(.messages-conversations__item-main) {
+		display: grid;
+		grid-template-columns: auto minmax(0, 1fr) auto;
+		gap: inherit;
+		min-width: 0;
+		padding: 0;
+		border: 0;
+		background: transparent;
+		color: inherit;
+		font: inherit;
+		text-align: inherit;
+		cursor: pointer;
+	}
+
+	:global(.messages-conversations__actions) {
+		display: flex;
+		align-items: center;
+	}
+</style>

--- a/packages/shared/messaging/src/Conversations.svelte
+++ b/packages/shared/messaging/src/Conversations.svelte
@@ -2,6 +2,7 @@
   Messages.Conversations - Conversations List
 -->
 <script lang="ts">
+	import { sanitizeForPreview } from '@equaltoai/greater-components-utils';
 	import { getMessagesContext } from './context.svelte.js';
 	import { getConversationName, formatMessageTime } from './utils.js';
 	import type { Conversation } from './context.svelte.js';
@@ -33,7 +34,7 @@
 		if (message.sensitive) {
 			return message.spoilerText?.trim() || 'Sensitive message';
 		}
-		return message.content;
+		return sanitizeForPreview(message.content, 200);
 	}
 </script>
 

--- a/packages/shared/messaging/src/Conversations.svelte
+++ b/packages/shared/messaging/src/Conversations.svelte
@@ -223,12 +223,12 @@
 </div>
 
 <style>
-	:global(.messages-conversations__item--with-actions) {
+	.messages-conversations__item--with-actions {
 		display: grid;
 		grid-template-columns: minmax(0, 1fr) auto;
 	}
 
-	:global(.messages-conversations__item-main) {
+	.messages-conversations__item-main {
 		display: grid;
 		grid-template-columns: auto minmax(0, 1fr) auto;
 		gap: inherit;
@@ -242,7 +242,7 @@
 		cursor: pointer;
 	}
 
-	:global(.messages-conversations__actions) {
+	.messages-conversations__actions {
 		display: flex;
 		align-items: center;
 	}

--- a/packages/shared/messaging/src/Message.svelte
+++ b/packages/shared/messaging/src/Message.svelte
@@ -4,6 +4,7 @@
 <script lang="ts">
 	import { Menu } from '@equaltoai/greater-components-primitives';
 	import { MoreVerticalIcon, TrashIcon } from '@equaltoai/greater-components-icons';
+	import { sanitizeHtml } from '@equaltoai/greater-components-utils';
 	import { formatMessageTime, isParticipantId } from './utils.js';
 	import { getMessagesContext } from './context.svelte.js';
 	import type { DirectMessage, MessagesContext } from './context.svelte.js';
@@ -24,6 +25,7 @@
 	const isSensitive = $derived(message.sensitive === true);
 	const isContentVisible = $derived(!isSensitive || sensitiveContentRevealed);
 	const messageContentId = $derived(`message-content-${message.id.replace(/[^\w-]/g, '-')}`);
+	const sanitizedMessageContent = $derived(sanitizeHtml(message.content).trim());
 
 	const context = (() => {
 		try {
@@ -120,7 +122,10 @@
 			</div>
 		{/if}
 		{#if isContentVisible}
-			<div class="message__content" id={messageContentId}>{message.content}</div>
+			<div class="message__content" id={messageContentId}>
+				<!-- eslint-disable-next-line svelte/no-at-html-tags -->
+				{@html sanitizedMessageContent}
+			</div>
 		{/if}
 		{#if message.workflowMoments?.length}
 			<div class="message__workflow">

--- a/packages/shared/messaging/src/Message.svelte
+++ b/packages/shared/messaging/src/Message.svelte
@@ -4,8 +4,8 @@
 <script lang="ts">
 	import { Menu } from '@equaltoai/greater-components-primitives';
 	import { MoreVerticalIcon, TrashIcon } from '@equaltoai/greater-components-icons';
-	import { sanitizeHtml } from '@equaltoai/greater-components-utils';
 	import { formatMessageTime, isParticipantId } from './utils.js';
+	import { sanitizeMessageHtml } from './sanitize.js';
 	import { getMessagesContext } from './context.svelte.js';
 	import type { DirectMessage, MessagesContext } from './context.svelte.js';
 	import WorkflowThreadMoment from './WorkflowThreadMoment.svelte';
@@ -25,7 +25,7 @@
 	const isSensitive = $derived(message.sensitive === true);
 	const isContentVisible = $derived(!isSensitive || sensitiveContentRevealed);
 	const messageContentId = $derived(`message-content-${message.id.replace(/[^\w-]/g, '-')}`);
-	const sanitizedMessageContent = $derived(sanitizeHtml(message.content).trim());
+	const sanitizedMessageContent = $derived(sanitizeMessageHtml(message.content));
 
 	const context = (() => {
 		try {

--- a/packages/shared/messaging/src/UnreadIndicator.svelte
+++ b/packages/shared/messaging/src/UnreadIndicator.svelte
@@ -53,6 +53,9 @@
 {#if shouldShow}
 	<span
 		class={`unread-indicator unread-indicator--${variant} unread-indicator--${size} ${className}`}
+		role="status"
+		aria-live="polite"
+		aria-atomic="true"
 		aria-label={`${unreadConversationCount} ${unreadConversationCount === 1 ? 'conversation' : 'conversations'} with unread messages`}
 	>
 		{#if variant === 'badge'}

--- a/packages/shared/messaging/src/UnreadIndicator.svelte
+++ b/packages/shared/messaging/src/UnreadIndicator.svelte
@@ -48,15 +48,26 @@
 	const displayCount = $derived(
 		unreadConversationCount > 99 ? '99+' : String(unreadConversationCount)
 	);
+	const announcement = $derived(
+		`${unreadConversationCount} ${unreadConversationCount === 1 ? 'conversation' : 'conversations'} with unread messages`
+	);
+	let announcedMessage = $state('');
+
+	$effect(() => {
+		const nextAnnouncement = shouldShow ? announcement : '';
+		const timer = setTimeout(() => {
+			announcedMessage = nextAnnouncement;
+		}, 150);
+
+		return () => clearTimeout(timer);
+	});
 </script>
 
 {#if shouldShow}
 	<span
 		class={`unread-indicator unread-indicator--${variant} unread-indicator--${size} ${className}`}
-		role="status"
-		aria-live="polite"
-		aria-atomic="true"
-		aria-label={`${unreadConversationCount} ${unreadConversationCount === 1 ? 'conversation' : 'conversations'} with unread messages`}
+		role="img"
+		aria-label={announcement}
 	>
 		{#if variant === 'badge'}
 			{displayCount}
@@ -65,3 +76,9 @@
 		{/if}
 	</span>
 {/if}
+
+<span class="unread-indicator__live-region" role="status" aria-live="polite" aria-atomic="true">
+	{#if announcedMessage}
+		<span class="gr-sr-only">{announcedMessage}</span>
+	{/if}
+</span>

--- a/packages/shared/messaging/src/UnreadIndicator.svelte
+++ b/packages/shared/messaging/src/UnreadIndicator.svelte
@@ -1,7 +1,7 @@
 <!--
-  Messages.UnreadIndicator - Unread Message Count Badge
+  Messages.UnreadIndicator - Unread Conversation Count Badge
   
-  Displays unread message count as a badge.
+  Displays the number of conversations with unread activity as a badge.
 -->
 <script lang="ts">
 	import { getMessagesContext } from './context.svelte.js';
@@ -37,19 +37,23 @@
 
 	const { state: messagesState } = getMessagesContext();
 
-	const unreadCount = $derived(
-		messagesState.conversations.reduce((sum, conv) => sum + conv.unreadCount, 0)
+	const unreadConversationCount = $derived(
+		messagesState.conversations.reduce((sum, conversation) => {
+			return sum + (conversation.unreadCount > 0 ? 1 : 0);
+		}, 0)
 	);
 
-	const shouldShow = $derived(unreadCount > 0 || showZero);
+	const shouldShow = $derived(unreadConversationCount > 0 || showZero);
 
-	const displayCount = $derived(unreadCount > 99 ? '99+' : String(unreadCount));
+	const displayCount = $derived(
+		unreadConversationCount > 99 ? '99+' : String(unreadConversationCount)
+	);
 </script>
 
 {#if shouldShow}
 	<span
 		class={`unread-indicator unread-indicator--${variant} unread-indicator--${size} ${className}`}
-		aria-label={`${unreadCount} unread message${unreadCount === 1 ? '' : 's'}`}
+		aria-label={`${unreadConversationCount} ${unreadConversationCount === 1 ? 'conversation' : 'conversations'} with unread messages`}
 	>
 		{#if variant === 'badge'}
 			{displayCount}

--- a/packages/shared/messaging/src/UnreadIndicator.svelte
+++ b/packages/shared/messaging/src/UnreadIndicator.svelte
@@ -4,7 +4,11 @@
   Displays the number of conversations with unread activity as a badge.
 -->
 <script lang="ts">
+	import { onDestroy } from 'svelte';
 	import { getMessagesContext } from './context.svelte.js';
+
+	const ANNOUNCEMENT_DEBOUNCE_MS = 150;
+	const ANNOUNCEMENT_MAX_WAIT_MS = 1_000;
 
 	interface Props {
 		/**
@@ -52,15 +56,41 @@
 		`${unreadConversationCount} ${unreadConversationCount === 1 ? 'conversation' : 'conversations'} with unread messages`
 	);
 	let announcedMessage = $state('');
+	let lastAnnouncedMessage = '';
+	let pendingAnnouncement = '';
+	let debounceTimer: ReturnType<typeof setTimeout> | undefined;
+	let maxWaitTimer: ReturnType<typeof setTimeout> | undefined;
+
+	function clearAnnouncementTimers() {
+		if (debounceTimer !== undefined) clearTimeout(debounceTimer);
+		if (maxWaitTimer !== undefined) clearTimeout(maxWaitTimer);
+		debounceTimer = undefined;
+		maxWaitTimer = undefined;
+	}
+
+	function publishPendingAnnouncement() {
+		clearAnnouncementTimers();
+		if (pendingAnnouncement === lastAnnouncedMessage) return;
+
+		lastAnnouncedMessage = pendingAnnouncement;
+		announcedMessage = pendingAnnouncement;
+	}
 
 	$effect(() => {
 		const nextAnnouncement = shouldShow ? announcement : '';
-		const timer = setTimeout(() => {
-			announcedMessage = nextAnnouncement;
-		}, 150);
+		pendingAnnouncement = nextAnnouncement;
 
-		return () => clearTimeout(timer);
+		if (debounceTimer !== undefined) clearTimeout(debounceTimer);
+		if (nextAnnouncement === lastAnnouncedMessage) {
+			clearAnnouncementTimers();
+			return;
+		}
+
+		debounceTimer = setTimeout(publishPendingAnnouncement, ANNOUNCEMENT_DEBOUNCE_MS);
+		maxWaitTimer ??= setTimeout(publishPendingAnnouncement, ANNOUNCEMENT_MAX_WAIT_MS);
 	});
+
+	onDestroy(clearAnnouncementTimers);
 </script>
 
 {#if shouldShow}

--- a/packages/shared/messaging/src/sanitize.ts
+++ b/packages/shared/messaging/src/sanitize.ts
@@ -1,4 +1,8 @@
 import { sanitizeHtml } from '@equaltoai/greater-components-utils';
+import rehypeParse from 'rehype-parse';
+import rehypeStringify from 'rehype-stringify';
+import { unified } from 'unified';
+import type { Element, Root } from 'hast';
 
 const RAW_TEXT_ELEMENTS_TO_DROP = [
 	'style',
@@ -78,27 +82,25 @@ function dropRawTextElements(html: string): string {
 	return result;
 }
 
-function getQuotedAttribute(attributes: string, name: string): string | undefined {
-	const match = new RegExp(`(?:^|\\s)${name}="([^"]*)"`, 'iu').exec(attributes);
-	return match?.[1];
+const htmlFragmentProcessor = unified().use(rehypeParse, { fragment: true }).use(rehypeStringify);
+
+function relTokens(element: Element): string[] {
+	const rel = element.properties.rel;
+	if (Array.isArray(rel)) return rel.map(String).filter(Boolean);
+	if (typeof rel === 'string') return rel.split(/\s+/u).filter(Boolean);
+	return [];
 }
 
-function setQuotedAttribute(attributes: string, name: string, value: string): string {
-	const matcher = new RegExp(`((?:^|\\s)${name}=")[^"]*(")`, 'iu');
-	if (matcher.test(attributes)) {
-		return attributes.replace(matcher, `$1${value}$2`);
-	}
-	return `${attributes} ${name}="${value}"`;
-}
+function hardenExternalAnchors(node: Root | Element): void {
+	for (const child of node.children) {
+		if (child.type !== 'element') continue;
 
-function secureExternalLinks(html: string): string {
-	return html.replace(/<a\b((?:"[^"]*"|'[^']*'|[^'">])*)>/giu, (_match, rawAttributes: string) => {
-		let attributes = rawAttributes;
-		const href = getQuotedAttribute(attributes, 'href');
-
-		if (/^https?:\/\//iu.test(href ?? '')) {
-			const existingRel = getQuotedAttribute(attributes, 'rel') ?? '';
-			const tokens = existingRel.split(/\s+/u).filter(Boolean);
+		if (
+			child.tagName === 'a' &&
+			typeof child.properties.href === 'string' &&
+			/^https?:\/\//iu.test(child.properties.href)
+		) {
+			const tokens = relTokens(child);
 			const normalizedTokens = new Set(tokens.map((token) => token.toLowerCase()));
 
 			for (const requiredToken of ['noopener', 'noreferrer']) {
@@ -108,11 +110,17 @@ function secureExternalLinks(html: string): string {
 				}
 			}
 
-			attributes = setQuotedAttribute(attributes, 'rel', tokens.join(' '));
+			child.properties.rel = tokens;
 		}
 
-		return `<a${attributes}>`;
-	});
+		hardenExternalAnchors(child);
+	}
+}
+
+function secureExternalLinks(html: string): string {
+	const tree = htmlFragmentProcessor.parse(html) as Root;
+	hardenExternalAnchors(tree);
+	return htmlFragmentProcessor.stringify(tree);
 }
 
 function decodeSerializedText(text: string): string {

--- a/packages/shared/messaging/src/sanitize.ts
+++ b/packages/shared/messaging/src/sanitize.ts
@@ -198,6 +198,8 @@ export function stripSerializedMarkup(serialized: string): string {
 
 /** Sanitize server-authored message HTML for the {@html} message-body sink. */
 export function sanitizeMessageHtml(dirty: string): string {
+	if (!dirty || typeof dirty !== 'string') return '';
+
 	return secureExternalLinks(
 		sanitizeHtml(dropRawTextElements(dirty), {
 			addRelToExternalLinks: false,

--- a/packages/shared/messaging/src/sanitize.ts
+++ b/packages/shared/messaging/src/sanitize.ts
@@ -1,8 +1,9 @@
 import { sanitizeHtml } from '@equaltoai/greater-components-utils';
 
 const RAW_TEXT_ELEMENTS_TO_DROP = ['style', 'textarea', 'title'] as const;
-const BLOCK_SEPARATOR_TAGS = /<(?:br|\/(?:p|pre|blockquote|li|ul|ol|h[1-6]))\b[^>]*>/giu;
-const HTML_TAG = /<[^>]*>/gu;
+const BLOCK_SEPARATOR_TAGS =
+	/<(?:br|\/(?:p|pre|blockquote|li|ul|ol|h[1-6]))\b(?:"[^"]*"|'[^']*'|[^'">])*>/giu;
+const HTML_TAG = /<(?:"[^"]*"|'[^']*'|[^'">])*>/gu;
 
 function findTagEnd(html: string, start: number): number {
 	let quote: '"' | "'" | undefined;
@@ -142,6 +143,24 @@ function decodeSerializedText(text: string): string {
 	);
 }
 
+function stripSerializedMarkup(serialized: string): string {
+	let text = serialized;
+	let previous: string;
+	let iterations = 0;
+	const maxIterations = serialized.length + 1;
+
+	// CodeQL js/incomplete-multi-character-sanitization: removing one tag can expose
+	// another across the joined boundary. Iterate the quote-aware tag-strip chain to
+	// a fixed point; every changing pass shortens the text, so this bound must converge.
+	do {
+		previous = text;
+		text = text.replace(BLOCK_SEPARATOR_TAGS, ' ').replace(HTML_TAG, '');
+		iterations += 1;
+	} while (text !== previous && iterations < maxIterations);
+
+	return text;
+}
+
 /** Sanitize server-authored message HTML for the {@html} message-body sink. */
 export function sanitizeMessageHtml(dirty: string): string {
 	return secureBlankTargetLinks(sanitizeHtml(dropRawTextElements(dirty))).trim();
@@ -152,11 +171,7 @@ export function sanitizeMessagePreview(dirty: string, maxLength = 200): string {
 	if (!dirty || typeof dirty !== 'string') return '';
 
 	const serialized = sanitizeMessageHtml(dirty);
-	const text = decodeSerializedText(
-		serialized.replace(BLOCK_SEPARATOR_TAGS, ' ').replace(HTML_TAG, '')
-	)
-		.replace(/\s+/gu, ' ')
-		.trim();
+	const text = decodeSerializedText(stripSerializedMarkup(serialized)).replace(/\s+/gu, ' ').trim();
 	const characters = Array.from(text);
 
 	if (characters.length <= maxLength) return text;

--- a/packages/shared/messaging/src/sanitize.ts
+++ b/packages/shared/messaging/src/sanitize.ts
@@ -98,7 +98,7 @@ function hardenExternalAnchors(node: Root | Element): void {
 		if (
 			child.tagName === 'a' &&
 			typeof child.properties['href'] === 'string' &&
-			/^(?:https?:)?\/\//iu.test(child.properties['href'])
+			/^(?:https?:)?[\\/]{2}/iu.test(child.properties['href'])
 		) {
 			const tokens = relTokens(child);
 			const normalizedTokens = new Set(tokens.map((token) => token.toLowerCase()));

--- a/packages/shared/messaging/src/sanitize.ts
+++ b/packages/shared/messaging/src/sanitize.ts
@@ -2,7 +2,21 @@ import { sanitizeHtml } from '@equaltoai/greater-components-utils';
 import rehypeParse from 'rehype-parse';
 import rehypeStringify from 'rehype-stringify';
 import { unified } from 'unified';
-import type { Element, Root } from 'hast';
+
+interface SanitizedNode {
+	type: string;
+}
+
+interface SanitizedElement extends SanitizedNode {
+	type: 'element';
+	tagName: string;
+	properties: Record<string, unknown>;
+	children: SanitizedNode[];
+}
+
+interface SanitizedParent {
+	children: SanitizedNode[];
+}
 
 const RAW_TEXT_ELEMENTS_TO_DROP = [
 	'style',
@@ -84,16 +98,20 @@ function dropRawTextElements(html: string): string {
 
 const htmlFragmentProcessor = unified().use(rehypeParse, { fragment: true }).use(rehypeStringify);
 
-function relTokens(element: Element): string[] {
+function isSanitizedElement(node: SanitizedNode): node is SanitizedElement {
+	return node.type === 'element';
+}
+
+function relTokens(element: SanitizedElement): string[] {
 	const rel = element.properties['rel'];
 	if (Array.isArray(rel)) return rel.map(String).filter(Boolean);
 	if (typeof rel === 'string') return rel.split(/\s+/u).filter(Boolean);
 	return [];
 }
 
-function hardenExternalAnchors(node: Root | Element): void {
+function hardenExternalAnchors(node: SanitizedParent): void {
 	for (const child of node.children) {
-		if (child.type !== 'element') continue;
+		if (!isSanitizedElement(child)) continue;
 
 		if (
 			child.tagName === 'a' &&
@@ -118,7 +136,7 @@ function hardenExternalAnchors(node: Root | Element): void {
 }
 
 function secureExternalLinks(html: string): string {
-	const tree = htmlFragmentProcessor.parse(html) as Root;
+	const tree = htmlFragmentProcessor.parse(html);
 	hardenExternalAnchors(tree);
 	return htmlFragmentProcessor.stringify(tree);
 }

--- a/packages/shared/messaging/src/sanitize.ts
+++ b/packages/shared/messaging/src/sanitize.ts
@@ -109,6 +109,12 @@ function relTokens(element: SanitizedElement): string[] {
 	return [];
 }
 
+// Mirror the WHATWG URL parser's pre-parse normalization.
+function urlParserNormalized(href: string): string {
+	// eslint-disable-next-line no-control-regex -- WHATWG strips the full leading C0 range.
+	return href.replace(/^[\x00-\x20]+/u, '').replace(/[\t\n\r]/gu, '');
+}
+
 function hardenExternalAnchors(node: SanitizedParent): void {
 	for (const child of node.children) {
 		if (!isSanitizedElement(child)) continue;
@@ -116,7 +122,7 @@ function hardenExternalAnchors(node: SanitizedParent): void {
 		if (
 			child.tagName === 'a' &&
 			typeof child.properties['href'] === 'string' &&
-			/^(?:https?:)?[\\/]{2}/iu.test(child.properties['href'])
+			/^(?:https?:)?[\\/]{2}/iu.test(urlParserNormalized(child.properties['href']))
 		) {
 			const tokens = relTokens(child);
 			const normalizedTokens = new Set(tokens.map((token) => token.toLowerCase()));

--- a/packages/shared/messaging/src/sanitize.ts
+++ b/packages/shared/messaging/src/sanitize.ts
@@ -1,0 +1,163 @@
+import { sanitizeHtml } from '@equaltoai/greater-components-utils';
+
+const RAW_TEXT_ELEMENTS_TO_DROP = ['style'] as const;
+const BLOCK_SEPARATOR_TAGS = /<(?:br|\/(?:p|pre|blockquote|li|ul|ol|h[1-6]))\b[^>]*>/giu;
+const HTML_TAG = /<[^>]*>/gu;
+
+function findTagEnd(html: string, start: number): number {
+	let quote: '"' | "'" | undefined;
+
+	for (let index = start; index < html.length; index += 1) {
+		const character = html[index];
+		if (quote) {
+			if (character === quote) quote = undefined;
+			continue;
+		}
+
+		if (character === '"' || character === "'") {
+			quote = character;
+		} else if (character === '>') {
+			return index;
+		}
+	}
+
+	return html.length - 1;
+}
+
+/**
+ * Drop raw-text elements whose contents must not become readable message text.
+ *
+ * The shared sanitizer intentionally preserves the text children of most
+ * disallowed elements. Messaging is a less-trusted surface: CSS source inside
+ * a style element is neither message content nor a useful preview, so remove
+ * the complete element before applying the shared allow-list sanitizer.
+ */
+function dropRawTextElements(html: string): string {
+	let result = html;
+
+	for (const tagName of RAW_TEXT_ELEMENTS_TO_DROP) {
+		const openingTag = new RegExp(`<${tagName}(?=[\\s/>])`, 'giu');
+		const closingTag = new RegExp(`</${tagName}(?=[\\s>])`, 'giu');
+		let cursor = 0;
+		let cleaned = '';
+
+		while (cursor < result.length) {
+			openingTag.lastIndex = cursor;
+			const openingMatch = openingTag.exec(result);
+			if (!openingMatch) {
+				cleaned += result.slice(cursor);
+				break;
+			}
+
+			cleaned += result.slice(cursor, openingMatch.index);
+			const openingEnd = findTagEnd(result, openingMatch.index);
+			closingTag.lastIndex = openingEnd + 1;
+			const closingMatch = closingTag.exec(result);
+			if (!closingMatch) {
+				// HTML parsers treat an unclosed style element as consuming the rest
+				// of the fragment, so the safe readable result ends here as well.
+				break;
+			}
+
+			cursor = findTagEnd(result, closingMatch.index) + 1;
+		}
+
+		result = cleaned;
+	}
+
+	return result;
+}
+
+function getQuotedAttribute(attributes: string, name: string): string | undefined {
+	const match = new RegExp(`(?:^|\\s)${name}="([^"]*)"`, 'iu').exec(attributes);
+	return match?.[1];
+}
+
+function setQuotedAttribute(attributes: string, name: string, value: string): string {
+	const matcher = new RegExp(`((?:^|\\s)${name}=")[^"]*(")`, 'iu');
+	if (matcher.test(attributes)) {
+		return attributes.replace(matcher, `$1${value}$2`);
+	}
+	return `${attributes} ${name}="${value}"`;
+}
+
+function secureBlankTargetLinks(html: string): string {
+	return html.replace(/<a\b([^>]*)>/giu, (_match, rawAttributes: string) => {
+		let attributes = rawAttributes;
+		const href = getQuotedAttribute(attributes, 'href');
+		let target = getQuotedAttribute(attributes, 'target');
+
+		if (/^https?:\/\//iu.test(href ?? '') && target === undefined) {
+			attributes = setQuotedAttribute(attributes, 'target', '_blank');
+			target = '_blank';
+		}
+
+		if (target?.toLowerCase() === '_blank') {
+			const existingRel = getQuotedAttribute(attributes, 'rel') ?? '';
+			const tokens = existingRel.split(/\s+/u).filter(Boolean);
+			const normalizedTokens = new Set(tokens.map((token) => token.toLowerCase()));
+
+			for (const requiredToken of ['noopener', 'noreferrer']) {
+				if (!normalizedTokens.has(requiredToken)) {
+					tokens.push(requiredToken);
+					normalizedTokens.add(requiredToken);
+				}
+			}
+
+			attributes = setQuotedAttribute(attributes, 'rel', tokens.join(' '));
+		}
+
+		return `<a${attributes}>`;
+	});
+}
+
+function decodeSerializedText(text: string): string {
+	return text.replace(
+		/&#(?:x([\da-f]+)|(\d+));?|&(amp|lt|gt|quot|apos);/giu,
+		(reference, hexadecimal: string | undefined, decimal: string | undefined, named: string) => {
+			if (named) {
+				return (
+					{
+						amp: '&',
+						lt: '<',
+						gt: '>',
+						quot: '"',
+						apos: "'",
+					} as const
+				)[named.toLowerCase() as 'amp' | 'lt' | 'gt' | 'quot' | 'apos'];
+			}
+
+			const codePoint = Number.parseInt(hexadecimal ?? decimal ?? '', hexadecimal ? 16 : 10);
+			if (
+				!Number.isFinite(codePoint) ||
+				codePoint <= 0 ||
+				codePoint > 0x10ffff ||
+				(codePoint >= 0xd800 && codePoint <= 0xdfff)
+			) {
+				return reference;
+			}
+			return String.fromCodePoint(codePoint);
+		}
+	);
+}
+
+/** Sanitize server-authored message HTML for the {@html} message-body sink. */
+export function sanitizeMessageHtml(dirty: string): string {
+	return secureBlankTargetLinks(sanitizeHtml(dropRawTextElements(dirty))).trim();
+}
+
+/** Extract a decoded, markup-free and Unicode-safe message-list preview. */
+export function sanitizeMessagePreview(dirty: string, maxLength = 200): string {
+	if (!dirty || typeof dirty !== 'string') return '';
+
+	const serialized = sanitizeMessageHtml(dirty);
+	const text = decodeSerializedText(
+		serialized.replace(BLOCK_SEPARATOR_TAGS, ' ').replace(HTML_TAG, '')
+	)
+		.replace(/\s+/gu, ' ')
+		.trim();
+	const characters = Array.from(text);
+
+	if (characters.length <= maxLength) return text;
+	return `${characters.slice(0, Math.max(0, maxLength)).join('').trim()}...`;
+}

--- a/packages/shared/messaging/src/sanitize.ts
+++ b/packages/shared/messaging/src/sanitize.ts
@@ -172,7 +172,12 @@ export function stripSerializedMarkup(serialized: string): string {
 
 /** Sanitize server-authored message HTML for the {@html} message-body sink. */
 export function sanitizeMessageHtml(dirty: string): string {
-	return secureBlankTargetLinks(sanitizeHtml(dropRawTextElements(dirty))).trim();
+	return secureBlankTargetLinks(
+		sanitizeHtml(dropRawTextElements(dirty), {
+			addRelToExternalLinks: false,
+			externalLinksInNewTab: false,
+		})
+	).trim();
 }
 
 /** Extract a decoded, markup-free and Unicode-safe message-list preview. */

--- a/packages/shared/messaging/src/sanitize.ts
+++ b/packages/shared/messaging/src/sanitize.ts
@@ -1,6 +1,6 @@
 import { sanitizeHtml } from '@equaltoai/greater-components-utils';
 
-const RAW_TEXT_ELEMENTS_TO_DROP = ['style'] as const;
+const RAW_TEXT_ELEMENTS_TO_DROP = ['style', 'textarea', 'title'] as const;
 const BLOCK_SEPARATOR_TAGS = /<(?:br|\/(?:p|pre|blockquote|li|ul|ol|h[1-6]))\b[^>]*>/giu;
 const HTML_TAG = /<[^>]*>/gu;
 
@@ -29,8 +29,9 @@ function findTagEnd(html: string, start: number): number {
  *
  * The shared sanitizer intentionally preserves the text children of most
  * disallowed elements. Messaging is a less-trusted surface: CSS source inside
- * a style element is neither message content nor a useful preview, so remove
- * the complete element before applying the shared allow-list sanitizer.
+ * style, textarea, and title elements is neither message content nor a useful
+ * preview, so remove the complete element before applying the shared allow-list
+ * sanitizer.
  */
 function dropRawTextElements(html: string): string {
 	let result = html;
@@ -54,7 +55,7 @@ function dropRawTextElements(html: string): string {
 			closingTag.lastIndex = openingEnd + 1;
 			const closingMatch = closingTag.exec(result);
 			if (!closingMatch) {
-				// HTML parsers treat an unclosed style element as consuming the rest
+				// HTML parsers treat an unclosed raw-text element as consuming the rest
 				// of the fragment, so the safe readable result ends here as well.
 				break;
 			}

--- a/packages/shared/messaging/src/sanitize.ts
+++ b/packages/shared/messaging/src/sanitize.ts
@@ -1,6 +1,15 @@
 import { sanitizeHtml } from '@equaltoai/greater-components-utils';
 
-const RAW_TEXT_ELEMENTS_TO_DROP = ['style', 'textarea', 'title'] as const;
+const RAW_TEXT_ELEMENTS_TO_DROP = [
+	'style',
+	'textarea',
+	'title',
+	'iframe',
+	'noembed',
+	'noframes',
+	'xmp',
+	'plaintext',
+] as const;
 const BLOCK_SEPARATOR_TAGS =
 	/<(?:br|\/(?:p|pre|blockquote|li|ul|ol|h[1-6]))\b(?:"[^"]*"|'[^']*'|[^'">])*>/giu;
 const HTML_TAG = /<(?:"[^"]*"|'[^']*'|[^'">])*>/gu;
@@ -30,9 +39,8 @@ function findTagEnd(html: string, start: number): number {
  *
  * The shared sanitizer intentionally preserves the text children of most
  * disallowed elements. Messaging is a less-trusted surface: CSS source inside
- * style, textarea, and title elements is neither message content nor a useful
- * preview, so remove the complete element before applying the shared allow-list
- * sanitizer.
+ * raw-text elements is neither message content nor a useful preview, so remove
+ * the complete element before applying the shared allow-list sanitizer.
  */
 function dropRawTextElements(html: string): string {
 	let result = html;
@@ -84,7 +92,7 @@ function setQuotedAttribute(attributes: string, name: string, value: string): st
 }
 
 function secureBlankTargetLinks(html: string): string {
-	return html.replace(/<a\b([^>]*)>/giu, (_match, rawAttributes: string) => {
+	return html.replace(/<a\b((?:"[^"]*"|'[^']*'|[^'">])*)>/giu, (_match, rawAttributes: string) => {
 		let attributes = rawAttributes;
 		const href = getQuotedAttribute(attributes, 'href');
 		let target = getQuotedAttribute(attributes, 'target');
@@ -143,7 +151,8 @@ function decodeSerializedText(text: string): string {
 	);
 }
 
-function stripSerializedMarkup(serialized: string): string {
+/** @internal Exported only for direct fixed-point regression coverage. */
+export function stripSerializedMarkup(serialized: string): string {
 	let text = serialized;
 	let previous: string;
 	let iterations = 0;

--- a/packages/shared/messaging/src/sanitize.ts
+++ b/packages/shared/messaging/src/sanitize.ts
@@ -91,18 +91,12 @@ function setQuotedAttribute(attributes: string, name: string, value: string): st
 	return `${attributes} ${name}="${value}"`;
 }
 
-function secureBlankTargetLinks(html: string): string {
+function secureExternalLinks(html: string): string {
 	return html.replace(/<a\b((?:"[^"]*"|'[^']*'|[^'">])*)>/giu, (_match, rawAttributes: string) => {
 		let attributes = rawAttributes;
 		const href = getQuotedAttribute(attributes, 'href');
-		let target = getQuotedAttribute(attributes, 'target');
 
-		if (/^https?:\/\//iu.test(href ?? '') && target === undefined) {
-			attributes = setQuotedAttribute(attributes, 'target', '_blank');
-			target = '_blank';
-		}
-
-		if (target?.toLowerCase() === '_blank') {
+		if (/^https?:\/\//iu.test(href ?? '')) {
 			const existingRel = getQuotedAttribute(attributes, 'rel') ?? '';
 			const tokens = existingRel.split(/\s+/u).filter(Boolean);
 			const normalizedTokens = new Set(tokens.map((token) => token.toLowerCase()));
@@ -172,7 +166,7 @@ export function stripSerializedMarkup(serialized: string): string {
 
 /** Sanitize server-authored message HTML for the {@html} message-body sink. */
 export function sanitizeMessageHtml(dirty: string): string {
-	return secureBlankTargetLinks(
+	return secureExternalLinks(
 		sanitizeHtml(dropRawTextElements(dirty), {
 			addRelToExternalLinks: false,
 			externalLinksInNewTab: false,

--- a/packages/shared/messaging/src/sanitize.ts
+++ b/packages/shared/messaging/src/sanitize.ts
@@ -85,7 +85,7 @@ function dropRawTextElements(html: string): string {
 const htmlFragmentProcessor = unified().use(rehypeParse, { fragment: true }).use(rehypeStringify);
 
 function relTokens(element: Element): string[] {
-	const rel = element.properties.rel;
+	const rel = element.properties['rel'];
 	if (Array.isArray(rel)) return rel.map(String).filter(Boolean);
 	if (typeof rel === 'string') return rel.split(/\s+/u).filter(Boolean);
 	return [];
@@ -97,8 +97,8 @@ function hardenExternalAnchors(node: Root | Element): void {
 
 		if (
 			child.tagName === 'a' &&
-			typeof child.properties.href === 'string' &&
-			/^https?:\/\//iu.test(child.properties.href)
+			typeof child.properties['href'] === 'string' &&
+			/^(?:https?:)?\/\//iu.test(child.properties['href'])
 		) {
 			const tokens = relTokens(child);
 			const normalizedTokens = new Set(tokens.map((token) => token.toLowerCase()));
@@ -110,7 +110,7 @@ function hardenExternalAnchors(node: Root | Element): void {
 				}
 			}
 
-			child.properties.rel = tokens;
+			child.properties['rel'] = tokens;
 		}
 
 		hardenExternalAnchors(child);

--- a/packages/shared/messaging/tests/Conversations.context.test.ts
+++ b/packages/shared/messaging/tests/Conversations.context.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it, vi } from 'vitest';
+import { mount, unmount } from 'svelte';
+import ConversationsContextHarness from './fixtures/ConversationsContextHarness.svelte';
+
+describe('Conversations with a real messages context', () => {
+	it.each([
+		['controlled', true],
+		['uncontrolled', false],
+	] as const)(
+		'keeps %s folder tabs synchronized with the list after accepting a request',
+		async (_mode, controlled) => {
+			const target = document.createElement('div');
+			const instance = mount(ConversationsContextHarness, {
+				target,
+				props: { controlled },
+			});
+
+			await vi.waitFor(() => {
+				expect(target.querySelector('.request-action'), target.innerHTML).toBeTruthy();
+			});
+			const initialTabs = target.querySelectorAll('[role="tab"]');
+			expect(initialTabs[0]?.getAttribute('aria-selected')).toBe('false');
+			expect(initialTabs[1]?.getAttribute('aria-selected')).toBe('true');
+
+			(target.querySelector('.request-action') as HTMLButtonElement).click();
+
+			await vi.waitFor(() => {
+				expect(target.textContent).toContain('Bob');
+				expect(target.textContent).not.toContain('Alice');
+			});
+			const nextTabs = target.querySelectorAll('[role="tab"]');
+			expect(nextTabs[0]?.getAttribute('aria-selected')).toBe('true');
+			expect(nextTabs[1]?.getAttribute('aria-selected')).toBe('false');
+			if (controlled) {
+				expect(target.querySelector('output')?.dataset.boundFolder).toBe('INBOX');
+			}
+
+			unmount(instance);
+		}
+	);
+});

--- a/packages/shared/messaging/tests/Conversations.test.ts
+++ b/packages/shared/messaging/tests/Conversations.test.ts
@@ -270,6 +270,9 @@ describe('Conversations', () => {
 		const card = target.querySelector('.messages-conversations__item');
 		const selectionButton = card?.querySelector('.messages-conversations__item-main');
 		const action = card?.querySelector('.request-action') as HTMLButtonElement;
+		const lateThemeRule = document.createElement('style');
+		lateThemeRule.textContent = '.messages-conversations__item { display: flex; }';
+		document.head.append(lateThemeRule);
 		expect(card?.tagName).toBe('DIV');
 		expect(selectionButton?.tagName).toBe('BUTTON');
 		expect(action?.dataset.conversationId).toBe('c-request');
@@ -278,11 +281,17 @@ describe('Conversations', () => {
 		expect(card?.querySelector('.messages-conversations__actions')?.hasAttribute('style')).toBe(
 			false
 		);
+		expect(getComputedStyle(card as Element).display).toBe('grid');
+		expect(getComputedStyle(selectionButton as Element).display).toBe('grid');
+		expect(
+			getComputedStyle(card?.querySelector('.messages-conversations__actions') as Element).display
+		).toBe('flex');
 
 		action.click();
 		await flushSync();
 		expect(mockSelectConversation).not.toHaveBeenCalled();
 
+		lateThemeRule.remove();
 		unmount(instance);
 	});
 
@@ -300,9 +309,14 @@ describe('Conversations', () => {
 		await flushSync();
 
 		const card = target.querySelector('.messages-conversations__item');
+		const lateThemeRule = document.createElement('style');
+		lateThemeRule.textContent = '.messages-conversations__item { display: flex; }';
+		document.head.append(lateThemeRule);
 		expect(card?.tagName).toBe('BUTTON');
 		expect(card?.querySelector('.messages-conversations__item-main')).toBeNull();
+		expect(getComputedStyle(card as Element).display).toBe('flex');
 
+		lateThemeRule.remove();
 		unmount(instance);
 	});
 

--- a/packages/shared/messaging/tests/Conversations.test.ts
+++ b/packages/shared/messaging/tests/Conversations.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { mount, unmount, flushSync } from 'svelte';
 import Conversations from '../src/Conversations.svelte';
+import ConversationsActionsHarness from './fixtures/ConversationsActionsHarness.svelte';
 
 // Mock context
 const { mockHandlers, mockState, mockSelectConversation, mockFetchConversations } = vi.hoisted(
@@ -89,6 +90,16 @@ describe('Conversations', () => {
 			'.messages-conversations__tab'
 		)[1] as HTMLButtonElement;
 		requestsTab.click();
+		await flushSync();
+
+		expect(mockFetchConversations).toHaveBeenCalledWith('REQUESTS');
+
+		unmount(instance);
+	});
+
+	it('selects an externally controlled initial folder', async () => {
+		const target = document.createElement('div');
+		const instance = mount(Conversations, { target, props: { folder: 'REQUESTS' } });
 		await flushSync();
 
 		expect(mockFetchConversations).toHaveBeenCalledWith('REQUESTS');
@@ -210,6 +221,56 @@ describe('Conversations', () => {
 		expect(mockHandlers.onConversationClick).toHaveBeenCalledWith(
 			expect.objectContaining({ id: 'c1' })
 		);
+
+		unmount(instance);
+	});
+
+	it('renders request actions beside the card selection button', async () => {
+		mockState.conversations = [
+			{
+				id: 'c-request',
+				participants: [{ id: 'u1', displayName: 'Alice', avatar: '' }],
+				unreadCount: 0,
+			},
+		];
+
+		const target = document.createElement('div');
+		const instance = mount(ConversationsActionsHarness, {
+			target,
+			props: { folder: 'REQUESTS' },
+		});
+		await flushSync();
+
+		const card = target.querySelector('.messages-conversations__item');
+		const selectionButton = card?.querySelector('.messages-conversations__item-main');
+		const action = card?.querySelector('.request-action') as HTMLButtonElement;
+		expect(card?.tagName).toBe('DIV');
+		expect(selectionButton?.tagName).toBe('BUTTON');
+		expect(action?.dataset.conversationId).toBe('c-request');
+
+		action.click();
+		await flushSync();
+		expect(mockSelectConversation).not.toHaveBeenCalled();
+
+		unmount(instance);
+	});
+
+	it('keeps the legacy single-button card when no actions snippet is supplied', async () => {
+		mockState.conversations = [
+			{
+				id: 'c-default',
+				participants: [{ id: 'u1', displayName: 'Alice', avatar: '' }],
+				unreadCount: 0,
+			},
+		];
+
+		const target = document.createElement('div');
+		const instance = mount(Conversations, { target });
+		await flushSync();
+
+		const card = target.querySelector('.messages-conversations__item');
+		expect(card?.tagName).toBe('BUTTON');
+		expect(card?.querySelector('.messages-conversations__item-main')).toBeNull();
 
 		unmount(instance);
 	});

--- a/packages/shared/messaging/tests/Conversations.test.ts
+++ b/packages/shared/messaging/tests/Conversations.test.ts
@@ -162,6 +162,33 @@ describe('Conversations', () => {
 		unmount(instance);
 	});
 
+	it('renders a safe plain-text excerpt for server HTML previews', async () => {
+		mockState.conversations = [
+			{
+				id: 'c-html-preview',
+				participants: [{ id: 'u1', displayName: 'Alice', avatar: '' }],
+				unreadCount: 0,
+				lastMessage: {
+					content:
+						'<p>Hello <strong>world</strong></p><img src="x" onerror="alert(1)"><script>alert(2)</script>',
+					createdAt: '',
+				},
+			},
+		];
+
+		const target = document.createElement('div');
+		const instance = mount(Conversations, { target });
+		await flushSync();
+
+		const preview = target.querySelector('.messages-conversations__preview');
+		expect(preview?.textContent).toBe('Hello world');
+		expect(preview?.querySelector('strong')).toBeNull();
+		expect(preview?.querySelector('img')).toBeNull();
+		expect(preview?.innerHTML).not.toContain('onerror');
+
+		unmount(instance);
+	});
+
 	it('handles selection', async () => {
 		mockState.conversations = [
 			{

--- a/packages/shared/messaging/tests/Conversations.test.ts
+++ b/packages/shared/messaging/tests/Conversations.test.ts
@@ -200,6 +200,32 @@ describe('Conversations', () => {
 		unmount(instance);
 	});
 
+	it('decodes entities and drops style text from server HTML previews', async () => {
+		mockState.conversations = [
+			{
+				id: 'c-encoded-preview',
+				participants: [{ id: 'u1', displayName: 'Alice', avatar: '' }],
+				unreadCount: 0,
+				lastMessage: {
+					content:
+						'<style>.messages-conversations{display:none}</style><p>Tom &amp; <strong>Jerry</strong></p>',
+					createdAt: '',
+				},
+			},
+		];
+
+		const target = document.createElement('div');
+		const instance = mount(Conversations, { target });
+		await flushSync();
+
+		const preview = target.querySelector('.messages-conversations__preview');
+		expect(preview?.textContent).toBe('Tom & Jerry');
+		expect(preview?.textContent).not.toContain('display:none');
+		expect(preview?.children).toHaveLength(0);
+
+		unmount(instance);
+	});
+
 	it('handles selection', async () => {
 		mockState.conversations = [
 			{
@@ -247,6 +273,11 @@ describe('Conversations', () => {
 		expect(card?.tagName).toBe('DIV');
 		expect(selectionButton?.tagName).toBe('BUTTON');
 		expect(action?.dataset.conversationId).toBe('c-request');
+		expect(card?.hasAttribute('style')).toBe(false);
+		expect(selectionButton?.hasAttribute('style')).toBe(false);
+		expect(card?.querySelector('.messages-conversations__actions')?.hasAttribute('style')).toBe(
+			false
+		);
 
 		action.click();
 		await flushSync();

--- a/packages/shared/messaging/tests/Message.test.ts
+++ b/packages/shared/messaging/tests/Message.test.ts
@@ -143,7 +143,7 @@ describe('Message', () => {
 		unmount(instance);
 	});
 
-	it('secures blank-target links while preserving existing rel tokens', () => {
+	it('secures external links while preserving existing rel tokens and target intent', () => {
 		const target = document.createElement('div');
 		const message = {
 			id: 'm-link',
@@ -163,7 +163,7 @@ describe('Message', () => {
 			'noopener',
 			'noreferrer',
 		]);
-		expect(links[1]?.getAttribute('target')).toBe('_blank');
+		expect(links[1]?.getAttribute('target')).toBeNull();
 		expect(links[1]?.getAttribute('rel')).toBe('noopener noreferrer');
 
 		unmount(instance);

--- a/packages/shared/messaging/tests/Message.test.ts
+++ b/packages/shared/messaging/tests/Message.test.ts
@@ -3,6 +3,34 @@ import { mount, unmount } from 'svelte';
 import { flushSync } from 'svelte';
 import Message from '../src/Message.svelte';
 
+const WHATWG_PREPARSE_EXTERNAL_HREF_CASES = [
+	{ name: 'leading space', predicateHref: ' //evil.test/messages' },
+	{ name: 'leading tab', predicateHref: '\t//evil.test/messages' },
+	{ name: 'leading line breaks', predicateHref: '\n\r//evil.test/messages' },
+	{ name: 'leading C0 control', predicateHref: '\x01//evil.test/messages' },
+	{ name: 'tab between slashes', predicateHref: '/\t/evil.test/messages' },
+	{ name: 'line feed between slashes', predicateHref: '/\n/evil.test/messages' },
+	{ name: 'tab before backslash separator', predicateHref: '/\t\\evil.test/messages' },
+	{
+		name: 'entity-encoded tab',
+		predicateHref: '\t//evil.test/messages',
+		authoredHref: '&#9;//evil.test/messages',
+	},
+] as const;
+
+const WHATWG_PREPARSE_EXTERNAL_HREF_MATRIX = WHATWG_PREPARSE_EXTERNAL_HREF_CASES.flatMap(
+	({ name, predicateHref, ...hrefCase }) =>
+		(['named', '_blank'] as const).map(
+			(target) =>
+				[
+					name,
+					predicateHref,
+					'authoredHref' in hrefCase ? hrefCase.authoredHref : predicateHref,
+					target,
+				] as const
+		)
+);
+
 // Mock context helpers
 vi.mock('../src/utils.js', async () => {
 	const actual = await vi.importActual('../src/utils.js');
@@ -253,6 +281,62 @@ describe('Message', () => {
 
 				unmount(instance);
 			}
+		}
+	);
+
+	it.each(WHATWG_PREPARSE_EXTERNAL_HREF_MATRIX)(
+		'hardens a %s external href %j authored as %j after WHATWG pre-parse normalization with target %s through the real message render path',
+		(_case, predicateHref, authoredHref, linkTarget) => {
+			const target = document.createElement('div');
+			const message = {
+				id: `m-preparse-${linkTarget}`,
+				conversationId: 'c1',
+				sender: bob,
+				content: `<a href="${authoredHref}" target="${linkTarget}">external</a>`,
+				createdAt: new Date().toISOString(),
+				read: true,
+			};
+
+			const instance = mount(Message, { target, props: { message, currentUserId: 'u1' } });
+			const anchor = target.querySelector('.message__content a');
+
+			// Exercise the raw entity end-to-end while pinning the decoded predicate input.
+			if (authoredHref.startsWith('&#9;')) {
+				expect(anchor?.getAttribute('href')).toBe(predicateHref);
+			}
+			expect(new URL(anchor?.getAttribute('href') ?? '', 'https://messages.test').origin).toBe(
+				'https://evil.test'
+			);
+			expect(anchor?.getAttribute('target')).toBe(linkTarget);
+			expect(anchor?.getAttribute('rel')?.split(/\s+/u)).toEqual(['noopener', 'noreferrer']);
+
+			unmount(instance);
+		}
+	);
+
+	it.each([' /local/path', '\t#frag', ' ../up'])(
+		'keeps the parser-normalized internal href %j unhardened through the real message render path',
+		(href) => {
+			const target = document.createElement('div');
+			const message = {
+				id: 'm-preparse-internal',
+				conversationId: 'c1',
+				sender: bob,
+				content: `<a href="${href}" target="named">internal</a>`,
+				createdAt: new Date().toISOString(),
+				read: true,
+			};
+
+			const instance = mount(Message, { target, props: { message, currentUserId: 'u1' } });
+			const anchor = target.querySelector('.message__content a');
+
+			expect(
+				new URL(anchor?.getAttribute('href') ?? '', 'https://messages.test/base/').origin
+			).toBe('https://messages.test');
+			expect(anchor?.getAttribute('target')).toBe('named');
+			expect(anchor?.getAttribute('rel')).toBeNull();
+
+			unmount(instance);
 		}
 	);
 

--- a/packages/shared/messaging/tests/Message.test.ts
+++ b/packages/shared/messaging/tests/Message.test.ts
@@ -122,6 +122,53 @@ describe('Message', () => {
 		unmount(instance);
 	});
 
+	it('drops style elements with their text from the sanitized message body', () => {
+		const target = document.createElement('div');
+		const message = {
+			id: 'm-style',
+			conversationId: 'c1',
+			sender: bob,
+			content: '<style>body{display:none}</style><p>Visible message</p>',
+			createdAt: new Date().toISOString(),
+			read: true,
+		};
+
+		const instance = mount(Message, { target, props: { message, currentUserId: 'u1' } });
+		const content = target.querySelector('.message__content');
+
+		expect(content?.textContent).toBe('Visible message');
+		expect(content?.textContent).not.toContain('display:none');
+		expect(content?.querySelector('style')).toBeNull();
+
+		unmount(instance);
+	});
+
+	it('secures blank-target links while preserving existing rel tokens', () => {
+		const target = document.createElement('div');
+		const message = {
+			id: 'm-link',
+			conversationId: 'c1',
+			sender: bob,
+			content:
+				'<a href="https://example.test" rel="nofollow" target="_blank">first</a> <a href="https://example.test/second" title="rel= target=">second</a>',
+			createdAt: new Date().toISOString(),
+			read: true,
+		};
+
+		const instance = mount(Message, { target, props: { message, currentUserId: 'u1' } });
+		const links = target.querySelectorAll('.message__content a');
+
+		expect(links[0]?.getAttribute('rel')?.split(/\s+/u)).toEqual([
+			'nofollow',
+			'noopener',
+			'noreferrer',
+		]);
+		expect(links[1]?.getAttribute('target')).toBe('_blank');
+		expect(links[1]?.getAttribute('rel')).toBe('noopener noreferrer');
+
+		unmount(instance);
+	});
+
 	it('renders avatar image when available', () => {
 		const target = document.createElement('div');
 		const message = {

--- a/packages/shared/messaging/tests/Message.test.ts
+++ b/packages/shared/messaging/tests/Message.test.ts
@@ -205,6 +205,27 @@ describe('Message', () => {
 		unmount(instance);
 	});
 
+	it('hardens protocol-relative links through the real message render path', () => {
+		const target = document.createElement('div');
+		const message = {
+			id: 'm-protocol-relative',
+			conversationId: 'c1',
+			sender: bob,
+			content: '<a href="//evil.test/messages" target="named">external</a>',
+			createdAt: new Date().toISOString(),
+			read: true,
+		};
+
+		const instance = mount(Message, { target, props: { message, currentUserId: 'u1' } });
+		const anchor = target.querySelector('.message__content a');
+
+		expect(anchor?.getAttribute('href')).toBe('//evil.test/messages');
+		expect(anchor?.getAttribute('target')).toBe('named');
+		expect(anchor?.getAttribute('rel')?.split(/\s+/u)).toEqual(['noopener', 'noreferrer']);
+
+		unmount(instance);
+	});
+
 	it('renders avatar image when available', () => {
 		const target = document.createElement('div');
 		const message = {

--- a/packages/shared/messaging/tests/Message.test.ts
+++ b/packages/shared/messaging/tests/Message.test.ts
@@ -98,6 +98,30 @@ describe('Message', () => {
 		unmount(instance);
 	});
 
+	it('renders server HTML while neutralizing executable markup', () => {
+		const target = document.createElement('div');
+		const message = {
+			id: 'm-html',
+			conversationId: 'c1',
+			sender: bob,
+			content:
+				'<p>Hello <strong>world</strong></p><img src="x" onerror="alert(1)"><script>alert(2)</script>',
+			createdAt: new Date().toISOString(),
+			read: true,
+		};
+
+		const instance = mount(Message, { target, props: { message, currentUserId: 'u1' } });
+
+		const content = target.querySelector('.message__content');
+		expect(content?.querySelector('strong')?.textContent).toBe('world');
+		expect(content?.textContent).toBe('Hello world');
+		expect(content?.querySelector('img')).toBeNull();
+		expect(content?.querySelector('script')).toBeNull();
+		expect(content?.innerHTML).not.toContain('onerror');
+
+		unmount(instance);
+	});
+
 	it('renders avatar image when available', () => {
 		const target = document.createElement('div');
 		const message = {

--- a/packages/shared/messaging/tests/Message.test.ts
+++ b/packages/shared/messaging/tests/Message.test.ts
@@ -169,6 +169,42 @@ describe('Message', () => {
 		unmount(instance);
 	});
 
+	it.each([
+		[
+			'NEW-20 quote-parity payload',
+			'<a href="https://evil.test" title=" rel=" target="a><img src=x onerror=alert(1)>">click me</a>',
+		],
+		[
+			'latent authored-rel payload',
+			'<a href="https://evil.test" rel="a><img src=x onerror=alert(1)>" target="_blank">click me</a>',
+		],
+	])('keeps the %s inert through the real message render path', (_case, dirty) => {
+		const target = document.createElement('div');
+		const message = {
+			id: 'm-link-parity',
+			conversationId: 'c1',
+			sender: bob,
+			content: dirty,
+			createdAt: new Date().toISOString(),
+			read: true,
+		};
+
+		const instance = mount(Message, { target, props: { message, currentUserId: 'u1' } });
+		const content = target.querySelector('.message__content');
+		const elements = Array.from(content?.querySelectorAll('*') ?? []);
+		const anchor = content?.querySelector('a');
+
+		expect(elements.map((element) => element.localName)).toEqual(['a']);
+		expect(content?.querySelector('img, form, input')).toBeNull();
+		expect(content?.querySelector('[onerror], [onclick], [onload]')).toBeNull();
+		expect(anchor?.textContent).toBe('click me');
+		expect(anchor?.getAttribute('rel')?.split(/\s+/u)).toEqual(
+			expect.arrayContaining(['noopener', 'noreferrer'])
+		);
+
+		unmount(instance);
+	});
+
 	it('renders avatar image when available', () => {
 		const target = document.createElement('div');
 		const message = {

--- a/packages/shared/messaging/tests/Message.test.ts
+++ b/packages/shared/messaging/tests/Message.test.ts
@@ -226,6 +226,36 @@ describe('Message', () => {
 		unmount(instance);
 	});
 
+	it.each([
+		['backslash pair', String.raw`\\evil.test/messages`],
+		['slash-backslash pair', String.raw`/\evil.test/messages`],
+		['backslash-slash pair', String.raw`\/evil.test/messages`],
+	])(
+		'hardens browser-normalized protocol-relative links using a %s through the real message render path',
+		(_case, href) => {
+			for (const linkTarget of ['named', '_blank']) {
+				const target = document.createElement('div');
+				const message = {
+					id: `m-backslash-${linkTarget}`,
+					conversationId: 'c1',
+					sender: bob,
+					content: `<a href="${href}" target="${linkTarget}">external</a>`,
+					createdAt: new Date().toISOString(),
+					read: true,
+				};
+
+				const instance = mount(Message, { target, props: { message, currentUserId: 'u1' } });
+				const anchor = target.querySelector('.message__content a');
+
+				expect(anchor?.getAttribute('href')).toBe(href);
+				expect(anchor?.getAttribute('target')).toBe(linkTarget);
+				expect(anchor?.getAttribute('rel')?.split(/\s+/u)).toEqual(['noopener', 'noreferrer']);
+
+				unmount(instance);
+			}
+		}
+	);
+
 	it('renders avatar image when available', () => {
 		const target = document.createElement('div');
 		const message = {

--- a/packages/shared/messaging/tests/UnreadIndicator.live.test.ts
+++ b/packages/shared/messaging/tests/UnreadIndicator.live.test.ts
@@ -3,6 +3,7 @@ import { flushSync, mount, unmount } from 'svelte';
 import UnreadIndicatorHarness from './fixtures/UnreadIndicatorHarness.svelte';
 
 const ANNOUNCEMENT_DEBOUNCE_MS = 150;
+const ANNOUNCEMENT_MAX_WAIT_MS = 1_000;
 
 describe('UnreadIndicator live announcements', () => {
 	beforeEach(() => {
@@ -78,5 +79,41 @@ describe('UnreadIndicator live announcements', () => {
 
 		observer.disconnect();
 		unmount(instance);
+	});
+
+	it('announces the current count within the max wait during sustained churn', async () => {
+		const target = document.createElement('div');
+		const instance = mount(UnreadIndicatorHarness, { target });
+		const liveRegion = target.querySelector('[role="status"]') as HTMLElement;
+
+		(target.querySelector('[data-testid="sustained-churn"]') as HTMLButtonElement).click();
+		await flushSync();
+
+		await vi.advanceTimersByTimeAsync(ANNOUNCEMENT_MAX_WAIT_MS - 1);
+		await flushSync();
+		expect(liveRegion.textContent?.trim()).toBe('');
+
+		await vi.advanceTimersByTimeAsync(1);
+		await flushSync();
+		const currentCount = target.querySelector('.unread-indicator')?.textContent?.trim();
+
+		expect(currentCount).toBe('11');
+		expect(liveRegion.textContent?.trim()).toBe(
+			`${currentCount} conversations with unread messages`
+		);
+
+		unmount(instance);
+	});
+
+	it('clears pending debounce and max-wait timers on unmount', async () => {
+		const target = document.createElement('div');
+		const instance = mount(UnreadIndicatorHarness, { target });
+
+		(target.querySelector('[data-testid="set-one"]') as HTMLButtonElement).click();
+		await flushSync();
+		expect(vi.getTimerCount()).toBe(2);
+
+		unmount(instance);
+		expect(vi.getTimerCount()).toBe(0);
 	});
 });

--- a/packages/shared/messaging/tests/UnreadIndicator.live.test.ts
+++ b/packages/shared/messaging/tests/UnreadIndicator.live.test.ts
@@ -1,0 +1,82 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { flushSync, mount, unmount } from 'svelte';
+import UnreadIndicatorHarness from './fixtures/UnreadIndicatorHarness.svelte';
+
+const ANNOUNCEMENT_DEBOUNCE_MS = 150;
+
+describe('UnreadIndicator live announcements', () => {
+	beforeEach(() => {
+		vi.useFakeTimers();
+	});
+
+	afterEach(() => {
+		vi.useRealTimers();
+	});
+
+	it('keeps the empty live region mounted before announcing the zero-to-one transition', async () => {
+		const target = document.createElement('div');
+		const instance = mount(UnreadIndicatorHarness, { target });
+		const liveRegion = target.querySelector('[role="status"]');
+
+		expect(liveRegion).toBeTruthy();
+		expect(liveRegion?.textContent?.trim()).toBe('');
+
+		(target.querySelector('[data-testid="set-one"]') as HTMLButtonElement).click();
+		await flushSync();
+		expect(target.querySelector('.unread-indicator')?.textContent).toBe('1');
+		expect(liveRegion?.textContent?.trim()).toBe('');
+
+		await vi.advanceTimersByTimeAsync(ANNOUNCEMENT_DEBOUNCE_MS);
+		await flushSync();
+		expect(liveRegion?.textContent?.trim()).toBe('1 conversation with unread messages');
+
+		unmount(instance);
+	});
+
+	it('announces the dot variant through visually hidden live-region text', async () => {
+		const target = document.createElement('div');
+		const instance = mount(UnreadIndicatorHarness, { target, props: { variant: 'dot' } });
+
+		(target.querySelector('[data-testid="set-one"]') as HTMLButtonElement).click();
+		await vi.advanceTimersByTimeAsync(ANNOUNCEMENT_DEBOUNCE_MS);
+		await flushSync();
+
+		const indicator = target.querySelector('.unread-indicator');
+		const liveRegion = target.querySelector('[role="status"]');
+		expect(indicator?.textContent?.trim()).toBe('');
+		expect(liveRegion?.querySelector('.gr-sr-only')?.textContent?.trim()).toBe(
+			'1 conversation with unread messages'
+		);
+
+		unmount(instance);
+	});
+
+	it('coalesces a realtime burst into one announcement with the final count', async () => {
+		const target = document.createElement('div');
+		const instance = mount(UnreadIndicatorHarness, { target });
+		const liveRegion = target.querySelector('[role="status"]') as HTMLElement;
+		const announcements: string[] = [];
+		const observer = new MutationObserver(() => {
+			const announcement = liveRegion.textContent?.trim();
+			if (announcement) announcements.push(announcement);
+		});
+		observer.observe(liveRegion, { childList: true, characterData: true, subtree: true });
+
+		(target.querySelector('[data-testid="burst"]') as HTMLButtonElement).click();
+		await vi.advanceTimersByTimeAsync(20);
+		await flushSync();
+
+		expect(target.querySelector('.unread-indicator')?.textContent).toBe('3');
+		expect(liveRegion.textContent?.trim()).toBe('');
+
+		await vi.advanceTimersByTimeAsync(ANNOUNCEMENT_DEBOUNCE_MS);
+		await flushSync();
+		await Promise.resolve();
+
+		expect(liveRegion.textContent?.trim()).toBe('3 conversations with unread messages');
+		expect(announcements).toEqual(['3 conversations with unread messages']);
+
+		observer.disconnect();
+		unmount(instance);
+	});
+});

--- a/packages/shared/messaging/tests/UnreadIndicator.test.ts
+++ b/packages/shared/messaging/tests/UnreadIndicator.test.ts
@@ -34,7 +34,7 @@ describe('UnreadIndicator', () => {
 		unmount(instance);
 	});
 
-	it('renders count when has unread messages', async () => {
+	it('renders the number of conversations with unread messages', async () => {
 		mockState.conversations = [{ unreadCount: 5 }, { unreadCount: 2 }];
 
 		const target = document.createElement('div');
@@ -43,8 +43,22 @@ describe('UnreadIndicator', () => {
 
 		const indicator = target.querySelector('.unread-indicator');
 		expect(indicator).toBeTruthy();
-		expect(indicator?.textContent).toBe('7');
-		expect(indicator?.getAttribute('aria-label')).toBe('7 unread messages');
+		expect(indicator?.textContent).toBe('2');
+		expect(indicator?.getAttribute('aria-label')).toBe('2 conversations with unread messages');
+
+		unmount(instance);
+	});
+
+	it('announces the number of conversations with unread activity', async () => {
+		mockState.conversations = [{ unreadCount: 1 }, { unreadCount: 0 }, { unreadCount: 1 }];
+
+		const target = document.createElement('div');
+		const instance = mount(UnreadIndicator, { target });
+		await flushSync();
+
+		const indicator = target.querySelector('.unread-indicator');
+		expect(indicator?.textContent).toBe('2');
+		expect(indicator?.getAttribute('aria-label')).toBe('2 conversations with unread messages');
 
 		unmount(instance);
 	});
@@ -62,7 +76,7 @@ describe('UnreadIndicator', () => {
 	});
 
 	it('formats counts over 99', async () => {
-		mockState.conversations = [{ unreadCount: 100 }];
+		mockState.conversations = Array.from({ length: 100 }, () => ({ unreadCount: 1 }));
 
 		const target = document.createElement('div');
 		const instance = mount(UnreadIndicator, { target });

--- a/packages/shared/messaging/tests/UnreadIndicator.test.ts
+++ b/packages/shared/messaging/tests/UnreadIndicator.test.ts
@@ -97,6 +97,10 @@ describe('UnreadIndicator', () => {
 		const indicator = target.querySelector('.unread-indicator');
 		expect(indicator?.classList.contains('unread-indicator--dot')).toBe(true);
 		expect(indicator?.textContent?.trim()).toBe(''); // Dot has no text
+		expect(indicator?.getAttribute('role')).toBe('status');
+		expect(indicator?.getAttribute('aria-live')).toBe('polite');
+		expect(indicator?.getAttribute('aria-atomic')).toBe('true');
+		expect(indicator?.getAttribute('aria-label')).toBe('1 conversation with unread messages');
 
 		unmount(instance);
 	});

--- a/packages/shared/messaging/tests/UnreadIndicator.test.ts
+++ b/packages/shared/messaging/tests/UnreadIndicator.test.ts
@@ -95,11 +95,12 @@ describe('UnreadIndicator', () => {
 		await flushSync();
 
 		const indicator = target.querySelector('.unread-indicator');
+		const liveRegion = target.querySelector('[role="status"]');
 		expect(indicator?.classList.contains('unread-indicator--dot')).toBe(true);
 		expect(indicator?.textContent?.trim()).toBe(''); // Dot has no text
-		expect(indicator?.getAttribute('role')).toBe('status');
-		expect(indicator?.getAttribute('aria-live')).toBe('polite');
-		expect(indicator?.getAttribute('aria-atomic')).toBe('true');
+		expect(indicator?.getAttribute('role')).toBe('img');
+		expect(liveRegion?.getAttribute('aria-live')).toBe('polite');
+		expect(liveRegion?.getAttribute('aria-atomic')).toBe('true');
 		expect(indicator?.getAttribute('aria-label')).toBe('1 conversation with unread messages');
 
 		unmount(instance);

--- a/packages/shared/messaging/tests/fixtures/ConversationsActionsHarness.svelte
+++ b/packages/shared/messaging/tests/fixtures/ConversationsActionsHarness.svelte
@@ -1,0 +1,27 @@
+<script lang="ts">
+	import Conversations from '../../src/Conversations.svelte';
+	import type { Conversation, ConversationFolder } from '../../src/context.svelte.js';
+
+	interface Props {
+		folder?: ConversationFolder;
+	}
+
+	let { folder = $bindable() }: Props = $props();
+
+	function stopSelection(event: MouseEvent) {
+		event.stopPropagation();
+	}
+</script>
+
+<Conversations bind:folder>
+	{#snippet actions(conversation: Conversation)}
+		<button
+			type="button"
+			class="request-action"
+			data-conversation-id={conversation.id}
+			onclick={stopSelection}
+		>
+			Accept
+		</button>
+	{/snippet}
+</Conversations>

--- a/packages/shared/messaging/tests/fixtures/ConversationsContextHarness.svelte
+++ b/packages/shared/messaging/tests/fixtures/ConversationsContextHarness.svelte
@@ -1,0 +1,62 @@
+<script lang="ts">
+	import Conversations from '../../src/Conversations.svelte';
+	import {
+		createMessagesContext,
+		type Conversation,
+		type ConversationFolder,
+	} from '../../src/context.svelte.js';
+
+	interface Props {
+		controlled?: boolean;
+	}
+
+	let { controlled = false }: Props = $props();
+	let folder = $state<ConversationFolder>('REQUESTS');
+
+	const requestConversation: Conversation = {
+		id: 'req-1',
+		folder: 'REQUESTS',
+		requestState: 'PENDING',
+		participants: [{ id: 'alice', username: 'alice', displayName: 'Alice', avatar: '' }],
+		unreadCount: 0,
+		updatedAt: '2026-08-02T00:00:00.000Z',
+	};
+	const inboxConversation: Conversation = {
+		id: 'inbox-1',
+		folder: 'INBOX',
+		requestState: 'ACCEPTED',
+		participants: [{ id: 'bob', username: 'bob', displayName: 'Bob', avatar: '' }],
+		unreadCount: 0,
+		updatedAt: '2026-08-02T00:01:00.000Z',
+	};
+
+	const context = createMessagesContext({
+		onFetchConversations: async (nextFolder) =>
+			nextFolder === 'REQUESTS' ? [requestConversation] : [inboxConversation],
+		onAcceptMessageRequest: async () => ({
+			...requestConversation,
+			folder: 'INBOX',
+			requestState: 'ACCEPTED',
+		}),
+	});
+	context.state.folder = 'REQUESTS';
+	context.state.conversations = [requestConversation];
+</script>
+
+<output data-bound-folder={folder}>{folder}</output>
+
+{#snippet actions(conversation: Conversation)}
+	<button
+		type="button"
+		class="request-action"
+		onclick={() => void context.acceptMessageRequest(conversation.id)}
+	>
+		Accept
+	</button>
+{/snippet}
+
+{#if controlled}
+	<Conversations bind:folder {actions} />
+{:else}
+	<Conversations {actions} />
+{/if}

--- a/packages/shared/messaging/tests/fixtures/UnreadIndicatorHarness.svelte
+++ b/packages/shared/messaging/tests/fixtures/UnreadIndicatorHarness.svelte
@@ -1,0 +1,34 @@
+<script lang="ts">
+	import UnreadIndicator from '../../src/UnreadIndicator.svelte';
+	import { createMessagesContext, type Conversation } from '../../src/context.svelte.js';
+
+	interface Props {
+		variant?: 'badge' | 'dot' | 'number';
+	}
+
+	let { variant = 'badge' }: Props = $props();
+	const context = createMessagesContext();
+
+	function unreadConversations(count: number): Conversation[] {
+		return Array.from({ length: count }, (_, index) => ({
+			id: `conversation-${index}`,
+			participants: [],
+			unreadCount: 1,
+			updatedAt: '',
+		}));
+	}
+
+	function setUnreadCount(count: number) {
+		context.state.conversations = unreadConversations(count);
+	}
+
+	function simulateBurst() {
+		setUnreadCount(1);
+		setTimeout(() => setUnreadCount(2), 10);
+		setTimeout(() => setUnreadCount(3), 20);
+	}
+</script>
+
+<button type="button" data-testid="set-one" onclick={() => setUnreadCount(1)}>Set one</button>
+<button type="button" data-testid="burst" onclick={simulateBurst}>Burst</button>
+<UnreadIndicator {variant} />

--- a/packages/shared/messaging/tests/fixtures/UnreadIndicatorHarness.svelte
+++ b/packages/shared/messaging/tests/fixtures/UnreadIndicatorHarness.svelte
@@ -27,8 +27,18 @@
 		setTimeout(() => setUnreadCount(2), 10);
 		setTimeout(() => setUnreadCount(3), 20);
 	}
+
+	function simulateSustainedChurn() {
+		setUnreadCount(1);
+		for (let count = 2; count <= 12; count += 1) {
+			setTimeout(() => setUnreadCount(count), (count - 1) * 100);
+		}
+	}
 </script>
 
 <button type="button" data-testid="set-one" onclick={() => setUnreadCount(1)}>Set one</button>
 <button type="button" data-testid="burst" onclick={simulateBurst}>Burst</button>
+<button type="button" data-testid="sustained-churn" onclick={simulateSustainedChurn}>
+	Sustained churn
+</button>
 <UnreadIndicator {variant} />

--- a/packages/shared/messaging/tests/sanitize.test.ts
+++ b/packages/shared/messaging/tests/sanitize.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from 'vitest';
-import { sanitizeMessageHtml, sanitizeMessagePreview } from '../src/sanitize.js';
+import {
+	sanitizeMessageHtml,
+	sanitizeMessagePreview,
+	stripSerializedMarkup,
+} from '../src/sanitize.js';
 
 describe('messaging sanitization', () => {
 	it('extracts decoded plain text without rendering markup', () => {
@@ -26,6 +30,20 @@ describe('messaging sanitization', () => {
 
 		expect(sanitized).toContain('rel="nofollow noopener noreferrer"');
 		expect(sanitized).toContain('target="_blank"');
+	});
+
+	it('secures blank-target links when an earlier quoted attribute contains >', () => {
+		const dirty = '<a title="a > b" href="https://evil.test" target="_blank">intact link text</a>';
+
+		expect(sanitizeMessageHtml(dirty)).toBe(
+			'<a title="a > b" href="https://evil.test" target="_blank" rel="noopener noreferrer">intact link text</a>'
+		);
+	});
+
+	it('keeps normal external-link hardening byte-identical', () => {
+		expect(sanitizeMessageHtml('<a href="https://example.test">link</a>')).toBe(
+			'<a href="https://example.test" rel="noopener noreferrer" target="_blank">link</a>'
+		);
 	});
 
 	it.each([
@@ -56,13 +74,37 @@ describe('messaging sanitization', () => {
 	});
 
 	it.each([
-		['textarea', '<textarea><img src=x onerror=alert(1)></textarea><p>a</p>', '<img'],
-		['title', '<title>SECRET</title><p>a</p>', 'SECRET'],
-	])('drops %s raw text from message previews', (_element, dirty, leakedText) => {
+		['textarea', '<textarea>LEAK_<img src=x onerror=alert(1)></textarea><p>Visible</p>'],
+		['title', '<title>LEAK_<img src=x onerror=alert(1)></title><p>Visible</p>'],
+		['iframe', '<iframe>LEAK_<img src=x onerror=alert(1)></iframe><p>Visible</p>'],
+		['noembed', '<noembed>LEAK_<img src=x onerror=alert(1)></noembed><p>Visible</p>'],
+		['noframes', '<noframes>LEAK_<img src=x onerror=alert(1)></noframes><p>Visible</p>'],
+		['xmp', '<xmp>LEAK_<img src=x onerror=alert(1)></xmp><p>Visible</p>'],
+	])('drops %s raw text and markup from message bodies and previews', (element, dirty) => {
+		const body = sanitizeMessageHtml(dirty);
 		const preview = sanitizeMessagePreview(dirty);
 
-		expect(preview).toBe('a');
-		expect(preview).not.toContain(leakedText);
+		expect(body).toBe('<p>Visible</p>');
+		expect(preview).toBe('Visible');
+		expect(body).not.toContain(`<${element}`);
+		expect(body).not.toContain('LEAK_');
+		expect(body).not.toContain('onerror');
+		expect(preview).not.toContain('LEAK_');
+		expect(preview).not.toContain('<img');
+	});
+
+	it('drops plaintext and everything it consumes from message bodies and previews', () => {
+		const dirty = '<p>Visible</p><plaintext>LEAK_<img src=x onerror=alert(1)>';
+		const body = sanitizeMessageHtml(dirty);
+		const preview = sanitizeMessagePreview(dirty);
+
+		expect(body).toBe('<p>Visible</p>');
+		expect(preview).toBe('Visible');
+		expect(body).not.toContain('<plaintext');
+		expect(body).not.toContain('LEAK_');
+		expect(body).not.toContain('onerror');
+		expect(preview).not.toContain('LEAK_');
+		expect(preview).not.toContain('<img');
 	});
 
 	it('continues to drop script and style contents from previews', () => {
@@ -73,5 +115,12 @@ describe('messaging sanitization', () => {
 		expect(preview).toBe('Visible');
 		expect(preview).not.toContain('SECRET_SCRIPT');
 		expect(preview).not.toContain('SECRET_STYLE');
+	});
+
+	it('iterates serialized markup stripping until a second-pass tag is gone', () => {
+		const serialized = `<'<"'">'>`;
+
+		expect(serialized.replace(/<(?:(?:"[^"]*")|(?:'[^']*')|[^'">])*>/gu, '')).toBe(`<''>`);
+		expect(stripSerializedMarkup(serialized)).toBe('');
 	});
 });

--- a/packages/shared/messaging/tests/sanitize.test.ts
+++ b/packages/shared/messaging/tests/sanitize.test.ts
@@ -28,6 +28,35 @@ function expectOnlySafeAnchor(dirty: string): HTMLAnchorElement {
 	return anchor as HTMLAnchorElement;
 }
 
+function expectHardenedAnchor(
+	dirty: string,
+	expected: {
+		attributes: string[];
+		text: string;
+		title?: string;
+		target?: string;
+		authorRelTokens?: string[];
+	}
+): HTMLAnchorElement {
+	const anchor = expectOnlySafeAnchor(dirty);
+
+	expect(Array.from(anchor.attributes, (attribute) => attribute.name).sort()).toEqual(
+		[...expected.attributes].sort()
+	);
+	expect(anchor.textContent).toBe(expected.text);
+	expect(anchor.getAttribute('title')).toBe(expected.title ?? null);
+	expect(anchor.getAttribute('target')).toBe(expected.target ?? null);
+
+	const relTokens = anchor.getAttribute('rel')?.split(/\s+/u).filter(Boolean) ?? [];
+	for (const token of expected.authorRelTokens ?? []) {
+		expect(relTokens).toContain(token);
+	}
+	expect(relTokens.filter((token) => token.toLowerCase() === 'noopener')).toHaveLength(1);
+	expect(relTokens.filter((token) => token.toLowerCase() === 'noreferrer')).toHaveLength(1);
+
+	return anchor;
+}
+
 describe('messaging sanitization', () => {
 	it('extracts decoded plain text without rendering markup', () => {
 		expect(sanitizeMessagePreview('<p>Tom &amp; <strong>Jerry</strong></p>')).toBe('Tom & Jerry');
@@ -122,6 +151,96 @@ describe('messaging sanitization', () => {
 		],
 	])('keeps the sanitized output structurally safe after an %s attempt', (_attack, dirty) => {
 		expectOnlySafeAnchor(dirty);
+	});
+
+	it.each([
+		[
+			'NEW-20 quote-parity payload',
+			'<a href="https://evil.test" title=" rel=" target="a><img src=x onerror=alert(1)>">click me</a>',
+			{
+				attributes: ['href', 'title', 'target', 'rel'],
+				text: 'click me',
+				title: ' rel=',
+				target: 'a><img src=x onerror=alert(1)>',
+			},
+		],
+		[
+			'latent authored-rel payload',
+			'<a href="https://evil.test" rel="a><img src=x onerror=alert(1)>" target="_blank">click me</a>',
+			{
+				attributes: ['href', 'rel', 'target'],
+				text: 'click me',
+				target: '_blank',
+				authorRelTokens: ['a><img', 'src=x', 'onerror=alert(1)>'],
+			},
+		],
+	])('keeps %s inside the parsed anchor attribute set', (_case, dirty, expected) => {
+		expectHardenedAnchor(dirty, expected);
+	});
+
+	it.each([
+		[
+			'double-quoted delimiter permutations inside a single-quoted title',
+			'<a href="https://evil.test" title=\'rel=" target=a> marker\' target="named">double</a>',
+			{
+				attributes: ['href', 'title', 'target', 'rel'],
+				text: 'double',
+				title: 'rel=" target=a> marker',
+				target: 'named',
+			},
+		],
+		[
+			'equals, quote, and greater-than permutations inside rel',
+			'<a href="https://evil.test" rel=\'author = " > marker\' target="_blank">rel</a>',
+			{
+				attributes: ['href', 'rel', 'target'],
+				text: 'rel',
+				target: '_blank',
+				authorRelTokens: ['author', '=', '"', '>', 'marker'],
+			},
+		],
+		[
+			'equals, quote, and greater-than permutations inside target',
+			'<a href="https://evil.test" target=\'named=>"\'>target</a>',
+			{
+				attributes: ['href', 'target', 'rel'],
+				text: 'target',
+				target: 'named=>"',
+			},
+		],
+		[
+			'single-quoted attributes',
+			"<a href='https://evil.test' title='single' target='named'>single</a>",
+			{
+				attributes: ['href', 'title', 'target', 'rel'],
+				text: 'single',
+				title: 'single',
+				target: 'named',
+			},
+		],
+		[
+			'unquoted attributes',
+			'<a href=https://evil.test title=unquoted target=named>unquoted</a>',
+			{
+				attributes: ['href', 'title', 'target', 'rel'],
+				text: 'unquoted',
+				title: 'unquoted',
+				target: 'named',
+			},
+		],
+		[
+			'mixed-case tag and attribute names',
+			'<A HrEf="https://evil.test" ReL="author" TaRgEt="named" TiTlE="mixed">mixed</A>',
+			{
+				attributes: ['href', 'rel', 'target', 'title'],
+				text: 'mixed',
+				title: 'mixed',
+				target: 'named',
+				authorRelTokens: ['author'],
+			},
+		],
+	])('keeps the quote-parity battery safe for %s', (_case, dirty, expected) => {
+		expectHardenedAnchor(dirty, expected);
 	});
 
 	it('hardens a normal external link without forcing it into a new browsing context', () => {

--- a/packages/shared/messaging/tests/sanitize.test.ts
+++ b/packages/shared/messaging/tests/sanitize.test.ts
@@ -110,6 +110,41 @@ describe('messaging sanitization', () => {
 		);
 	});
 
+	it.each(['_blank', 'named'])(
+		'hardens protocol-relative links with the authored %s target',
+		(target) => {
+			const anchor = expectOnlySafeAnchor(
+				`<a href="//evil.test/messages" target="${target}">external</a>`
+			);
+
+			expect(anchor.getAttribute('href')).toBe('//evil.test/messages');
+			expect(anchor.getAttribute('target')).toBe(target);
+			expect(anchor.getAttribute('rel')?.split(/\s+/u)).toEqual(['noopener', 'noreferrer']);
+		}
+	);
+
+	it('pins the sanitizer contract for an uppercase HTTP scheme', () => {
+		const anchor = expectOnlySafeAnchor(
+			'<a href="HTTPS://evil.test/messages" target="_blank">filtered scheme</a>'
+		);
+
+		// rehype-sanitize currently treats protocol allow-list entries case-sensitively,
+		// so it removes this href before the case-insensitive tree hardener runs.
+		expect(Array.from(anchor.attributes, (attribute) => attribute.name)).toEqual(['target']);
+		expect(anchor.getAttribute('href')).toBeNull();
+		expect(anchor.getAttribute('rel')).toBeNull();
+		expect(anchor.getAttribute('target')).toBe('_blank');
+	});
+
+	it.each(['/messages/next', '../thread', '#reply'])(
+		'leaves the relative or internal link %s untouched',
+		(href) => {
+			expect(sanitizeMessageHtml(`<a href="${href}" target="named">next</a>`)).toBe(
+				`<a href="${href}" target="named">next</a>`
+			);
+		}
+	);
+
 	it.each([
 		[
 			'href-first',

--- a/packages/shared/messaging/tests/sanitize.test.ts
+++ b/packages/shared/messaging/tests/sanitize.test.ts
@@ -7,6 +7,10 @@ describe('messaging sanitization', () => {
 		expect(sanitizeMessagePreview('<p>if a &lt; b then ship</p>')).toBe('if a < b then ship');
 	});
 
+	it('does not leave partial-tag residue when an attribute contains a greater-than sign', () => {
+		expect(sanitizeMessagePreview('<p title="a > b">Visible message</p>')).toBe('Visible message');
+	});
+
 	it('drops style elements together with their CSS text from both surfaces', () => {
 		const dirty = '<style>body{display:none}</style><p>Visible message</p>';
 

--- a/packages/shared/messaging/tests/sanitize.test.ts
+++ b/packages/shared/messaging/tests/sanitize.test.ts
@@ -5,6 +5,29 @@ import {
 	stripSerializedMarkup,
 } from '../src/sanitize.js';
 
+function expectOnlySafeAnchor(dirty: string): HTMLAnchorElement {
+	const sanitized = sanitizeMessageHtml(dirty);
+	const parsed = new DOMParser().parseFromString(sanitized, 'text/html');
+	const elements = Array.from(parsed.body.querySelectorAll('*'));
+
+	expect(elements.map((element) => element.localName)).toEqual(['a']);
+	expect(parsed.body.querySelector('img, form, input')).toBeNull();
+	for (const element of elements) {
+		expect(Array.from(element.attributes).map((attribute) => attribute.name)).not.toContainEqual(
+			expect.stringMatching(/^on/iu)
+		);
+	}
+
+	const anchor = elements[0];
+	expect(anchor).toBeInstanceOf(HTMLAnchorElement);
+	const href = anchor.getAttribute('href');
+	if (href !== null) {
+		expect(['http:', 'https:']).toContain(new URL(href, 'https://messages.test').protocol);
+	}
+
+	return anchor as HTMLAnchorElement;
+}
+
 describe('messaging sanitization', () => {
 	it('extracts decoded plain text without rendering markup', () => {
 		expect(sanitizeMessagePreview('<p>Tom &amp; <strong>Jerry</strong></p>')).toBe('Tom & Jerry');
@@ -32,17 +55,52 @@ describe('messaging sanitization', () => {
 		expect(sanitized).toContain('target="_blank"');
 	});
 
-	it('secures blank-target links when an earlier quoted attribute contains >', () => {
-		const dirty = '<a title="a > b" href="https://evil.test" target="_blank">intact link text</a>';
+	it.each([
+		[
+			'href-first',
+			'<a href="https://evil.test" title="a > b" target="_blank">intact link text</a>',
+			'<a href="https://evil.test" title="a > b" target="_blank" rel="noopener noreferrer">intact link text</a>',
+		],
+		[
+			'title-first',
+			'<a title="a > b" href="https://evil.test" target="_blank">intact link text</a>',
+			'<a title="a > b" href="https://evil.test" target="_blank" rel="noopener noreferrer">intact link text</a>',
+		],
+	])(
+		'secures %s blank-target links when a quoted attribute contains >',
+		(_order, dirty, expected) => {
+			expect(sanitizeMessageHtml(dirty)).toBe(expected);
+		}
+	);
 
-		expect(sanitizeMessageHtml(dirty)).toBe(
-			'<a title="a > b" href="https://evil.test" target="_blank" rel="noopener noreferrer">intact link text</a>'
-		);
+	it.each([
+		[
+			'img event-handler title breakout',
+			'<a href="https://x.test" title="q><img src=z onerror=alert(1)>">click</a>',
+		],
+		[
+			'javascript protocol title breakout',
+			'<a href="https://x.test" title="q><a href=javascript:alert(1)>">click</a>',
+		],
+		[
+			'credential-form title breakout',
+			'<a href="https://x.test" title="q><form><input type=password>">click</a>',
+		],
+		[
+			'rel attribute breakout',
+			'<a href="https://x.test" rel="q><img src=z onerror=alert(1)>">click</a>',
+		],
+		[
+			'target attribute breakout',
+			'<a href="https://x.test" target="q><img src=z onerror=alert(1)>">click</a>',
+		],
+	])('keeps the sanitized output structurally safe after an %s attempt', (_attack, dirty) => {
+		expectOnlySafeAnchor(dirty);
 	});
 
 	it('keeps normal external-link hardening byte-identical', () => {
 		expect(sanitizeMessageHtml('<a href="https://example.test">link</a>')).toBe(
-			'<a href="https://example.test" rel="noopener noreferrer" target="_blank">link</a>'
+			'<a href="https://example.test" target="_blank" rel="noopener noreferrer">link</a>'
 		);
 	});
 

--- a/packages/shared/messaging/tests/sanitize.test.ts
+++ b/packages/shared/messaging/tests/sanitize.test.ts
@@ -123,6 +123,40 @@ describe('messaging sanitization', () => {
 		}
 	);
 
+	it.each([
+		['backslash pair', String.raw`\\evil.test/messages`],
+		['slash-backslash pair', String.raw`/\evil.test/messages`],
+		['backslash-slash pair', String.raw`\/evil.test/messages`],
+	])('hardens browser-normalized protocol-relative links using a %s', (_case, href) => {
+		for (const target of ['named', '_blank']) {
+			const anchor = expectOnlySafeAnchor(`<a href="${href}" target="${target}">external</a>`);
+
+			expect(anchor.getAttribute('href')).toBe(href);
+			expect(anchor.getAttribute('target')).toBe(target);
+			expect(anchor.getAttribute('rel')?.split(/\s+/u)).toEqual(['noopener', 'noreferrer']);
+		}
+	});
+
+	it('pins the browser authority boundary for backslashes in relative-looking links', () => {
+		const authorityShape = String.raw`/\foo/bar`;
+		const internalPath = String.raw`/foo\bar`;
+
+		// For special schemes, WHATWG URL parsing turns the first shape into //foo/bar,
+		// whose host is `foo`; it is not a same-origin path and must be hardened.
+		expect(new URL(authorityShape, 'https://messages.test/base').origin).toBe('https://foo');
+		expect(sanitizeMessageHtml(`<a href="${authorityShape}" target="named">authority</a>`)).toBe(
+			`<a href="${authorityShape}" target="named" rel="noopener noreferrer">authority</a>`
+		);
+
+		// A backslash after a non-separator path segment remains on the current host.
+		expect(new URL(internalPath, 'https://messages.test/base').origin).toBe(
+			'https://messages.test'
+		);
+		expect(sanitizeMessageHtml(`<a href="${internalPath}" target="named">internal</a>`)).toBe(
+			`<a href="${internalPath}" target="named">internal</a>`
+		);
+	});
+
 	it('pins the sanitizer contract for an uppercase HTTP scheme', () => {
 		const anchor = expectOnlySafeAnchor(
 			'<a href="HTTPS://evil.test/messages" target="_blank">filtered scheme</a>'

--- a/packages/shared/messaging/tests/sanitize.test.ts
+++ b/packages/shared/messaging/tests/sanitize.test.ts
@@ -86,6 +86,15 @@ function expectHardenedAnchor(
 }
 
 describe('messaging sanitization', () => {
+	it.each([
+		['null', null],
+		['undefined', undefined],
+		['number', 42],
+	])('returns empty output for a %s runtime value', (_case, dirty) => {
+		expect(sanitizeMessageHtml(dirty as unknown as string)).toBe('');
+		expect(sanitizeMessagePreview(dirty as unknown as string)).toBe('');
+	});
+
 	it('extracts decoded plain text without rendering markup', () => {
 		expect(sanitizeMessagePreview('<p>Tom &amp; <strong>Jerry</strong></p>')).toBe('Tom & Jerry');
 		expect(sanitizeMessagePreview('<p>if a &lt; b then ship</p>')).toBe('if a < b then ship');

--- a/packages/shared/messaging/tests/sanitize.test.ts
+++ b/packages/shared/messaging/tests/sanitize.test.ts
@@ -463,7 +463,7 @@ describe('messaging sanitization', () => {
 	it('iterates serialized markup stripping until a second-pass tag is gone', () => {
 		const serialized = `<'<"'">'>`;
 
-		expect(serialized.replace(/<(?:(?:"[^"]*")|(?:'[^']*')|[^'">])*>/gu, '')).toBe(`<''>`);
+		// A single pass leaves the residue `<''>`; the fixpoint must remove that second-pass tag.
 		expect(stripSerializedMarkup(serialized)).toBe('');
 	});
 });

--- a/packages/shared/messaging/tests/sanitize.test.ts
+++ b/packages/shared/messaging/tests/sanitize.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from 'vitest';
+import { sanitizeMessageHtml, sanitizeMessagePreview } from '../src/sanitize.js';
+
+describe('messaging sanitization', () => {
+	it('extracts decoded plain text without rendering markup', () => {
+		expect(sanitizeMessagePreview('<p>Tom &amp; <strong>Jerry</strong></p>')).toBe('Tom & Jerry');
+		expect(sanitizeMessagePreview('<p>if a &lt; b then ship</p>')).toBe('if a < b then ship');
+	});
+
+	it('drops style elements together with their CSS text from both surfaces', () => {
+		const dirty = '<style>body{display:none}</style><p>Visible message</p>';
+
+		expect(sanitizeMessageHtml(dirty)).toBe('<p>Visible message</p>');
+		expect(sanitizeMessagePreview(dirty)).toBe('Visible message');
+		expect(sanitizeMessageHtml('<style>body{display:none}')).toBe('');
+	});
+
+	it('preserves rel tokens and adds whole-token blank-target protections', () => {
+		const sanitized = sanitizeMessageHtml(
+			'<a href="https://example.test" rel="nofollow" target="_blank">link</a>'
+		);
+
+		expect(sanitized).toContain('rel="nofollow noopener noreferrer"');
+		expect(sanitized).toContain('target="_blank"');
+	});
+
+	it('does not mistake other attribute values for rel or target attributes', () => {
+		const sanitized = sanitizeMessageHtml(
+			'<a href="https://example.test" title="rel= target=">link</a>'
+		);
+
+		expect(sanitized).toContain('target="_blank"');
+		expect(sanitized).toContain('rel="noopener noreferrer"');
+	});
+
+	it('truncates by Unicode code point rather than splitting surrogate pairs', () => {
+		const preview = sanitizeMessagePreview(`${'a'.repeat(199)}😀tail`, 200);
+
+		expect(preview).toBe(`${'a'.repeat(199)}😀...`);
+		expect(preview).not.toContain('\uFFFD');
+	});
+});

--- a/packages/shared/messaging/tests/sanitize.test.ts
+++ b/packages/shared/messaging/tests/sanitize.test.ts
@@ -24,6 +24,17 @@ describe('messaging sanitization', () => {
 		expect(sanitized).toContain('target="_blank"');
 	});
 
+	it.each([
+		['xnoopener ynoreferrer', 'xnoopener ynoreferrer noopener noreferrer'],
+		['xnoopener', 'xnoopener noopener noreferrer'],
+	])('does not treat substring-decoy rel tokens %s as protections', (rel, expectedRel) => {
+		const sanitized = sanitizeMessageHtml(
+			`<a href="https://example.test" rel="${rel}" target="_blank">link</a>`
+		);
+
+		expect(sanitized).toContain(`rel="${expectedRel}"`);
+	});
+
 	it('does not mistake other attribute values for rel or target attributes', () => {
 		const sanitized = sanitizeMessageHtml(
 			'<a href="https://example.test" title="rel= target=">link</a>'
@@ -38,5 +49,25 @@ describe('messaging sanitization', () => {
 
 		expect(preview).toBe(`${'a'.repeat(199)}😀...`);
 		expect(preview).not.toContain('\uFFFD');
+	});
+
+	it.each([
+		['textarea', '<textarea><img src=x onerror=alert(1)></textarea><p>a</p>', '<img'],
+		['title', '<title>SECRET</title><p>a</p>', 'SECRET'],
+	])('drops %s raw text from message previews', (_element, dirty, leakedText) => {
+		const preview = sanitizeMessagePreview(dirty);
+
+		expect(preview).toBe('a');
+		expect(preview).not.toContain(leakedText);
+	});
+
+	it('continues to drop script and style contents from previews', () => {
+		const preview = sanitizeMessagePreview(
+			'<script>SECRET_SCRIPT</script><style>SECRET_STYLE</style><p>Visible</p>'
+		);
+
+		expect(preview).toBe('Visible');
+		expect(preview).not.toContain('SECRET_SCRIPT');
+		expect(preview).not.toContain('SECRET_STYLE');
 	});
 });

--- a/packages/shared/messaging/tests/sanitize.test.ts
+++ b/packages/shared/messaging/tests/sanitize.test.ts
@@ -57,6 +57,32 @@ describe('messaging sanitization', () => {
 
 	it.each([
 		[
+			'named target',
+			'<a title="x" href="https://evil.test" target="named">link</a>',
+			'<a title="x" href="https://evil.test" target="named" rel="noopener noreferrer">link</a>',
+		],
+		[
+			'no target',
+			'<a href="https://evil.test">link</a>',
+			'<a href="https://evil.test" rel="noopener noreferrer">link</a>',
+		],
+		[
+			'self target',
+			'<a href="https://evil.test" target="_self">link</a>',
+			'<a href="https://evil.test" target="_self" rel="noopener noreferrer">link</a>',
+		],
+	])('hardens an external link with a %s without changing its target', (_case, dirty, expected) => {
+		expect(sanitizeMessageHtml(dirty)).toBe(expected);
+	});
+
+	it('preserves internal self-target links without adding an external-link rel', () => {
+		expect(sanitizeMessageHtml('<a href="/messages/next" target="_self">next</a>')).toBe(
+			'<a href="/messages/next" target="_self">next</a>'
+		);
+	});
+
+	it.each([
+		[
 			'href-first',
 			'<a href="https://evil.test" title="a > b" target="_blank">intact link text</a>',
 			'<a href="https://evil.test" title="a > b" target="_blank" rel="noopener noreferrer">intact link text</a>',
@@ -98,9 +124,9 @@ describe('messaging sanitization', () => {
 		expectOnlySafeAnchor(dirty);
 	});
 
-	it('keeps normal external-link hardening byte-identical', () => {
+	it('hardens a normal external link without forcing it into a new browsing context', () => {
 		expect(sanitizeMessageHtml('<a href="https://example.test">link</a>')).toBe(
-			'<a href="https://example.test" target="_blank" rel="noopener noreferrer">link</a>'
+			'<a href="https://example.test" rel="noopener noreferrer">link</a>'
 		);
 	});
 
@@ -120,7 +146,7 @@ describe('messaging sanitization', () => {
 			'<a href="https://example.test" title="rel= target=">link</a>'
 		);
 
-		expect(sanitized).toContain('target="_blank"');
+		expect(sanitized).not.toContain('target="_blank"');
 		expect(sanitized).toContain('rel="noopener noreferrer"');
 	});
 

--- a/packages/shared/messaging/tests/sanitize.test.ts
+++ b/packages/shared/messaging/tests/sanitize.test.ts
@@ -5,6 +5,34 @@ import {
 	stripSerializedMarkup,
 } from '../src/sanitize.js';
 
+const WHATWG_PREPARSE_EXTERNAL_HREF_CASES = [
+	{ name: 'leading space', predicateHref: ' //evil.test/messages' },
+	{ name: 'leading tab', predicateHref: '\t//evil.test/messages' },
+	{ name: 'leading line breaks', predicateHref: '\n\r//evil.test/messages' },
+	{ name: 'leading C0 control', predicateHref: '\x01//evil.test/messages' },
+	{ name: 'tab between slashes', predicateHref: '/\t/evil.test/messages' },
+	{ name: 'line feed between slashes', predicateHref: '/\n/evil.test/messages' },
+	{ name: 'tab before backslash separator', predicateHref: '/\t\\evil.test/messages' },
+	{
+		name: 'entity-encoded tab',
+		predicateHref: '\t//evil.test/messages',
+		authoredHref: '&#9;//evil.test/messages',
+	},
+] as const;
+
+const WHATWG_PREPARSE_EXTERNAL_HREF_MATRIX = WHATWG_PREPARSE_EXTERNAL_HREF_CASES.flatMap(
+	({ name, predicateHref, ...hrefCase }) =>
+		(['named', '_blank'] as const).map(
+			(target) =>
+				[
+					name,
+					predicateHref,
+					'authoredHref' in hrefCase ? hrefCase.authoredHref : predicateHref,
+					target,
+				] as const
+		)
+);
+
 function expectOnlySafeAnchor(dirty: string): HTMLAnchorElement {
 	const sanitized = sanitizeMessageHtml(dirty);
 	const parsed = new DOMParser().parseFromString(sanitized, 'text/html');
@@ -136,6 +164,40 @@ describe('messaging sanitization', () => {
 			expect(anchor.getAttribute('rel')?.split(/\s+/u)).toEqual(['noopener', 'noreferrer']);
 		}
 	});
+
+	it.each(WHATWG_PREPARSE_EXTERNAL_HREF_MATRIX)(
+		'hardens a %s external href %j authored as %j after WHATWG pre-parse normalization with target %s',
+		(_case, predicateHref, authoredHref, target) => {
+			const anchor = expectOnlySafeAnchor(
+				`<a href="${authoredHref}" target="${target}">external</a>`
+			);
+
+			// Numeric entities are decoded by the HTML parser before the predicate sees href.
+			if (authoredHref.startsWith('&#9;')) {
+				expect(anchor.getAttribute('href')).toBe(predicateHref);
+			}
+			expect(new URL(anchor.getAttribute('href') ?? '', 'https://messages.test').origin).toBe(
+				'https://evil.test'
+			);
+			expect(anchor.getAttribute('target')).toBe(target);
+			expect(anchor.getAttribute('rel')?.split(/\s+/u)).toEqual(['noopener', 'noreferrer']);
+		}
+	);
+
+	it.each([' /local/path', '\t#frag', ' ../up'])(
+		'keeps the parser-normalized internal href %j unhardened',
+		(href) => {
+			const anchor = expectOnlySafeAnchor(`<a href="${href}" target="named">internal</a>`);
+
+			// Contract: classify the parser-trimmed value, but preserve the authored href. Leading
+			// whitespace that still resolves internally must not receive external-link hardening.
+			expect(new URL(anchor.getAttribute('href') ?? '', 'https://messages.test/base/').origin).toBe(
+				'https://messages.test'
+			);
+			expect(anchor.getAttribute('target')).toBe('named');
+			expect(anchor.getAttribute('rel')).toBeNull();
+		}
+	);
 
 	it('pins the browser authority boundary for backslashes in relative-looking links', () => {
 		const authorityShape = String.raw`/\foo/bar`;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1377,6 +1377,9 @@ importers:
       '@equaltoai/greater-components-primitives':
         specifier: workspace:*
         version: link:../../primitives
+      '@equaltoai/greater-components-utils':
+        specifier: workspace:*
+        version: link:../../utils
     devDependencies:
       '@sveltejs/vite-plugin-svelte':
         specifier: ^7.0.0

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1396,9 +1396,6 @@ importers:
       '@testing-library/svelte':
         specifier: ^5.3.1
         version: 5.3.1(svelte@5.55.7(@typescript-eslint/types@8.58.0))(vite@8.0.16(@types/node@25.6.0)(esbuild@0.25.12)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))(vitest@4.1.4)
-      '@types/hast':
-        specifier: ^3.0.4
-        version: 3.0.4
       '@types/node':
         specifier: ^25.6.0
         version: 25.6.0
@@ -3499,6 +3496,9 @@ packages:
 
   '@types/hast@3.0.4':
     resolution: {integrity: sha512-WPs+bbQw5aCj+x6laNGWLH3wviHtoCv/P3+otBhbOhJgG8qtpdAMlTCxLtsTWA7LH1Oh/bFCHsBn0TPS5m30EQ==}
+
+  '@types/hast@3.0.5':
+    resolution: {integrity: sha512-rp/ezSWaD1m44dPKICGhiskI13nVr7qTloFwDa/IYkhhf5nzwP+zIQcIJh3WIFSBOy/H1PzB40jPjMDksN4F+g==}
 
   '@types/json-schema@7.0.15':
     resolution: {integrity: sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==}
@@ -8707,6 +8707,10 @@ snapshots:
     dependencies:
       '@types/unist': 3.0.3
 
+  '@types/hast@3.0.5':
+    dependencies:
+      '@types/unist': 3.0.3
+
   '@types/json-schema@7.0.15': {}
 
   '@types/jsonfile@6.1.4':
@@ -9991,7 +9995,7 @@ snapshots:
 
   hast-util-from-html@2.0.3:
     dependencies:
-      '@types/hast': 3.0.4
+      '@types/hast': 3.0.5
       devlop: 1.1.0
       hast-util-from-parse5: 8.0.3
       parse5: 7.3.0
@@ -10000,7 +10004,7 @@ snapshots:
 
   hast-util-from-parse5@8.0.3:
     dependencies:
-      '@types/hast': 3.0.4
+      '@types/hast': 3.0.5
       '@types/unist': 3.0.3
       devlop: 1.1.0
       hastscript: 9.0.1
@@ -10031,7 +10035,7 @@ snapshots:
 
   hast-util-parse-selector@4.0.0:
     dependencies:
-      '@types/hast': 3.0.4
+      '@types/hast': 3.0.5
 
   hast-util-phrasing@3.0.1:
     dependencies:
@@ -10049,7 +10053,7 @@ snapshots:
 
   hast-util-to-html@9.0.5:
     dependencies:
-      '@types/hast': 3.0.4
+      '@types/hast': 3.0.5
       '@types/unist': 3.0.3
       ccount: 2.0.1
       comma-separated-tokens: 2.0.3
@@ -10091,7 +10095,7 @@ snapshots:
 
   hastscript@9.0.1:
     dependencies:
-      '@types/hast': 3.0.4
+      '@types/hast': 3.0.5
       comma-separated-tokens: 2.0.3
       hast-util-parse-selector: 4.0.0
       property-information: 7.1.0
@@ -11375,7 +11379,7 @@ snapshots:
 
   rehype-parse@9.0.1:
     dependencies:
-      '@types/hast': 3.0.4
+      '@types/hast': 3.0.5
       hast-util-from-html: 2.0.3
       unified: 11.0.5
 
@@ -11386,7 +11390,7 @@ snapshots:
 
   rehype-stringify@10.0.1:
     dependencies:
-      '@types/hast': 3.0.4
+      '@types/hast': 3.0.5
       hast-util-to-html: 9.0.5
       unified: 11.0.5
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1380,6 +1380,15 @@ importers:
       '@equaltoai/greater-components-utils':
         specifier: workspace:*
         version: link:../../utils
+      rehype-parse:
+        specifier: ^9.0.1
+        version: 9.0.1
+      rehype-stringify:
+        specifier: ^10.0.1
+        version: 10.0.1
+      unified:
+        specifier: ^11.0.5
+        version: 11.0.5
     devDependencies:
       '@sveltejs/vite-plugin-svelte':
         specifier: ^7.0.0
@@ -1387,6 +1396,9 @@ importers:
       '@testing-library/svelte':
         specifier: ^5.3.1
         version: 5.3.1(svelte@5.55.7(@typescript-eslint/types@8.58.0))(vite@8.0.16(@types/node@25.6.0)(esbuild@0.25.12)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))(vitest@4.1.4)
+      '@types/hast':
+        specifier: ^3.0.4
+        version: 3.0.4
       '@types/node':
         specifier: ^25.6.0
         version: 25.6.0

--- a/registry/index.json
+++ b/registry/index.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://equalto.ai/schemas/registry-index.schema.json",
   "schemaVersion": "1.0.0",
-  "generatedAt": "2026-08-02T04:52:56.504Z",
+  "generatedAt": "2026-08-02T04:54:00.404Z",
   "ref": "greater-v0.11.9",
   "version": "0.11.9",
   "checksums": {
@@ -1423,7 +1423,7 @@
     "packages/shared/messaging/src/Composer.svelte": "sha256-mDu8POEo19GzW1+bDIWvQauxpZ7H1gTw5r4Z7UXMUnU=",
     "packages/shared/messaging/src/context.svelte.ts": "sha256-NihRfF2shXYMQTnQbjfYGKmyhNT+881dUYxrBEGFrKk=",
     "packages/shared/messaging/src/ConversationPicker.svelte": "sha256-GyuC58bLhCyxEV1cl8m1bykp3fKVsOKjPZ+/GeihVq8=",
-    "packages/shared/messaging/src/Conversations.svelte": "sha256-wf5E6+34vkqfW/LqpVjuc7ns9zqitKM73t6lnHip3Cc=",
+    "packages/shared/messaging/src/Conversations.svelte": "sha256-ccFlL2WIH+/d9j0Lv8/ZOOF7kGsorphPAOtD+dm+bgs=",
     "packages/shared/messaging/src/ConversationWorkflowSummary.svelte": "sha256-+mO7cS42J9G7FplGDcvuUealcYVAqx47qH4WqUkaxPU=",
     "packages/shared/messaging/src/index.ts": "sha256-51SFnggIOSpqEXRczLt8ySe8GJM2LmokXYfhkNtVcp4=",
     "packages/shared/messaging/src/MediaUpload.svelte": "sha256-5ORpNjGoJKb1SXWhVzFZ80Frxi0e6VYP1oM1ow2Oejo=",
@@ -9653,8 +9653,8 @@
         },
         {
           "path": "src/Conversations.svelte",
-          "checksum": "sha256-wf5E6+34vkqfW/LqpVjuc7ns9zqitKM73t6lnHip3Cc=",
-          "size": 4891
+          "checksum": "sha256-ccFlL2WIH+/d9j0Lv8/ZOOF7kGsorphPAOtD+dm+bgs=",
+          "size": 6755
         },
         {
           "path": "src/ConversationWorkflowSummary.svelte",

--- a/registry/index.json
+++ b/registry/index.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://equalto.ai/schemas/registry-index.schema.json",
   "schemaVersion": "1.0.0",
-  "generatedAt": "2026-08-02T10:05:33.738Z",
+  "generatedAt": "2026-08-02T10:31:18.290Z",
   "ref": "greater-v0.11.9",
   "version": "0.11.9",
   "checksums": {
@@ -1430,7 +1430,7 @@
     "packages/shared/messaging/src/Message.svelte": "sha256-/i/rdtKRja1KMVaTH2P/Zog1062AiKfNmfY1lBUxhgY=",
     "packages/shared/messaging/src/NewConversation.svelte": "sha256-23nXlWNf5SY+FF7NBPVU5WVMWj+ywpAq3MUbyauX8rE=",
     "packages/shared/messaging/src/Root.svelte": "sha256-ayF6lgF3ZxI5MuuIcj1zCntD+iSfaS7lCkRRQx54NZY=",
-    "packages/shared/messaging/src/sanitize.ts": "sha256-Q6eL8tQbdvtBP2umVbistd5eDCJDaavGOncBFsqsdcc=",
+    "packages/shared/messaging/src/sanitize.ts": "sha256-8SnIGpQ40MZAvfUxXl9FbqsKz5bo2UJCHP+pvF4E/EE=",
     "packages/shared/messaging/src/Thread.svelte": "sha256-wF052p+7XJQJ2ccM+j9Za+DROrObEKmYCS+MXfBmTGU=",
     "packages/shared/messaging/src/types.ts": "sha256-hHc+ulSYjI46KKV/O+h845OcqMhB6feSn6oR7CV76JY=",
     "packages/shared/messaging/src/UnreadIndicator.svelte": "sha256-IG65mT6Y0jrY2AKbFCIlFaRKKHj9XpUpViWd+lcCoT0=",
@@ -9689,8 +9689,8 @@
         },
         {
           "path": "src/sanitize.ts",
-          "checksum": "sha256-Q6eL8tQbdvtBP2umVbistd5eDCJDaavGOncBFsqsdcc=",
-          "size": 6496
+          "checksum": "sha256-8SnIGpQ40MZAvfUxXl9FbqsKz5bo2UJCHP+pvF4E/EE=",
+          "size": 6550
         },
         {
           "path": "src/Thread.svelte",

--- a/registry/index.json
+++ b/registry/index.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://equalto.ai/schemas/registry-index.schema.json",
   "schemaVersion": "1.0.0",
-  "generatedAt": "2026-08-02T09:04:59.439Z",
+  "generatedAt": "2026-08-02T10:05:33.738Z",
   "ref": "greater-v0.11.9",
   "version": "0.11.9",
   "checksums": {
@@ -1430,7 +1430,7 @@
     "packages/shared/messaging/src/Message.svelte": "sha256-/i/rdtKRja1KMVaTH2P/Zog1062AiKfNmfY1lBUxhgY=",
     "packages/shared/messaging/src/NewConversation.svelte": "sha256-23nXlWNf5SY+FF7NBPVU5WVMWj+ywpAq3MUbyauX8rE=",
     "packages/shared/messaging/src/Root.svelte": "sha256-ayF6lgF3ZxI5MuuIcj1zCntD+iSfaS7lCkRRQx54NZY=",
-    "packages/shared/messaging/src/sanitize.ts": "sha256-KH0H0Hjvfza+cdoJ1U4YKb/hv+xAChOU1IWNtIgPTH8=",
+    "packages/shared/messaging/src/sanitize.ts": "sha256-Q6eL8tQbdvtBP2umVbistd5eDCJDaavGOncBFsqsdcc=",
     "packages/shared/messaging/src/Thread.svelte": "sha256-wF052p+7XJQJ2ccM+j9Za+DROrObEKmYCS+MXfBmTGU=",
     "packages/shared/messaging/src/types.ts": "sha256-hHc+ulSYjI46KKV/O+h845OcqMhB6feSn6oR7CV76JY=",
     "packages/shared/messaging/src/UnreadIndicator.svelte": "sha256-IG65mT6Y0jrY2AKbFCIlFaRKKHj9XpUpViWd+lcCoT0=",
@@ -9689,8 +9689,8 @@
         },
         {
           "path": "src/sanitize.ts",
-          "checksum": "sha256-KH0H0Hjvfza+cdoJ1U4YKb/hv+xAChOU1IWNtIgPTH8=",
-          "size": 6200
+          "checksum": "sha256-Q6eL8tQbdvtBP2umVbistd5eDCJDaavGOncBFsqsdcc=",
+          "size": 6496
         },
         {
           "path": "src/Thread.svelte",

--- a/registry/index.json
+++ b/registry/index.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://equalto.ai/schemas/registry-index.schema.json",
   "schemaVersion": "1.0.0",
-  "generatedAt": "2026-08-02T06:23:37.652Z",
+  "generatedAt": "2026-08-02T06:40:56.707Z",
   "ref": "greater-v0.11.9",
   "version": "0.11.9",
   "checksums": {
@@ -1430,7 +1430,7 @@
     "packages/shared/messaging/src/Message.svelte": "sha256-/i/rdtKRja1KMVaTH2P/Zog1062AiKfNmfY1lBUxhgY=",
     "packages/shared/messaging/src/NewConversation.svelte": "sha256-23nXlWNf5SY+FF7NBPVU5WVMWj+ywpAq3MUbyauX8rE=",
     "packages/shared/messaging/src/Root.svelte": "sha256-ayF6lgF3ZxI5MuuIcj1zCntD+iSfaS7lCkRRQx54NZY=",
-    "packages/shared/messaging/src/sanitize.ts": "sha256-lM02t/qJEYmIAPW43zmZC1WFJ8EWmqKc7RWTM9HSXe0=",
+    "packages/shared/messaging/src/sanitize.ts": "sha256-ehRPgnzmWxxptwPi9JteLdun/7y1MuTKhTVMiIO3ew4=",
     "packages/shared/messaging/src/Thread.svelte": "sha256-wF052p+7XJQJ2ccM+j9Za+DROrObEKmYCS+MXfBmTGU=",
     "packages/shared/messaging/src/types.ts": "sha256-hHc+ulSYjI46KKV/O+h845OcqMhB6feSn6oR7CV76JY=",
     "packages/shared/messaging/src/UnreadIndicator.svelte": "sha256-bBLfNcUURY3ieOoEs7TXQeo9Lt3Bp0o4TNq5X2g6aE0=",
@@ -9689,8 +9689,8 @@
         },
         {
           "path": "src/sanitize.ts",
-          "checksum": "sha256-lM02t/qJEYmIAPW43zmZC1WFJ8EWmqKc7RWTM9HSXe0=",
-          "size": 5145
+          "checksum": "sha256-ehRPgnzmWxxptwPi9JteLdun/7y1MuTKhTVMiIO3ew4=",
+          "size": 5768
         },
         {
           "path": "src/Thread.svelte",

--- a/registry/index.json
+++ b/registry/index.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://equalto.ai/schemas/registry-index.schema.json",
   "schemaVersion": "1.0.0",
-  "generatedAt": "2026-08-02T04:54:00.404Z",
+  "generatedAt": "2026-08-02T04:54:05.864Z",
   "ref": "greater-v0.11.9",
   "version": "0.11.9",
   "checksums": {
@@ -1432,7 +1432,7 @@
     "packages/shared/messaging/src/Root.svelte": "sha256-ayF6lgF3ZxI5MuuIcj1zCntD+iSfaS7lCkRRQx54NZY=",
     "packages/shared/messaging/src/Thread.svelte": "sha256-wF052p+7XJQJ2ccM+j9Za+DROrObEKmYCS+MXfBmTGU=",
     "packages/shared/messaging/src/types.ts": "sha256-hHc+ulSYjI46KKV/O+h845OcqMhB6feSn6oR7CV76JY=",
-    "packages/shared/messaging/src/UnreadIndicator.svelte": "sha256-oo+td3vo+3SQR4zYbS0PNjHDoQ8j4qEoqyMrYrK7Z5s=",
+    "packages/shared/messaging/src/UnreadIndicator.svelte": "sha256-VMY0MfrCwEPWs3K2lKKNRP7ALWu7rY9GrM0B3ktBuVw=",
     "packages/shared/messaging/src/utils.ts": "sha256-n5s8ZSURaYg3TP01VFafGTH43dn04IiTwLtAKMU1Hyk=",
     "packages/shared/messaging/src/WorkflowThreadMoment.svelte": "sha256-FN/gYB5HCi3ltwxI0L3qjqep+jXwQE1zJSEAKtXnzlU=",
     "packages/shared/soul/src/AnchorAssuranceBadge.svelte": "sha256-IUAvzymXQ8r/oY6B5JmwdkHQ+mhW5aZzmMQC74KwkiE=",
@@ -9698,8 +9698,8 @@
         },
         {
           "path": "src/UnreadIndicator.svelte",
-          "checksum": "sha256-oo+td3vo+3SQR4zYbS0PNjHDoQ8j4qEoqyMrYrK7Z5s=",
-          "size": 1271
+          "checksum": "sha256-VMY0MfrCwEPWs3K2lKKNRP7ALWu7rY9GrM0B3ktBuVw=",
+          "size": 1459
         },
         {
           "path": "src/utils.ts",

--- a/registry/index.json
+++ b/registry/index.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://equalto.ai/schemas/registry-index.schema.json",
   "schemaVersion": "1.0.0",
-  "generatedAt": "2026-08-02T04:54:05.864Z",
+  "generatedAt": "2026-08-02T05:42:46.935Z",
   "ref": "greater-v0.11.9",
   "version": "0.11.9",
   "checksums": {
@@ -855,7 +855,7 @@
     "packages/adapters/src/mappers/mastodon/mappers.ts": "sha256-azySwXrEAWqu3nuiQkR3IFQ84Z9Pr0boYFgzpqXYJtE=",
     "packages/adapters/src/mappers/mastodon/types.d.ts": "sha256-LLN8HNltLV9QnLl0tY3zOF4ovD0+sYN0UvGJIx7MH70=",
     "packages/adapters/src/mappers/mastodon/types.ts": "sha256-54WrBVIzEH/QIxzBUL6OOjfsanvpM8WNkpJjKSVFSlA=",
-    "packages/adapters/src/messaging/createLesserMessagesHandlers.ts": "sha256-qu9tdupn585B8Ynn8CbDcESBWZdUKT21+QAMHrLCAHA=",
+    "packages/adapters/src/messaging/createLesserMessagesHandlers.ts": "sha256-sJRvV5v+hIQ9lkrtz6t/Olcf7iTYIQ1HFymWKZtQZFg=",
     "packages/adapters/src/messaging/index.ts": "sha256-hIJPyGpRY8EhsYDn/PnzPbahiYpTH9sgPKS5VV9H0cc=",
     "packages/adapters/src/messaging/messagingOperations.ts": "sha256-KlymQ8y2PhLoIRqvOZldwtuK+A7bJ/BSXv0WCeQrEK8=",
     "packages/adapters/src/models/unified.d.ts": "sha256-8Z2SFddm7Cszpe6EoB85lJVH0xW16xjo68PhJGuvmeQ=",
@@ -1423,16 +1423,17 @@
     "packages/shared/messaging/src/Composer.svelte": "sha256-mDu8POEo19GzW1+bDIWvQauxpZ7H1gTw5r4Z7UXMUnU=",
     "packages/shared/messaging/src/context.svelte.ts": "sha256-NihRfF2shXYMQTnQbjfYGKmyhNT+881dUYxrBEGFrKk=",
     "packages/shared/messaging/src/ConversationPicker.svelte": "sha256-GyuC58bLhCyxEV1cl8m1bykp3fKVsOKjPZ+/GeihVq8=",
-    "packages/shared/messaging/src/Conversations.svelte": "sha256-ccFlL2WIH+/d9j0Lv8/ZOOF7kGsorphPAOtD+dm+bgs=",
+    "packages/shared/messaging/src/Conversations.svelte": "sha256-5lHl48Vydkatf8xkf0YTH9AvgVJu7bitqqc4P749UOU=",
     "packages/shared/messaging/src/ConversationWorkflowSummary.svelte": "sha256-+mO7cS42J9G7FplGDcvuUealcYVAqx47qH4WqUkaxPU=",
     "packages/shared/messaging/src/index.ts": "sha256-51SFnggIOSpqEXRczLt8ySe8GJM2LmokXYfhkNtVcp4=",
     "packages/shared/messaging/src/MediaUpload.svelte": "sha256-5ORpNjGoJKb1SXWhVzFZ80Frxi0e6VYP1oM1ow2Oejo=",
-    "packages/shared/messaging/src/Message.svelte": "sha256-xg3hDI8DfZFcUh02kiCNF+9R3KMlDzZgyNqWym2QQjI=",
+    "packages/shared/messaging/src/Message.svelte": "sha256-/i/rdtKRja1KMVaTH2P/Zog1062AiKfNmfY1lBUxhgY=",
     "packages/shared/messaging/src/NewConversation.svelte": "sha256-23nXlWNf5SY+FF7NBPVU5WVMWj+ywpAq3MUbyauX8rE=",
     "packages/shared/messaging/src/Root.svelte": "sha256-ayF6lgF3ZxI5MuuIcj1zCntD+iSfaS7lCkRRQx54NZY=",
+    "packages/shared/messaging/src/sanitize.ts": "sha256-h4idjv5pB8/cZUDzrXGXgBZEpEcXQb0xCutTy+8X9Lo=",
     "packages/shared/messaging/src/Thread.svelte": "sha256-wF052p+7XJQJ2ccM+j9Za+DROrObEKmYCS+MXfBmTGU=",
     "packages/shared/messaging/src/types.ts": "sha256-hHc+ulSYjI46KKV/O+h845OcqMhB6feSn6oR7CV76JY=",
-    "packages/shared/messaging/src/UnreadIndicator.svelte": "sha256-VMY0MfrCwEPWs3K2lKKNRP7ALWu7rY9GrM0B3ktBuVw=",
+    "packages/shared/messaging/src/UnreadIndicator.svelte": "sha256-gDgjK759Jf0kmrRyBXfXUxxdSgfRdDUSzmAe+Zu4ROc=",
     "packages/shared/messaging/src/utils.ts": "sha256-n5s8ZSURaYg3TP01VFafGTH43dn04IiTwLtAKMU1Hyk=",
     "packages/shared/messaging/src/WorkflowThreadMoment.svelte": "sha256-FN/gYB5HCi3ltwxI0L3qjqep+jXwQE1zJSEAKtXnzlU=",
     "packages/shared/soul/src/AnchorAssuranceBadge.svelte": "sha256-IUAvzymXQ8r/oY6B5JmwdkHQ+mhW5aZzmMQC74KwkiE=",
@@ -5795,8 +5796,8 @@
         },
         {
           "path": "src/messaging/createLesserMessagesHandlers.ts",
-          "checksum": "sha256-qu9tdupn585B8Ynn8CbDcESBWZdUKT21+QAMHrLCAHA=",
-          "size": 10668
+          "checksum": "sha256-sJRvV5v+hIQ9lkrtz6t/Olcf7iTYIQ1HFymWKZtQZFg=",
+          "size": 10696
         },
         {
           "path": "src/messaging/index.ts",
@@ -9653,8 +9654,8 @@
         },
         {
           "path": "src/Conversations.svelte",
-          "checksum": "sha256-ccFlL2WIH+/d9j0Lv8/ZOOF7kGsorphPAOtD+dm+bgs=",
-          "size": 6755
+          "checksum": "sha256-5lHl48Vydkatf8xkf0YTH9AvgVJu7bitqqc4P749UOU=",
+          "size": 7512
         },
         {
           "path": "src/ConversationWorkflowSummary.svelte",
@@ -9673,8 +9674,8 @@
         },
         {
           "path": "src/Message.svelte",
-          "checksum": "sha256-xg3hDI8DfZFcUh02kiCNF+9R3KMlDzZgyNqWym2QQjI=",
-          "size": 4069
+          "checksum": "sha256-/i/rdtKRja1KMVaTH2P/Zog1062AiKfNmfY1lBUxhgY=",
+          "size": 4054
         },
         {
           "path": "src/NewConversation.svelte",
@@ -9685,6 +9686,11 @@
           "path": "src/Root.svelte",
           "checksum": "sha256-ayF6lgF3ZxI5MuuIcj1zCntD+iSfaS7lCkRRQx54NZY=",
           "size": 1299
+        },
+        {
+          "path": "src/sanitize.ts",
+          "checksum": "sha256-h4idjv5pB8/cZUDzrXGXgBZEpEcXQb0xCutTy+8X9Lo=",
+          "size": 5098
         },
         {
           "path": "src/Thread.svelte",
@@ -9698,8 +9704,8 @@
         },
         {
           "path": "src/UnreadIndicator.svelte",
-          "checksum": "sha256-VMY0MfrCwEPWs3K2lKKNRP7ALWu7rY9GrM0B3ktBuVw=",
-          "size": 1459
+          "checksum": "sha256-gDgjK759Jf0kmrRyBXfXUxxdSgfRdDUSzmAe+Zu4ROc=",
+          "size": 1517
         },
         {
           "path": "src/utils.ts",

--- a/registry/index.json
+++ b/registry/index.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://equalto.ai/schemas/registry-index.schema.json",
   "schemaVersion": "1.0.0",
-  "generatedAt": "2026-08-02T05:42:46.935Z",
+  "generatedAt": "2026-08-02T06:23:37.652Z",
   "ref": "greater-v0.11.9",
   "version": "0.11.9",
   "checksums": {
@@ -1423,17 +1423,17 @@
     "packages/shared/messaging/src/Composer.svelte": "sha256-mDu8POEo19GzW1+bDIWvQauxpZ7H1gTw5r4Z7UXMUnU=",
     "packages/shared/messaging/src/context.svelte.ts": "sha256-NihRfF2shXYMQTnQbjfYGKmyhNT+881dUYxrBEGFrKk=",
     "packages/shared/messaging/src/ConversationPicker.svelte": "sha256-GyuC58bLhCyxEV1cl8m1bykp3fKVsOKjPZ+/GeihVq8=",
-    "packages/shared/messaging/src/Conversations.svelte": "sha256-5lHl48Vydkatf8xkf0YTH9AvgVJu7bitqqc4P749UOU=",
+    "packages/shared/messaging/src/Conversations.svelte": "sha256-WIOjfV5CmsCkhFyp9i0IOUMDz8ceMWrUc1Rr2box0hc=",
     "packages/shared/messaging/src/ConversationWorkflowSummary.svelte": "sha256-+mO7cS42J9G7FplGDcvuUealcYVAqx47qH4WqUkaxPU=",
     "packages/shared/messaging/src/index.ts": "sha256-51SFnggIOSpqEXRczLt8ySe8GJM2LmokXYfhkNtVcp4=",
     "packages/shared/messaging/src/MediaUpload.svelte": "sha256-5ORpNjGoJKb1SXWhVzFZ80Frxi0e6VYP1oM1ow2Oejo=",
     "packages/shared/messaging/src/Message.svelte": "sha256-/i/rdtKRja1KMVaTH2P/Zog1062AiKfNmfY1lBUxhgY=",
     "packages/shared/messaging/src/NewConversation.svelte": "sha256-23nXlWNf5SY+FF7NBPVU5WVMWj+ywpAq3MUbyauX8rE=",
     "packages/shared/messaging/src/Root.svelte": "sha256-ayF6lgF3ZxI5MuuIcj1zCntD+iSfaS7lCkRRQx54NZY=",
-    "packages/shared/messaging/src/sanitize.ts": "sha256-h4idjv5pB8/cZUDzrXGXgBZEpEcXQb0xCutTy+8X9Lo=",
+    "packages/shared/messaging/src/sanitize.ts": "sha256-lM02t/qJEYmIAPW43zmZC1WFJ8EWmqKc7RWTM9HSXe0=",
     "packages/shared/messaging/src/Thread.svelte": "sha256-wF052p+7XJQJ2ccM+j9Za+DROrObEKmYCS+MXfBmTGU=",
     "packages/shared/messaging/src/types.ts": "sha256-hHc+ulSYjI46KKV/O+h845OcqMhB6feSn6oR7CV76JY=",
-    "packages/shared/messaging/src/UnreadIndicator.svelte": "sha256-gDgjK759Jf0kmrRyBXfXUxxdSgfRdDUSzmAe+Zu4ROc=",
+    "packages/shared/messaging/src/UnreadIndicator.svelte": "sha256-bBLfNcUURY3ieOoEs7TXQeo9Lt3Bp0o4TNq5X2g6aE0=",
     "packages/shared/messaging/src/utils.ts": "sha256-n5s8ZSURaYg3TP01VFafGTH43dn04IiTwLtAKMU1Hyk=",
     "packages/shared/messaging/src/WorkflowThreadMoment.svelte": "sha256-FN/gYB5HCi3ltwxI0L3qjqep+jXwQE1zJSEAKtXnzlU=",
     "packages/shared/soul/src/AnchorAssuranceBadge.svelte": "sha256-IUAvzymXQ8r/oY6B5JmwdkHQ+mhW5aZzmMQC74KwkiE=",
@@ -9654,8 +9654,8 @@
         },
         {
           "path": "src/Conversations.svelte",
-          "checksum": "sha256-5lHl48Vydkatf8xkf0YTH9AvgVJu7bitqqc4P749UOU=",
-          "size": 7512
+          "checksum": "sha256-WIOjfV5CmsCkhFyp9i0IOUMDz8ceMWrUc1Rr2box0hc=",
+          "size": 7485
         },
         {
           "path": "src/ConversationWorkflowSummary.svelte",
@@ -9689,8 +9689,8 @@
         },
         {
           "path": "src/sanitize.ts",
-          "checksum": "sha256-h4idjv5pB8/cZUDzrXGXgBZEpEcXQb0xCutTy+8X9Lo=",
-          "size": 5098
+          "checksum": "sha256-lM02t/qJEYmIAPW43zmZC1WFJ8EWmqKc7RWTM9HSXe0=",
+          "size": 5145
         },
         {
           "path": "src/Thread.svelte",
@@ -9704,8 +9704,8 @@
         },
         {
           "path": "src/UnreadIndicator.svelte",
-          "checksum": "sha256-gDgjK759Jf0kmrRyBXfXUxxdSgfRdDUSzmAe+Zu4ROc=",
-          "size": 1517
+          "checksum": "sha256-bBLfNcUURY3ieOoEs7TXQeo9Lt3Bp0o4TNq5X2g6aE0=",
+          "size": 1954
         },
         {
           "path": "src/utils.ts",

--- a/registry/index.json
+++ b/registry/index.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://equalto.ai/schemas/registry-index.schema.json",
   "schemaVersion": "1.0.0",
-  "generatedAt": "2026-08-02T06:40:56.707Z",
+  "generatedAt": "2026-08-02T07:14:31.422Z",
   "ref": "greater-v0.11.9",
   "version": "0.11.9",
   "checksums": {
@@ -1430,10 +1430,10 @@
     "packages/shared/messaging/src/Message.svelte": "sha256-/i/rdtKRja1KMVaTH2P/Zog1062AiKfNmfY1lBUxhgY=",
     "packages/shared/messaging/src/NewConversation.svelte": "sha256-23nXlWNf5SY+FF7NBPVU5WVMWj+ywpAq3MUbyauX8rE=",
     "packages/shared/messaging/src/Root.svelte": "sha256-ayF6lgF3ZxI5MuuIcj1zCntD+iSfaS7lCkRRQx54NZY=",
-    "packages/shared/messaging/src/sanitize.ts": "sha256-ehRPgnzmWxxptwPi9JteLdun/7y1MuTKhTVMiIO3ew4=",
+    "packages/shared/messaging/src/sanitize.ts": "sha256-c4nfnfQ+ujmazkm5kZSNDkrdPTnkWgD0G7YOXQ0w0h4=",
     "packages/shared/messaging/src/Thread.svelte": "sha256-wF052p+7XJQJ2ccM+j9Za+DROrObEKmYCS+MXfBmTGU=",
     "packages/shared/messaging/src/types.ts": "sha256-hHc+ulSYjI46KKV/O+h845OcqMhB6feSn6oR7CV76JY=",
-    "packages/shared/messaging/src/UnreadIndicator.svelte": "sha256-bBLfNcUURY3ieOoEs7TXQeo9Lt3Bp0o4TNq5X2g6aE0=",
+    "packages/shared/messaging/src/UnreadIndicator.svelte": "sha256-IG65mT6Y0jrY2AKbFCIlFaRKKHj9XpUpViWd+lcCoT0=",
     "packages/shared/messaging/src/utils.ts": "sha256-n5s8ZSURaYg3TP01VFafGTH43dn04IiTwLtAKMU1Hyk=",
     "packages/shared/messaging/src/WorkflowThreadMoment.svelte": "sha256-FN/gYB5HCi3ltwxI0L3qjqep+jXwQE1zJSEAKtXnzlU=",
     "packages/shared/soul/src/AnchorAssuranceBadge.svelte": "sha256-IUAvzymXQ8r/oY6B5JmwdkHQ+mhW5aZzmMQC74KwkiE=",
@@ -9689,8 +9689,8 @@
         },
         {
           "path": "src/sanitize.ts",
-          "checksum": "sha256-ehRPgnzmWxxptwPi9JteLdun/7y1MuTKhTVMiIO3ew4=",
-          "size": 5768
+          "checksum": "sha256-c4nfnfQ+ujmazkm5kZSNDkrdPTnkWgD0G7YOXQ0w0h4=",
+          "size": 5915
         },
         {
           "path": "src/Thread.svelte",
@@ -9704,8 +9704,8 @@
         },
         {
           "path": "src/UnreadIndicator.svelte",
-          "checksum": "sha256-bBLfNcUURY3ieOoEs7TXQeo9Lt3Bp0o4TNq5X2g6aE0=",
-          "size": 1954
+          "checksum": "sha256-IG65mT6Y0jrY2AKbFCIlFaRKKHj9XpUpViWd+lcCoT0=",
+          "size": 2996
         },
         {
           "path": "src/utils.ts",

--- a/registry/index.json
+++ b/registry/index.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://equalto.ai/schemas/registry-index.schema.json",
   "schemaVersion": "1.0.0",
-  "generatedAt": "2026-08-02T08:28:35.945Z",
+  "generatedAt": "2026-08-02T09:04:59.439Z",
   "ref": "greater-v0.11.9",
   "version": "0.11.9",
   "checksums": {
@@ -1430,7 +1430,7 @@
     "packages/shared/messaging/src/Message.svelte": "sha256-/i/rdtKRja1KMVaTH2P/Zog1062AiKfNmfY1lBUxhgY=",
     "packages/shared/messaging/src/NewConversation.svelte": "sha256-23nXlWNf5SY+FF7NBPVU5WVMWj+ywpAq3MUbyauX8rE=",
     "packages/shared/messaging/src/Root.svelte": "sha256-ayF6lgF3ZxI5MuuIcj1zCntD+iSfaS7lCkRRQx54NZY=",
-    "packages/shared/messaging/src/sanitize.ts": "sha256-6I7Sry5OkSTVT+0BlCC1TzaWt1h/exzQ8VCn+/FPDzs=",
+    "packages/shared/messaging/src/sanitize.ts": "sha256-KH0H0Hjvfza+cdoJ1U4YKb/hv+xAChOU1IWNtIgPTH8=",
     "packages/shared/messaging/src/Thread.svelte": "sha256-wF052p+7XJQJ2ccM+j9Za+DROrObEKmYCS+MXfBmTGU=",
     "packages/shared/messaging/src/types.ts": "sha256-hHc+ulSYjI46KKV/O+h845OcqMhB6feSn6oR7CV76JY=",
     "packages/shared/messaging/src/UnreadIndicator.svelte": "sha256-IG65mT6Y0jrY2AKbFCIlFaRKKHj9XpUpViWd+lcCoT0=",
@@ -9689,8 +9689,8 @@
         },
         {
           "path": "src/sanitize.ts",
-          "checksum": "sha256-6I7Sry5OkSTVT+0BlCC1TzaWt1h/exzQ8VCn+/FPDzs=",
-          "size": 5863
+          "checksum": "sha256-KH0H0Hjvfza+cdoJ1U4YKb/hv+xAChOU1IWNtIgPTH8=",
+          "size": 6200
         },
         {
           "path": "src/Thread.svelte",
@@ -9731,7 +9731,6 @@
         { "name": "@equaltoai/greater-components-icons", "version": "0.11.9" },
         { "name": "@equaltoai/greater-components-primitives", "version": "0.11.9" },
         { "name": "@equaltoai/greater-components-utils", "version": "0.11.9" },
-        { "name": "hast", "version": "latest" },
         { "name": "rehype-parse", "version": "^9.0.1" },
         { "name": "rehype-stringify", "version": "^10.0.1" },
         { "name": "svelte", "version": "^5.55.1" },

--- a/registry/index.json
+++ b/registry/index.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://equalto.ai/schemas/registry-index.schema.json",
   "schemaVersion": "1.0.0",
-  "generatedAt": "2026-08-02T07:47:05.179Z",
+  "generatedAt": "2026-08-02T08:28:35.945Z",
   "ref": "greater-v0.11.9",
   "version": "0.11.9",
   "checksums": {
@@ -1430,7 +1430,7 @@
     "packages/shared/messaging/src/Message.svelte": "sha256-/i/rdtKRja1KMVaTH2P/Zog1062AiKfNmfY1lBUxhgY=",
     "packages/shared/messaging/src/NewConversation.svelte": "sha256-23nXlWNf5SY+FF7NBPVU5WVMWj+ywpAq3MUbyauX8rE=",
     "packages/shared/messaging/src/Root.svelte": "sha256-ayF6lgF3ZxI5MuuIcj1zCntD+iSfaS7lCkRRQx54NZY=",
-    "packages/shared/messaging/src/sanitize.ts": "sha256-t3ppgzdyiKmTNi6HCgHB25j1qCpxxudKO6etrNcrfew=",
+    "packages/shared/messaging/src/sanitize.ts": "sha256-6I7Sry5OkSTVT+0BlCC1TzaWt1h/exzQ8VCn+/FPDzs=",
     "packages/shared/messaging/src/Thread.svelte": "sha256-wF052p+7XJQJ2ccM+j9Za+DROrObEKmYCS+MXfBmTGU=",
     "packages/shared/messaging/src/types.ts": "sha256-hHc+ulSYjI46KKV/O+h845OcqMhB6feSn6oR7CV76JY=",
     "packages/shared/messaging/src/UnreadIndicator.svelte": "sha256-IG65mT6Y0jrY2AKbFCIlFaRKKHj9XpUpViWd+lcCoT0=",
@@ -9689,8 +9689,8 @@
         },
         {
           "path": "src/sanitize.ts",
-          "checksum": "sha256-t3ppgzdyiKmTNi6HCgHB25j1qCpxxudKO6etrNcrfew=",
-          "size": 5767
+          "checksum": "sha256-6I7Sry5OkSTVT+0BlCC1TzaWt1h/exzQ8VCn+/FPDzs=",
+          "size": 5863
         },
         {
           "path": "src/Thread.svelte",
@@ -9731,7 +9731,11 @@
         { "name": "@equaltoai/greater-components-icons", "version": "0.11.9" },
         { "name": "@equaltoai/greater-components-primitives", "version": "0.11.9" },
         { "name": "@equaltoai/greater-components-utils", "version": "0.11.9" },
-        { "name": "svelte", "version": "^5.55.1" }
+        { "name": "hast", "version": "latest" },
+        { "name": "rehype-parse", "version": "^9.0.1" },
+        { "name": "rehype-stringify", "version": "^10.0.1" },
+        { "name": "svelte", "version": "^5.55.1" },
+        { "name": "unified", "version": "^11.0.5" }
       ],
       "types": [
         "MessageParticipant",

--- a/registry/index.json
+++ b/registry/index.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://equalto.ai/schemas/registry-index.schema.json",
   "schemaVersion": "1.0.0",
-  "generatedAt": "2026-08-02T07:14:31.422Z",
+  "generatedAt": "2026-08-02T07:47:05.179Z",
   "ref": "greater-v0.11.9",
   "version": "0.11.9",
   "checksums": {
@@ -1430,7 +1430,7 @@
     "packages/shared/messaging/src/Message.svelte": "sha256-/i/rdtKRja1KMVaTH2P/Zog1062AiKfNmfY1lBUxhgY=",
     "packages/shared/messaging/src/NewConversation.svelte": "sha256-23nXlWNf5SY+FF7NBPVU5WVMWj+ywpAq3MUbyauX8rE=",
     "packages/shared/messaging/src/Root.svelte": "sha256-ayF6lgF3ZxI5MuuIcj1zCntD+iSfaS7lCkRRQx54NZY=",
-    "packages/shared/messaging/src/sanitize.ts": "sha256-c4nfnfQ+ujmazkm5kZSNDkrdPTnkWgD0G7YOXQ0w0h4=",
+    "packages/shared/messaging/src/sanitize.ts": "sha256-t3ppgzdyiKmTNi6HCgHB25j1qCpxxudKO6etrNcrfew=",
     "packages/shared/messaging/src/Thread.svelte": "sha256-wF052p+7XJQJ2ccM+j9Za+DROrObEKmYCS+MXfBmTGU=",
     "packages/shared/messaging/src/types.ts": "sha256-hHc+ulSYjI46KKV/O+h845OcqMhB6feSn6oR7CV76JY=",
     "packages/shared/messaging/src/UnreadIndicator.svelte": "sha256-IG65mT6Y0jrY2AKbFCIlFaRKKHj9XpUpViWd+lcCoT0=",
@@ -9689,8 +9689,8 @@
         },
         {
           "path": "src/sanitize.ts",
-          "checksum": "sha256-c4nfnfQ+ujmazkm5kZSNDkrdPTnkWgD0G7YOXQ0w0h4=",
-          "size": 5915
+          "checksum": "sha256-t3ppgzdyiKmTNi6HCgHB25j1qCpxxudKO6etrNcrfew=",
+          "size": 5767
         },
         {
           "path": "src/Thread.svelte",

--- a/registry/index.json
+++ b/registry/index.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://equalto.ai/schemas/registry-index.schema.json",
   "schemaVersion": "1.0.0",
-  "generatedAt": "2026-08-02T00:07:57.709Z",
+  "generatedAt": "2026-08-02T04:32:46.693Z",
   "ref": "greater-v0.11.9",
   "version": "0.11.9",
   "checksums": {
@@ -1422,11 +1422,11 @@
     "packages/shared/messaging/src/Composer.svelte": "sha256-mDu8POEo19GzW1+bDIWvQauxpZ7H1gTw5r4Z7UXMUnU=",
     "packages/shared/messaging/src/context.svelte.ts": "sha256-NihRfF2shXYMQTnQbjfYGKmyhNT+881dUYxrBEGFrKk=",
     "packages/shared/messaging/src/ConversationPicker.svelte": "sha256-GyuC58bLhCyxEV1cl8m1bykp3fKVsOKjPZ+/GeihVq8=",
-    "packages/shared/messaging/src/Conversations.svelte": "sha256-kEPIvS+0HxWGaoiU/UVG2sbMyoVQGTGWzllB3Q71lD0=",
+    "packages/shared/messaging/src/Conversations.svelte": "sha256-wf5E6+34vkqfW/LqpVjuc7ns9zqitKM73t6lnHip3Cc=",
     "packages/shared/messaging/src/ConversationWorkflowSummary.svelte": "sha256-+mO7cS42J9G7FplGDcvuUealcYVAqx47qH4WqUkaxPU=",
     "packages/shared/messaging/src/index.ts": "sha256-51SFnggIOSpqEXRczLt8ySe8GJM2LmokXYfhkNtVcp4=",
     "packages/shared/messaging/src/MediaUpload.svelte": "sha256-5ORpNjGoJKb1SXWhVzFZ80Frxi0e6VYP1oM1ow2Oejo=",
-    "packages/shared/messaging/src/Message.svelte": "sha256-55HxJkzJIGsjHI36WPnrSgJC/ZNUFdvzFjUwpgcIFTY=",
+    "packages/shared/messaging/src/Message.svelte": "sha256-xg3hDI8DfZFcUh02kiCNF+9R3KMlDzZgyNqWym2QQjI=",
     "packages/shared/messaging/src/NewConversation.svelte": "sha256-23nXlWNf5SY+FF7NBPVU5WVMWj+ywpAq3MUbyauX8rE=",
     "packages/shared/messaging/src/Root.svelte": "sha256-ayF6lgF3ZxI5MuuIcj1zCntD+iSfaS7lCkRRQx54NZY=",
     "packages/shared/messaging/src/Thread.svelte": "sha256-wF052p+7XJQJ2ccM+j9Za+DROrObEKmYCS+MXfBmTGU=",
@@ -9647,8 +9647,8 @@
         },
         {
           "path": "src/Conversations.svelte",
-          "checksum": "sha256-kEPIvS+0HxWGaoiU/UVG2sbMyoVQGTGWzllB3Q71lD0=",
-          "size": 4791
+          "checksum": "sha256-wf5E6+34vkqfW/LqpVjuc7ns9zqitKM73t6lnHip3Cc=",
+          "size": 4891
         },
         {
           "path": "src/ConversationWorkflowSummary.svelte",
@@ -9667,8 +9667,8 @@
         },
         {
           "path": "src/Message.svelte",
-          "checksum": "sha256-55HxJkzJIGsjHI36WPnrSgJC/ZNUFdvzFjUwpgcIFTY=",
-          "size": 3835
+          "checksum": "sha256-xg3hDI8DfZFcUh02kiCNF+9R3KMlDzZgyNqWym2QQjI=",
+          "size": 4069
         },
         {
           "path": "src/NewConversation.svelte",
@@ -9710,13 +9710,15 @@
         { "name": "compose", "version": "0.11.9" },
         { "name": "headless", "version": "0.11.9" },
         { "name": "icons", "version": "0.11.9" },
-        { "name": "primitives", "version": "0.11.9" }
+        { "name": "primitives", "version": "0.11.9" },
+        { "name": "utils", "version": "0.11.9" }
       ],
       "peerDependencies": [
         { "name": "@equaltoai/greater-components-compose", "version": "0.11.9" },
         { "name": "@equaltoai/greater-components-headless", "version": "0.11.9" },
         { "name": "@equaltoai/greater-components-icons", "version": "0.11.9" },
         { "name": "@equaltoai/greater-components-primitives", "version": "0.11.9" },
+        { "name": "@equaltoai/greater-components-utils", "version": "0.11.9" },
         { "name": "svelte", "version": "^5.55.1" }
       ],
       "types": [

--- a/registry/index.json
+++ b/registry/index.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://equalto.ai/schemas/registry-index.schema.json",
   "schemaVersion": "1.0.0",
-  "generatedAt": "2026-08-02T04:32:46.693Z",
+  "generatedAt": "2026-08-02T04:52:56.504Z",
   "ref": "greater-v0.11.9",
   "version": "0.11.9",
   "checksums": {
@@ -832,13 +832,13 @@
     "packages/adapters/src/graphql/index.d.ts": "sha256-orLx9yyDGxzzxd5wHeLg/XKql86ntzhZSG6iUj6Tjx8=",
     "packages/adapters/src/graphql/index.ts": "sha256-330bRj505ZOWM5XTbOpFZW1n8sy2/SCbzCu9XXYvrOA=",
     "packages/adapters/src/graphql/LesserGraphQLAdapter.d.ts": "sha256-tS4MSxFQSiPlKqIotIdGyDRMyfu7BjJ3dpPBXfjVqtU=",
-    "packages/adapters/src/graphql/LesserGraphQLAdapter.ts": "sha256-8EbsCoSKJzc1CpJa+oR4DuWQxjHtICJl+YUxlrjXJls=",
+    "packages/adapters/src/graphql/LesserGraphQLAdapter.ts": "sha256-TS7qFQl5mbyf1o13DtsHn/uNX38rgyquMfwFzwOkeNk=",
     "packages/adapters/src/graphql/optimistic.d.ts": "sha256-DO9Yg7q9e9k3+suvhBSBWMn+8+pVGydTpC7e70EPO1w=",
     "packages/adapters/src/graphql/optimistic.ts": "sha256-4U/b1aHeGBfl+YC+R+XaeY0Ts8hY8Er+3XfqUhSpqWY=",
     "packages/adapters/src/HttpPollingClient.d.ts": "sha256-6UbsJSk+ur6Rth93w5bnSj3HOl2teXThMIBozc0TQqI=",
     "packages/adapters/src/HttpPollingClient.ts": "sha256-3VvR+Q3A9QuT9IKrT2s2OP48Ir5wDbDiL3NFp6fhO0w=",
     "packages/adapters/src/index.d.ts": "sha256-N9rD+C+FY2TCOW91GXIb5Cqm9lMS5na3I8MoSewctBE=",
-    "packages/adapters/src/index.ts": "sha256-KoxVjknH5lCuvaphIgDk4LfgActPn5ja3ZGVudLSklM=",
+    "packages/adapters/src/index.ts": "sha256-xkBiSjdXZzk/ba8Cfax6AAgkIJFKn9kaI51ABAvTzZE=",
     "packages/adapters/src/lesser/client.ts": "sha256-1zz1lpu6roGoTtOC/LIwXsT8oLHXkFV4TA8OblQ2Zhs=",
     "packages/adapters/src/lesser/index.ts": "sha256-/G5V2Tcie3s4/bPAszGUu+RGRRiz6nhnEXbge7XGxTw=",
     "packages/adapters/src/logger.d.ts": "sha256-EWrIRS5/xIIlNv5OLPY+Rf37HgYqrYhXxGlfPX8oNgc=",
@@ -855,8 +855,9 @@
     "packages/adapters/src/mappers/mastodon/mappers.ts": "sha256-azySwXrEAWqu3nuiQkR3IFQ84Z9Pr0boYFgzpqXYJtE=",
     "packages/adapters/src/mappers/mastodon/types.d.ts": "sha256-LLN8HNltLV9QnLl0tY3zOF4ovD0+sYN0UvGJIx7MH70=",
     "packages/adapters/src/mappers/mastodon/types.ts": "sha256-54WrBVIzEH/QIxzBUL6OOjfsanvpM8WNkpJjKSVFSlA=",
-    "packages/adapters/src/messaging/createLesserMessagesHandlers.ts": "sha256-QGXz+0mFl0V4NM3JeTFag+9jLk61CIBUlf8kR6mXPZk=",
-    "packages/adapters/src/messaging/index.ts": "sha256-2P3bCyR2sBhuV0GrrVnAaqGSq8dMVhA95dIJZ2s+eKw=",
+    "packages/adapters/src/messaging/createLesserMessagesHandlers.ts": "sha256-qu9tdupn585B8Ynn8CbDcESBWZdUKT21+QAMHrLCAHA=",
+    "packages/adapters/src/messaging/index.ts": "sha256-hIJPyGpRY8EhsYDn/PnzPbahiYpTH9sgPKS5VV9H0cc=",
+    "packages/adapters/src/messaging/messagingOperations.ts": "sha256-KlymQ8y2PhLoIRqvOZldwtuK+A7bJ/BSXv0WCeQrEK8=",
     "packages/adapters/src/models/unified.d.ts": "sha256-8Z2SFddm7Cszpe6EoB85lJVH0xW16xjo68PhJGuvmeQ=",
     "packages/adapters/src/models/unified.ts": "sha256-KRILzc/F51pCxnEX9cvc2IG7lns7IO48k/UK489J/Vs=",
     "packages/adapters/src/rest/generated/lesser-api.ts": "sha256-8YKhh1BeBVfU+NwuP1QvpQGcuTxXlvQkbTUkYj0I5xQ=",
@@ -5679,8 +5680,8 @@
         },
         {
           "path": "src/graphql/LesserGraphQLAdapter.ts",
-          "checksum": "sha256-8EbsCoSKJzc1CpJa+oR4DuWQxjHtICJl+YUxlrjXJls=",
-          "size": 65150
+          "checksum": "sha256-TS7qFQl5mbyf1o13DtsHn/uNX38rgyquMfwFzwOkeNk=",
+          "size": 65274
         },
         {
           "path": "src/graphql/optimistic.d.ts",
@@ -5709,8 +5710,8 @@
         },
         {
           "path": "src/index.ts",
-          "checksum": "sha256-KoxVjknH5lCuvaphIgDk4LfgActPn5ja3ZGVudLSklM=",
-          "size": 13689
+          "checksum": "sha256-xkBiSjdXZzk/ba8Cfax6AAgkIJFKn9kaI51ABAvTzZE=",
+          "size": 13712
         },
         {
           "path": "src/lesser/client.ts",
@@ -5794,13 +5795,18 @@
         },
         {
           "path": "src/messaging/createLesserMessagesHandlers.ts",
-          "checksum": "sha256-QGXz+0mFl0V4NM3JeTFag+9jLk61CIBUlf8kR6mXPZk=",
-          "size": 9856
+          "checksum": "sha256-qu9tdupn585B8Ynn8CbDcESBWZdUKT21+QAMHrLCAHA=",
+          "size": 10668
         },
         {
           "path": "src/messaging/index.ts",
-          "checksum": "sha256-2P3bCyR2sBhuV0GrrVnAaqGSq8dMVhA95dIJZ2s+eKw=",
-          "size": 169
+          "checksum": "sha256-hIJPyGpRY8EhsYDn/PnzPbahiYpTH9sgPKS5VV9H0cc=",
+          "size": 195
+        },
+        {
+          "path": "src/messaging/messagingOperations.ts",
+          "checksum": "sha256-KlymQ8y2PhLoIRqvOZldwtuK+A7bJ/BSXv0WCeQrEK8=",
+          "size": 8924
         },
         {
           "path": "src/models/unified.d.ts",


### PR DESCRIPTION
Closes #929. Closes #930. Closes #931. Closes #932.

Surfaced from contentus PR #57 (M5 Direct Messaging) consumption evidence.

## What
- **#929** — message bodies render through `sanitizeHtml` + `{@html}` (project convention); conversation-list previews use `sanitizeForPreview` (plain-text excerpt — compact selection button can't host block/interactive HTML). Readers see bold, not literal tags; scripts/event attributes neutralized.
- **#930** — exported structural `LesserMessagesAdapter` (the seven methods the binding calls); config accepts it; `LesserGraphQLAdapter implements LesserMessagesAdapter`; dependency-free messaging GraphQL operation structures; isolated no-`node_modules` TS consumer probe. Non-Apollo consumers no longer typecheck-locked out. Backward compatible.
- **#931** — bindable optional `folder` prop (URL and tab state stay synchronized) and `actions` snippet on `Conversations`; action cards use sibling controls (no nested interactives); omitted props preserve byte-identical default DOM.
- **#932** — `UnreadIndicator` announces "N conversation(s) with unread messages" — the unit actually counted. Visual variants unchanged.

## Semver impact

**minor** — additive props/interface only (`folder`, `actions`, `LesserMessagesAdapter` structural export); `UnreadIndicator` live-region DOM/ARIA wiring changes (always-mounted region, debounce + max-wait) but the component's prop API is unchanged. No breaking changes.

## Consumer impact

- **sim:** preserved — all additions are optional/bindable; omitted props render byte-identical default DOM.
- **lesser-host web:** preserved — same reasoning; adapter interface is structural, existing `LesserGraphQLAdapter` satisfies it unchanged.
- **lesser UIs:** preserved — sanitizer hardening only strips content that was never legitimately renderable (raw-text element leakage, tabnabbing links, attribute-order breakouts). One deliberate output-contract change (round 6): the messaging sanitizer no longer forces `target="_blank"` onto external links — authored targets are preserved and every external anchor gains whole-token `rel="noopener noreferrer"` regardless of target (named-target `window.opener` closed). The utils `sanitizeHtml` serialized-output post-processor no longer runs on the messaging path (defuses the XSS-capable regex defect tracked as #945 on this sink).
- **external Mastodon-compat:** preserved — messaging GraphQL operation shapes unchanged (dependency-free structures mirror the existing queries).

## Cross-repo coordination

**Required — contentus (steward: contentus steward via factory assignment):** on the greater-components **v0.13.0** pin bump, contentus should:
1. Drop its inverted probes and disclosure notices that worked around #929-#932 (the sanitizer/adapter/folder/unread gaps are now fixed upstream).
2. Evaluate swapping its vendored Conversations wrapper back to the upstream component per #931 (bindable `folder` + `actions` are now first-class).
3. Evaluate the named `LesserMessagesAdapter` binding per #930.

This coordination is queued in factory's fleet-update wave; no action needed before this merge.

## Evidence

Six rounds of cross-client adversarial review (codex implements, claude reviews comment-only), every finding fixed with fault-injection proof:
- r1→r2: CSP inline-style violations eliminated (scoped Svelte styles), 8 findings resolved.
- r2→r3: substring-decoy `rel` token matching, always-mounted live region + 150ms trailing debounce, `:global()` dropped for scoped selectors, `textarea`/`title` added to drop set.
- r3→r4: CodeQL #136 — quote-aware tag patterns + bounded fixpoint loop; `title="a > b"` regression test.
- r4→r5: quote-aware anchor hardening in `secureBlankTargetLinks` (tabnabbing closed, no `[^>]*` matchers remain), `iframe`/`noembed`/`noframes`/`xmp`/`plaintext` drop set, 1s max-wait anti-starvation guard, direct multi-pass fixpoint coverage.
- r5→r6 (round-4 do-not-merge, NEW-18 CRITICAL + NEW-19 HIGH): messaging sanitizer no longer runs the utils serialized-output post-processor on its path (attribute-order breakout → live `img onerror`, `javascript:` href, and credential-harvest form all neutralized — the utils root cause is tracked as #945 and fixed separately); every external anchor now gets whole-token `rel="noopener noreferrer"` regardless of target (named-target `window.opener` closed); attack battery asserted against the re-parsed output element set in BOTH attribute orderings.

Fault-injection per fix (tests fail on revert, pass on restore): #929 2 failed→19 passed; #930 TS2307 trio→probe passes; #931 2 failed→12 passed; #932 1 failed→7 passed; NEW-18 default-options restore → re-parsed `["a","img"]` with `onerror` → battery fails, fix restores; NEW-19 `_blank`-only restore → named target lacks rel → fails, fix restores. Suites: messaging 15 files/158 tests green; adapters 43 files/683 green (6 skipped). Root `pnpm build` exit 0; typecheck, lint, messaging svelte-check zero errors; `validate:csp` zero new violations; `check:openapi-auth` pass. Registry regenerated — `registry/index.json` only, 1,453 checksums, `--check` gate clean, `git diff --exit-code` 0.

Branch cut from the #942 head (now merged); diff vs staging is only these commits.

Implementing client: codex. Adversarial review: claude (cross-client rule).
