### PR TITLE
fix(utils,messaging): align external-anchor rel hardening across sanitizers (#947)

### DIFF
--- a/packages/shared/messaging/src/sanitize.ts
+++ b/packages/shared/messaging/src/sanitize.ts
@@ -124,7 +124,7 @@ function hardenExternalAnchors(node: SanitizedParent): void {
 			typeof child.properties['href'] === 'string' &&
 			/^(?:https?:)?[\\/]{2}/iu.test(urlParserNormalized(child.properties['href']))
 		) {
-			const tokens = relTokens(child);
+			const tokens = relTokens(child).filter((token) => token.toLowerCase() !== 'opener');
 			const normalizedTokens = new Set(tokens.map((token) => token.toLowerCase()));
 
 			for (const requiredToken of ['noopener', 'noreferrer']) {

--- a/packages/shared/messaging/tests/sanitize.test.ts
+++ b/packages/shared/messaging/tests/sanitize.test.ts
@@ -122,6 +122,29 @@ describe('messaging sanitization', () => {
 	});
 
 	it.each([
+		['opener noopener noreferrer', ['noopener', 'noreferrer']],
+		['OPENER', ['noopener', 'noreferrer']],
+		['Me Opener', ['Me', 'noopener', 'noreferrer']],
+	] as const)('drops authored rel=%s case-insensitively', (rel, expectedRel) => {
+		const anchor = expectOnlySafeAnchor(
+			`<a href="https://evil.test" target="named" rel="${rel}">x</a>`
+		);
+
+		expect(anchor.getAttribute('target')).toBe('named');
+		expect(anchor.getAttribute('rel')?.split(/\s+/u)).toEqual(expectedRel);
+	});
+
+	it('treats https:evil.test as a non-authority href under the shared predicate', () => {
+		const anchor = expectOnlySafeAnchor(
+			'<a href="https:evil.test" target="named" rel="opener">x</a>'
+		);
+
+		expect(anchor.getAttribute('href')).toBe('https:evil.test');
+		expect(anchor.getAttribute('target')).toBe('named');
+		expect(anchor.getAttribute('rel')).toBe('opener');
+	});
+
+	it.each([
 		[
 			'named target',
 			'<a title="x" href="https://evil.test" target="named">link</a>',

--- a/packages/utils/src/sanitizeHtml.ts
+++ b/packages/utils/src/sanitizeHtml.ts
@@ -161,24 +161,24 @@ function rehypeExternalLinkProperties(options: ExternalLinkOptions) {
 					const isExternal = /^(?:https?:)?[\\/]{2}/iu.test(urlParserNormalized(href));
 					const hasTarget = 'target' in child.properties;
 
-					if (isExternal && options.addRelToExternalLinks && !('rel' in child.properties)) {
-						child.properties['rel'] = [...SECURITY_TOKENS];
+					if (isExternal && options.addRelToExternalLinks) {
+						const tokens = relTokens(child.properties['rel']).filter(
+							(token) => token.toLowerCase() !== 'opener'
+						);
+						const normalizedTokens = new Set(tokens.map((token) => token.toLowerCase()));
+
+						for (const token of SECURITY_TOKENS) {
+							if (!normalizedTokens.has(token)) {
+								tokens.push(token);
+								normalizedTokens.add(token);
+							}
+						}
+
+						child.properties['rel'] = tokens;
 					}
 
 					if (isExternal && options.externalLinksInNewTab && !hasTarget) {
 						child.properties['target'] = '_blank';
-
-						if (options.addRelToExternalLinks) {
-							const tokens = relTokens(child.properties['rel']).filter(
-								(token) => token !== 'opener'
-							);
-
-							for (const token of SECURITY_TOKENS) {
-								if (!tokens.includes(token)) tokens.push(token);
-							}
-
-							child.properties['rel'] = tokens;
-						}
 					}
 				}
 

--- a/packages/utils/tests/sanitizeHtml.test.ts
+++ b/packages/utils/tests/sanitizeHtml.test.ts
@@ -56,6 +56,85 @@ describe('sanitizeHtml', () => {
 	});
 
 	it.each([
+		[
+			'rel absent and new-tab enabled',
+			'<a href="https://evil.test">x</a>',
+			{},
+			['noopener', 'noreferrer'],
+			'_blank',
+		],
+		[
+			'rel present and new-tab enabled',
+			'<a href="https://evil.test" target="named" rel="me opener">x</a>',
+			{},
+			['me', 'noopener', 'noreferrer'],
+			'named',
+		],
+		[
+			'rel absent and new-tab disabled',
+			'<a href="https://evil.test">x</a>',
+			{ externalLinksInNewTab: false },
+			['noopener', 'noreferrer'],
+			null,
+		],
+		[
+			'rel present and new-tab disabled',
+			'<a href="https://evil.test" target="_blank" rel="me opener">x</a>',
+			{ externalLinksInNewTab: false },
+			['me', 'noopener', 'noreferrer'],
+			'_blank',
+		],
+	] as const)(
+		'unions external-link rel protections with defaults when %s',
+		(_case, input, options, expectedRel, expectedTarget) => {
+			const anchor = expectOnlySafeAnchor(input, options);
+
+			expect(anchor.getAttribute('rel')?.split(/\s+/u)).toEqual(expectedRel);
+			expect(anchor.getAttribute('target')).toBe(expectedTarget);
+		}
+	);
+
+	it('leaves authored rel verbatim when library rel intervention is disabled', () => {
+		const anchor = expectOnlySafeAnchor('<a href="https://evil.test" rel="me opener">x</a>', {
+			addRelToExternalLinks: false,
+		});
+
+		expect(anchor.getAttribute('rel')).toBe('me opener');
+		expect(anchor.getAttribute('target')).toBe('_blank');
+	});
+
+	it('leaves an authored target verbatim when library new-tab attachment is disabled', () => {
+		const anchor = expectOnlySafeAnchor(
+			'<a href="https://evil.test" target="named" rel="author">x</a>',
+			{ externalLinksInNewTab: false }
+		);
+
+		expect(anchor.getAttribute('target')).toBe('named');
+		expect(anchor.getAttribute('rel')).toBe('author noopener noreferrer');
+	});
+
+	it.each([
+		['OPENER', ['noopener', 'noreferrer']],
+		['Me Opener', ['Me', 'noopener', 'noreferrer']],
+	] as const)('drops authored rel=%s case-insensitively', (rel, expectedRel) => {
+		const anchor = expectOnlySafeAnchor(`<a href="https://evil.test" rel="${rel}">x</a>`, {
+			externalLinksInNewTab: false,
+		});
+
+		expect(anchor.getAttribute('rel')?.split(/\s+/u)).toEqual(expectedRel);
+	});
+
+	it('treats https:evil.test as a non-authority href under the shared predicate', () => {
+		const anchor = expectOnlySafeAnchor(
+			'<a href="https:evil.test" target="named" rel="opener">x</a>'
+		);
+
+		expect(anchor.getAttribute('href')).toBe('https:evil.test');
+		expect(anchor.getAttribute('target')).toBe('named');
+		expect(anchor.getAttribute('rel')).toBe('opener');
+	});
+
+	it.each([
 		['double-quoted attributes', '<a href="https://x.test" title="a > b">Link</a>'],
 		['single-quoted attributes', "<a href='https://x.test' title='a > b'>Link</a>"],
 		['unquoted attributes', '<a href=https://x.test title=a&#32;&#62;&#32;b>Link</a>'],

--- a/registry/index.json
+++ b/registry/index.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://equalto.ai/schemas/registry-index.schema.json",
   "schemaVersion": "1.0.0",
-  "generatedAt": "2026-08-02T12:28:21.312Z",
+  "generatedAt": "2026-08-02T13:36:00.465Z",
   "ref": "greater-v0.11.9",
   "version": "0.11.9",
   "checksums": {
@@ -804,7 +804,7 @@
     "packages/utils/src/relativeTime.d.ts": "sha256-Qn0ZcGrZhk6bQH/Q2SRgd77DvwJDjqjY9huhAwoP9Cw=",
     "packages/utils/src/relativeTime.ts": "sha256-LNKyqZAw1SBOLzbbhAi7WCTj3zOKrerlYC1WPdjbz3Y=",
     "packages/utils/src/sanitizeHtml.d.ts": "sha256-UpBs/qZXZsO3Z0e573ymN2RL9B72Xflb7Pr6GN7bQB0=",
-    "packages/utils/src/sanitizeHtml.ts": "sha256-6/PkyDoWpskuTNH+Ju8my/K8EdX1Df9jwZiZUupHU+E=",
+    "packages/utils/src/sanitizeHtml.ts": "sha256-aKznJgbaHTaeceYrNZtHEEruzhoUYXwGlS5cybC7BQo=",
     "packages/utils/src/theme/color-harmony.d.ts": "sha256-0+LnEDhmzDYw3+EY+9jEK/EIYuIfuKbSHA8wjExZr7E=",
     "packages/utils/src/theme/color-harmony.ts": "sha256-lVx0yr/R8QQJj5McT8v3IDiDRb9tGEjUm/QobaZvzXw=",
     "packages/utils/src/theme/contrast.d.ts": "sha256-zsityhdzJBydoWIVSgb1FKyxYiva9NPELBNHBPr1Z/Q=",
@@ -1430,7 +1430,7 @@
     "packages/shared/messaging/src/Message.svelte": "sha256-/i/rdtKRja1KMVaTH2P/Zog1062AiKfNmfY1lBUxhgY=",
     "packages/shared/messaging/src/NewConversation.svelte": "sha256-23nXlWNf5SY+FF7NBPVU5WVMWj+ywpAq3MUbyauX8rE=",
     "packages/shared/messaging/src/Root.svelte": "sha256-ayF6lgF3ZxI5MuuIcj1zCntD+iSfaS7lCkRRQx54NZY=",
-    "packages/shared/messaging/src/sanitize.ts": "sha256-8SnIGpQ40MZAvfUxXl9FbqsKz5bo2UJCHP+pvF4E/EE=",
+    "packages/shared/messaging/src/sanitize.ts": "sha256-A3akkek1hp71uftE4GGcc1wGKx3eydnIbTNE29mQzwI=",
     "packages/shared/messaging/src/Thread.svelte": "sha256-wF052p+7XJQJ2ccM+j9Za+DROrObEKmYCS+MXfBmTGU=",
     "packages/shared/messaging/src/types.ts": "sha256-hHc+ulSYjI46KKV/O+h845OcqMhB6feSn6oR7CV76JY=",
     "packages/shared/messaging/src/UnreadIndicator.svelte": "sha256-IG65mT6Y0jrY2AKbFCIlFaRKKHj9XpUpViWd+lcCoT0=",
@@ -5520,8 +5520,8 @@
         },
         {
           "path": "src/sanitizeHtml.ts",
-          "checksum": "sha256-6/PkyDoWpskuTNH+Ju8my/K8EdX1Df9jwZiZUupHU+E=",
-          "size": 6047
+          "checksum": "sha256-aKznJgbaHTaeceYrNZtHEEruzhoUYXwGlS5cybC7BQo=",
+          "size": 6061
         },
         {
           "path": "src/theme/color-harmony.d.ts",
@@ -9689,8 +9689,8 @@
         },
         {
           "path": "src/sanitize.ts",
-          "checksum": "sha256-8SnIGpQ40MZAvfUxXl9FbqsKz5bo2UJCHP+pvF4E/EE=",
-          "size": 6550
+          "checksum": "sha256-A3akkek1hp71uftE4GGcc1wGKx3eydnIbTNE29mQzwI=",
+          "size": 6602
         },
         {
           "path": "src/Thread.svelte",


### PR DESCRIPTION
Closes #947.

## What

Final sanitizer-alignment gap from the #945/#946 review chain (claude r2 residual-shape ruling + r3 informational notes I1/I2). Utils and messaging now apply the **same** external-anchor hardening policy:

- **Unconditional union when `addRelToExternalLinks` is on (default):** every authority-shaped external anchor ends with `noopener noreferrer` present and `opener` dropped — regardless of whether `target` exists, who supplied it, or the `externalLinksInNewTab` setting. Author semantic tokens (`me`, `author`, `nofollow`, `tag`) preserved.
- **Case-insensitive token handling** in both files: `rel="OPENER"` / `rel="Me Opener"` can no longer bypass the drop; dedup is case-insensitive with author casing preserved.
- **Messaging** (`packages/shared/messaging/src/sanitize.ts`): drops the `opener` token where #943's union previously preserved it (`opener noopener noreferrer` → `noopener noreferrer`).
- **I1 (`https:evil.test`, scheme without slashes):** remains non-external under the shared authority-prefix predicate — parity decision, documented in the utils commit. Predicate and `urlParserNormalized` unchanged (correct on https-served pages; the http-served under-hardening precondition is unrealistic for a Fediverse client).

## Option-matrix semantics (record correction)

The #946 round-2 review claimed the options remove `rel`/`target` from the schema allow-list when off. Source-verified during this PR: **under the default `allowedAttributes`** the wildcard admits `rel` and `target` unconditionally, so authored values always survive — the options govern **library intervention only** in that configuration. With caller-supplied `allowedAttributes` that omit rel/target (e.g. `['href','title']`), the options *do* gate schema admission (claude's review refinement). Codex stopped twice on this rather than improvise (stop-condition protocol working as designed); the matrix is now pinned as documentation tests:

- `addRelToExternalLinks: false` → authored `rel` verbatim (INTENDED; off means off).
- `externalLinksInNewTab: false` → authored `target` verbatim (INTENDED).
- Union condition is exactly `isExternal && addRelToExternalLinks`.

## Semver impact — patch

When `addRelToExternalLinks` is enabled (default), author-supplied `rel` tokens on authority-shaped external anchors now always gain `noopener noreferrer` and lose `opener` case-insensitively, regardless of authored target presence or `externalLinksInNewTab`. Messaging applies the same opener removal while retaining its unconditional union. No API change.

## Evidence

Utils 233, messaging 227, blog 237, notifications 214, social 884, search 396 — all green (2,191 passed across 148 files). Fault injection both halves: rel-gate re-added → option-matrix cases FAIL; opener-drop made case-sensitive → OPENER/Me Opener FAIL in BOTH suites; restored → PASS. Cross-engine agreement probe: rel token sets identical between `sanitizeHtml` and `sanitizeMessageHtml` on author-target+opener (http/`//`/`\\`), OPENER, me+opener, and I1 shapes. Root typecheck/lint(0 errors)/build/validate:csp(0 new)/validate:registry/format:check all exit 0; `pnpm build` leaves tree clean. Registry: 1,453 checksums, delta limited to the two sanitize files. 3 commits, GPG-signed (72D6153132D52023) + DCO.

Implementing client: codex (three sessions — two correct stop-and-report cycles on inherited option-matrix assumptions, then implementation). Adversarial review: claude (cross-client rule).


