### PR TITLE
fix(cli): batch B — never rewrite consumer-owned pins; relative imports in vendored trees

### DIFF
--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -176,3 +176,8 @@ greater add
 # Add with dependencies
 greater add timeline
 ```
+
+`greater add` installs dependency declarations that are absent from `package.json`. If your
+manifest already declares a dependency below Greater's required floor, the CLI preserves the
+consumer-owned declaration and prints a `manifest vs required floors` warning. Run `greater doctor`
+to review the same drift and decide whether to upgrade manually.

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -181,3 +181,7 @@ greater add timeline
 manifest already declares a dependency below Greater's required floor, the CLI preserves the
 consumer-owned declaration and prints a `manifest vs required floors` warning. Run `greater doctor`
 to review the same drift and decide whether to upgrade manually.
+
+In vendored mode, imports between installed Greater files (including CSS `@import` paths) are
+written as relative specifiers. The copied tree therefore resolves in a standard SvelteKit/Vite
+project without adding a Greater-specific alias to `vite.config` or `tsconfig.json`.

--- a/packages/cli/src/commands/add.ts
+++ b/packages/cli/src/commands/add.ts
@@ -513,7 +513,7 @@ export const addAction = async (
 			}
 
 			for (const [targetDir, groupFiles] of byTargetDir) {
-				const result = await writeComponentFilesWithTransform(groupFiles, targetDir, config);
+				const result = await writeComponentFilesWithTransform(groupFiles, targetDir, config, cwd);
 				totalFiles += result.writtenFiles.length;
 				totalTransformed += result.transformResults.reduce((sum, r) => sum + r.transformedCount, 0);
 

--- a/packages/cli/src/commands/add.ts
+++ b/packages/cli/src/commands/add.ts
@@ -27,7 +27,7 @@ import { writeComponentFilesWithTransform, fileExists } from '../utils/files.js'
 import { getInstallTarget } from '../utils/install-path.js';
 import {
 	installDependencies,
-	getMissingDependencies,
+	getDependencyInstallPlan,
 	detectPackageManager,
 } from '../utils/packages.js';
 import { logger } from '../utils/logger.js';
@@ -618,8 +618,23 @@ export const addAction = async (
 	});
 
 	// Check which dependencies are missing
-	const missingDeps = await getMissingDependencies(allDeps, cwd);
-	const missingDevDeps = await getMissingDependencies(allDevDeps, cwd);
+	const dependencyPlan = await getDependencyInstallPlan(allDeps, cwd);
+	const devDependencyPlan = await getDependencyInstallPlan(allDevDeps, cwd);
+	const missingDeps = dependencyPlan.missing;
+	const missingDevDeps = devDependencyPlan.missing;
+	const manifestDrift = [...dependencyPlan.drift, ...devDependencyPlan.drift];
+
+	if (manifestDrift.length > 0) {
+		logger.warn(chalk.yellow('\n⚠ Manifest vs required floors drift (consumer pins preserved):'));
+		for (const { dependency, declaration } of manifestDrift) {
+			logger.warn(
+				`  ${dependency.name}: manifest ${declaration}; Greater requires ${dependency.version}`
+			);
+		}
+		logger.note(
+			chalk.dim('  Review these declarations manually; greater add will not rewrite them.')
+		);
+	}
 
 	if (missingDeps.length > 0 || missingDevDeps.length > 0) {
 		logger.info(chalk.bold('\n📦 Installing dependencies:\n'));

--- a/packages/cli/src/commands/diff.ts
+++ b/packages/cli/src/commands/diff.ts
@@ -170,7 +170,10 @@ async function diffComponent(
 		const remoteFile = remoteFiles.get(file.path);
 		const remoteContent =
 			remoteFile && remoteFile.transform !== false
-				? transformImports(remoteFile.content, config, file.path).content
+				? transformImports(remoteFile.content, config, file.path, {
+						sourceFilePath: localPath,
+						consumerRoot: cwd,
+					}).content
 				: (remoteFile?.content ?? '');
 
 		const result: FileDiffResult = {

--- a/packages/cli/src/commands/doctor.ts
+++ b/packages/cli/src/commands/doctor.ts
@@ -287,6 +287,7 @@ export async function checkNpmDependencies(
 	const installedComponents = getInstalledComponentNames(config);
 	const missingDeps: Set<string> = new Set();
 	const skippedFloorChecks = new Map<string, string>();
+	const manifestFloorDrift = new Map<string, { declaration: string; floor: string }>();
 	const pm = await detectPackageManager(cwd);
 
 	for (const componentName of installedComponents) {
@@ -295,8 +296,13 @@ export async function checkNpmDependencies(
 
 		for (const dep of component.dependencies) {
 			const status = await getDependencyDeclarationStatus(dep.name, cwd, dep.version);
-			if (!status.installed) {
+			if (!status.present) {
 				missingDeps.add(`${dep.name}@${dep.version}`);
+			} else if (!status.installed && status.declaration) {
+				manifestFloorDrift.set(dep.name, {
+					declaration: status.declaration,
+					floor: dep.version,
+				});
 			} else if (status.floorCheckSkipped && status.declaration) {
 				skippedFloorChecks.set(dep.name, status.declaration);
 			}
@@ -333,6 +339,18 @@ export async function checkNpmDependencies(
 			message: `floor check skipped: ${name} declared as ${declaration}`,
 			details:
 				'Dependency presence was verified by name only because its declaration is not semver.',
+		});
+	}
+
+	for (const [name, { declaration, floor }] of manifestFloorDrift) {
+		results.push({
+			name: 'Manifest vs Required Floors',
+			passed: false,
+			severity: 'warning',
+			message: `${name}: manifest ${declaration}; Greater requires ${floor}`,
+			details: 'The consumer-owned declaration was preserved.',
+			fix: `Review ${name} in package.json and upgrade manually if appropriate.`,
+			autoFixable: false,
 		});
 	}
 

--- a/packages/cli/src/commands/doctor.ts
+++ b/packages/cli/src/commands/doctor.ts
@@ -327,7 +327,7 @@ export async function checkNpmDependencies(
 			name: 'NPM Dependencies',
 			passed: true,
 			severity: 'info',
-			message: 'All required dependencies are installed',
+			message: 'All required dependencies are declared',
 		});
 	}
 

--- a/packages/cli/src/commands/update.ts
+++ b/packages/cli/src/commands/update.ts
@@ -291,7 +291,10 @@ async function updateComponent(
 					} else if (shouldBypassTransform) {
 						await writeFile(localPath, remoteContent);
 					} else {
-						const transformed = transformImports(remoteContent, config, file.path);
+						const transformed = transformImports(remoteContent, config, file.path, {
+							sourceFilePath: localPath,
+							consumerRoot: cwd,
+						});
 						await writeFile(localPath, transformed.content);
 					}
 				}
@@ -312,7 +315,10 @@ async function updateComponent(
 					} else if (shouldBypassTransform) {
 						await writeFile(localPath, remoteContent);
 					} else {
-						const transformed = transformImports(remoteContent, config, file.path);
+						const transformed = transformImports(remoteContent, config, file.path, {
+							sourceFilePath: localPath,
+							consumerRoot: cwd,
+						});
 						await writeFile(localPath, transformed.content);
 					}
 				} catch (error) {

--- a/packages/cli/src/utils/files.ts
+++ b/packages/cli/src/utils/files.ts
@@ -200,11 +200,21 @@ export async function detectProjectDetails(cwd: string): Promise<ProjectDetectio
 
 	try {
 		const content = await readFile(packageJsonPath);
-		const pkg = JSON.parse(content);
+		const pkg = JSON.parse(content) as {
+			dependencies?: Record<string, string>;
+			devDependencies?: Record<string, string>;
+			peerDependencies?: Record<string, string>;
+			optionalDependencies?: Record<string, string>;
+		};
+		const declaredVersion = (name: string): string | undefined =>
+			pkg.dependencies?.[name] ||
+			pkg.devDependencies?.[name] ||
+			pkg.peerDependencies?.[name] ||
+			pkg.optionalDependencies?.[name];
 
 		// Check for TypeScript
 		result.hasTypeScript = !!(
-			pkg.devDependencies?.['typescript'] || (await fileExists(path.join(cwd, 'tsconfig.json')))
+			declaredVersion('typescript') || (await fileExists(path.join(cwd, 'tsconfig.json')))
 		);
 
 		// Check for svelte.config.js
@@ -228,11 +238,9 @@ export async function detectProjectDetails(cwd: string): Promise<ProjectDetectio
 		}
 
 		// Detect project type
-		const hasSvelteKit = !!(
-			pkg.dependencies?.['@sveltejs/kit'] || pkg.devDependencies?.['@sveltejs/kit']
-		);
-		const hasSvelte = !!(pkg.dependencies?.['svelte'] || pkg.devDependencies?.['svelte']);
-		const hasVite = !!pkg.devDependencies?.['vite'];
+		const hasSvelteKit = !!declaredVersion('@sveltejs/kit');
+		const hasSvelte = !!declaredVersion('svelte');
+		const hasVite = !!declaredVersion('vite');
 
 		if (hasSvelteKit && result.svelteConfigPath) {
 			result.type = 'sveltekit';
@@ -368,8 +376,17 @@ export async function getSvelteVersionDetails(cwd: string): Promise<SvelteVersio
 
 	try {
 		const content = await readFile(packageJsonPath);
-		const pkg = JSON.parse(content);
-		const svelteVersion = pkg.dependencies?.['svelte'] || pkg.devDependencies?.['svelte'];
+		const pkg = JSON.parse(content) as {
+			dependencies?: Record<string, string>;
+			devDependencies?: Record<string, string>;
+			peerDependencies?: Record<string, string>;
+			optionalDependencies?: Record<string, string>;
+		};
+		const svelteVersion =
+			pkg.dependencies?.['svelte'] ||
+			pkg.devDependencies?.['svelte'] ||
+			pkg.peerDependencies?.['svelte'] ||
+			pkg.optionalDependencies?.['svelte'];
 
 		if (!svelteVersion) {
 			return null;
@@ -381,9 +398,9 @@ export async function getSvelteVersionDetails(cwd: string): Promise<SvelteVersio
 			return null;
 		}
 
-		const major = parseInt(match[1], 10);
-		const minor = parseInt(match[2], 10);
-		const patch = parseInt(match[3], 10);
+		const major = parseInt(match[1]!, 10);
+		const minor = parseInt(match[2]!, 10);
+		const patch = parseInt(match[3]!, 10);
 
 		return {
 			raw: svelteVersion,

--- a/packages/cli/src/utils/files.ts
+++ b/packages/cli/src/utils/files.ts
@@ -84,7 +84,8 @@ export async function writeComponentFiles(
 export async function writeComponentFilesWithTransform(
 	files: ComponentFile[],
 	targetDir: string,
-	config: ComponentConfig
+	config: ComponentConfig,
+	consumerRoot?: string
 ): Promise<WriteResult> {
 	const writtenFiles: string[] = [];
 	const transformResults: TransformResult[] = [];
@@ -106,7 +107,12 @@ export async function writeComponentFilesWithTransform(
 		}
 
 		// Transform imports based on file type
-		const result = transformImports(file.content, config, file.path);
+		const result = transformImports(
+			file.content,
+			config,
+			file.path,
+			consumerRoot ? { sourceFilePath: filePath, consumerRoot } : undefined
+		);
 		transformResults.push(result);
 
 		// Write the transformed content

--- a/packages/cli/src/utils/packages.ts
+++ b/packages/cli/src/utils/packages.ts
@@ -9,9 +9,20 @@ import { minVersion, satisfies } from 'semver';
 import type { ComponentDependency } from '../registry/index.js';
 
 export interface DependencyDeclarationStatus {
+	present: boolean;
 	installed: boolean;
 	declaration?: string;
 	floorCheckSkipped: boolean;
+}
+
+export interface DependencyManifestDrift {
+	dependency: ComponentDependency;
+	declaration: string;
+}
+
+export interface DependencyInstallPlan {
+	missing: ComponentDependency[];
+	drift: DependencyManifestDrift[];
 }
 
 /**
@@ -101,7 +112,7 @@ export async function getDependencyDeclarationStatus(
 	const packageJsonPath = path.join(cwd, 'package.json');
 
 	if (!(await fs.pathExists(packageJsonPath))) {
-		return { installed: false, floorCheckSkipped: false };
+		return { present: false, installed: false, floorCheckSkipped: false };
 	}
 
 	try {
@@ -116,29 +127,47 @@ export async function getDependencyDeclarationStatus(
 			pkg.devDependencies?.[packageName] ||
 			pkg.peerDependencies?.[packageName];
 
-		if (!installedVersion) return { installed: false, floorCheckSkipped: false };
+		if (!installedVersion) {
+			return { present: false, installed: false, floorCheckSkipped: false };
+		}
 		if (!requiredVersion) {
-			return { installed: true, declaration: installedVersion, floorCheckSkipped: false };
+			return {
+				present: true,
+				installed: true,
+				declaration: installedVersion,
+				floorCheckSkipped: false,
+			};
 		}
 
 		let installedFloor;
 		try {
 			installedFloor = minVersion(installedVersion);
 		} catch {
-			return { installed: true, declaration: installedVersion, floorCheckSkipped: true };
+			return {
+				present: true,
+				installed: true,
+				declaration: installedVersion,
+				floorCheckSkipped: true,
+			};
 		}
 
 		if (!installedFloor) {
-			return { installed: true, declaration: installedVersion, floorCheckSkipped: true };
+			return {
+				present: true,
+				installed: true,
+				declaration: installedVersion,
+				floorCheckSkipped: true,
+			};
 		}
 
 		return {
+			present: true,
 			installed: satisfies(installedFloor, requiredVersion),
 			declaration: installedVersion,
 			floorCheckSkipped: false,
 		};
 	} catch {
-		return { installed: false, floorCheckSkipped: false };
+		return { present: false, installed: false, floorCheckSkipped: false };
 	}
 }
 
@@ -157,13 +186,28 @@ export async function getMissingDependencies(
 	dependencies: ComponentDependency[],
 	cwd: string
 ): Promise<ComponentDependency[]> {
-	const missing: ComponentDependency[] = [];
+	return (await getDependencyInstallPlan(dependencies, cwd)).missing;
+}
+
+/**
+ * Separate dependencies absent from package.json from consumer-owned declarations
+ * that do not satisfy Greater's required floor. Only absent dependencies are safe
+ * for the CLI to install; package managers would otherwise rewrite the declaration.
+ */
+export async function getDependencyInstallPlan(
+	dependencies: ComponentDependency[],
+	cwd: string
+): Promise<DependencyInstallPlan> {
+	const plan: DependencyInstallPlan = { missing: [], drift: [] };
 
 	for (const dep of dependencies) {
-		if (!(await isDependencyInstalled(dep.name, cwd, dep.version))) {
-			missing.push(dep);
+		const status = await getDependencyDeclarationStatus(dep.name, cwd, dep.version);
+		if (!status.present) {
+			plan.missing.push(dep);
+		} else if (!status.installed && status.declaration) {
+			plan.drift.push({ dependency: dep, declaration: status.declaration });
 		}
 	}
 
-	return missing;
+	return plan;
 }

--- a/packages/cli/src/utils/packages.ts
+++ b/packages/cli/src/utils/packages.ts
@@ -121,11 +121,13 @@ export async function getDependencyDeclarationStatus(
 			dependencies?: Record<string, string>;
 			devDependencies?: Record<string, string>;
 			peerDependencies?: Record<string, string>;
+			optionalDependencies?: Record<string, string>;
 		};
 		const installedVersion =
 			pkg.dependencies?.[packageName] ||
 			pkg.devDependencies?.[packageName] ||
-			pkg.peerDependencies?.[packageName];
+			pkg.peerDependencies?.[packageName] ||
+			pkg.optionalDependencies?.[packageName];
 
 		if (!installedVersion) {
 			return { present: false, installed: false, floorCheckSkipped: false };

--- a/packages/cli/src/utils/transform.ts
+++ b/packages/cli/src/utils/transform.ts
@@ -4,11 +4,13 @@
  *
  * - Canonicalizes legacy hyphenated packages (e.g. `@equaltoai/greater-components-utils`)
  *   to umbrella subpath imports (e.g. `@equaltoai/greater-components/utils`).
- * - Rewrites shared module imports to local CLI-installed paths based on `components.json`
- *   (e.g. `@equaltoai/greater-components-auth` → `$lib/components/auth` by default).
+ * - Rewrites shared module imports to local CLI-installed paths based on `components.json`.
+ *   During a real vendored write, local targets are emitted relative to the source file so
+ *   the copied tree does not depend on a consumer alias.
  */
 
-import type { ComponentConfig } from './config.js';
+import path from 'node:path';
+import { resolveAlias, type ComponentConfig } from './config.js';
 
 /**
  * Path mapping rule for transforming imports
@@ -34,6 +36,13 @@ export interface TransformResult {
 	transformedPaths: Array<{ from: string; to: string }>;
 	/** Whether any transformations were made */
 	hasChanges: boolean;
+}
+
+export interface TransformContext {
+	/** Absolute path of the file as written into the consumer project. */
+	sourceFilePath: string;
+	/** Absolute consumer project root used to resolve components.json paths. */
+	consumerRoot: string;
 }
 
 /**
@@ -313,9 +322,49 @@ function transformRelativeInstallPath(importPath: string, filePath?: string): st
 function transformImportPath(
 	importPath: string,
 	mappings: PathMapping[],
-	filePath?: string
+	config: ComponentConfig,
+	filePath?: string,
+	context?: TransformContext
 ): string | null {
-	return transformPath(importPath, mappings) ?? transformRelativeInstallPath(importPath, filePath);
+	const mappedPath = transformPath(importPath, mappings);
+	if (mappedPath) {
+		return toRelativeVendoredPath(mappedPath, config, context) ?? mappedPath;
+	}
+
+	return transformRelativeInstallPath(importPath, filePath);
+}
+
+function toRelativeVendoredPath(
+	mappedPath: string,
+	config: ComponentConfig,
+	context?: TransformContext
+): string | null {
+	if (config.installMode !== 'vendored' || !context) return null;
+
+	const configuredRoots = [
+		config.aliases.greater,
+		config.aliases.components,
+		config.aliases.hooks,
+		config.aliases.ui,
+		config.aliases.utils,
+		config.aliases.lib,
+	].sort((a, b) => b.length - a.length);
+
+	for (const configuredRoot of configuredRoots) {
+		if (mappedPath !== configuredRoot && !mappedPath.startsWith(`${configuredRoot}/`)) continue;
+
+		const suffix = mappedPath.slice(configuredRoot.length).replace(/^\/+/, '');
+		const targetPath = path.join(
+			resolveAlias(configuredRoot, config, context.consumerRoot),
+			suffix
+		);
+		let relativePath = path.relative(path.dirname(context.sourceFilePath), targetPath);
+		relativePath = relativePath.replace(/\\/g, '/');
+		if (!relativePath.startsWith('.')) relativePath = `./${relativePath}`;
+		return relativePath;
+	}
+
+	return null;
 }
 
 /**
@@ -417,7 +466,9 @@ function isExecutableScriptMatch(content: string, offset: number): boolean {
 function transformScriptImports(
 	content: string,
 	mappings: PathMapping[],
-	filePath?: string
+	config: ComponentConfig,
+	filePath?: string,
+	context?: TransformContext
 ): TransformResult {
 	let transformedContent = content;
 	let transformedCount = 0;
@@ -432,7 +483,7 @@ function transformScriptImports(
 			if (!isExecutableScriptMatch(beforeEsImports, statementOffset)) {
 				return match;
 			}
-			const newPath = transformImportPath(importPath, mappings, filePath);
+			const newPath = transformImportPath(importPath, mappings, config, filePath, context);
 			if (newPath) {
 				transformedCount++;
 				transformedPaths.push({ from: importPath, to: newPath });
@@ -451,7 +502,7 @@ function transformScriptImports(
 			if (!isExecutableScriptMatch(beforeSideEffectImports, statementOffset)) {
 				return match;
 			}
-			const newPath = transformImportPath(importPath, mappings, filePath);
+			const newPath = transformImportPath(importPath, mappings, config, filePath, context);
 			if (newPath) {
 				transformedCount++;
 				transformedPaths.push({ from: importPath, to: newPath });
@@ -470,7 +521,7 @@ function transformScriptImports(
 			if (!isExecutableScriptMatch(beforeDynamicImports, statementOffset)) {
 				return match;
 			}
-			const newPath = transformImportPath(importPath, mappings, filePath);
+			const newPath = transformImportPath(importPath, mappings, config, filePath, context);
 			if (newPath) {
 				transformedCount++;
 				transformedPaths.push({ from: importPath, to: newPath });
@@ -489,7 +540,7 @@ function transformScriptImports(
 			if (!isExecutableScriptMatch(beforeReExports, statementOffset)) {
 				return match;
 			}
-			const newPath = transformImportPath(importPath, mappings, filePath);
+			const newPath = transformImportPath(importPath, mappings, config, filePath, context);
 			if (newPath) {
 				transformedCount++;
 				transformedPaths.push({ from: importPath, to: newPath });
@@ -510,7 +561,12 @@ function transformScriptImports(
 /**
  * Transform CSS @import statements
  */
-function transformCssImports(content: string, mappings: PathMapping[]): TransformResult {
+function transformCssImports(
+	content: string,
+	mappings: PathMapping[],
+	config: ComponentConfig,
+	context?: TransformContext
+): TransformResult {
 	let transformedContent = content;
 	let transformedCount = 0;
 	const transformedPaths: Array<{ from: string; to: string }> = [];
@@ -518,7 +574,10 @@ function transformCssImports(content: string, mappings: PathMapping[]): Transfor
 	transformedContent = transformedContent.replace(
 		IMPORT_PATTERNS.cssImport,
 		(match, _quote, importPath) => {
-			const newPath = transformPath(importPath, mappings);
+			const mappedPath = transformPath(importPath, mappings);
+			const newPath = mappedPath
+				? (toRelativeVendoredPath(mappedPath, config, context) ?? mappedPath)
+				: null;
 			if (newPath) {
 				transformedCount++;
 				transformedPaths.push({ from: importPath, to: newPath });
@@ -624,7 +683,8 @@ export function transformSvelteImports(content: string, config: ComponentConfig)
 function transformSvelteImportsForFile(
 	content: string,
 	config: ComponentConfig,
-	filePath?: string
+	filePath?: string,
+	context?: TransformContext
 ): TransformResult {
 	const mappings = buildPathMappings(config);
 	let transformedContent = content;
@@ -635,7 +695,7 @@ function transformSvelteImportsForFile(
 	const scriptBlocks = extractScriptBlocks(content);
 	// Process in reverse order to maintain correct positions
 	for (const block of scriptBlocks.reverse()) {
-		const result = transformScriptImports(block.content, mappings, filePath);
+		const result = transformScriptImports(block.content, mappings, config, filePath, context);
 		if (result.hasChanges) {
 			const before = transformedContent.slice(0, block.start);
 			const after = transformedContent.slice(block.end);
@@ -653,7 +713,7 @@ function transformSvelteImportsForFile(
 	// Transform style blocks
 	const styleBlocks = extractStyleBlocks(transformedContent);
 	for (const block of styleBlocks.reverse()) {
-		const result = transformCssImports(block.content, mappings);
+		const result = transformCssImports(block.content, mappings, config, context);
 		if (result.hasChanges) {
 			const before = transformedContent.slice(0, block.start);
 			const after = transformedContent.slice(block.end);
@@ -682,18 +742,23 @@ function transformSvelteImportsForFile(
 export function transformTypeScriptImports(
 	content: string,
 	config: ComponentConfig,
-	filePath?: string
+	filePath?: string,
+	context?: TransformContext
 ): TransformResult {
 	const mappings = buildPathMappings(config);
-	return transformScriptImports(content, mappings, filePath);
+	return transformScriptImports(content, mappings, config, filePath, context);
 }
 
 /**
  * Transform imports in a CSS file
  */
-export function transformCssFileImports(content: string, config: ComponentConfig): TransformResult {
+export function transformCssFileImports(
+	content: string,
+	config: ComponentConfig,
+	context?: TransformContext
+): TransformResult {
 	const mappings = buildPathMappings(config);
-	return transformCssImports(content, mappings);
+	return transformCssImports(content, mappings, config, context);
 }
 
 /**
@@ -706,31 +771,32 @@ export function transformCssFileImports(content: string, config: ComponentConfig
 export function transformImports(
 	content: string,
 	config: ComponentConfig,
-	filePath?: string
+	filePath?: string,
+	context?: TransformContext
 ): TransformResult {
 	// Detect file type from extension or content
 	const ext = filePath?.split('.').pop()?.toLowerCase();
 
 	if (ext === 'svelte') {
-		return transformSvelteImportsForFile(content, config, filePath);
+		return transformSvelteImportsForFile(content, config, filePath, context);
 	}
 
 	if (ext === 'css' || ext === 'scss' || ext === 'less') {
-		return transformCssFileImports(content, config);
+		return transformCssFileImports(content, config, context);
 	}
 
 	// Trust explicit file extensions before content sniffing so JSDoc examples like
 	// `<script>` inside .ts files do not get misclassified as Svelte.
 	if (ext) {
-		return transformTypeScriptImports(content, config, filePath);
+		return transformTypeScriptImports(content, config, filePath, context);
 	}
 
 	if (content.includes('<script')) {
-		return transformSvelteImportsForFile(content, config, filePath);
+		return transformSvelteImportsForFile(content, config, filePath, context);
 	}
 
 	// Default to TypeScript/JavaScript handling for extensionless text files.
-	return transformTypeScriptImports(content, config, filePath);
+	return transformTypeScriptImports(content, config, filePath, context);
 }
 
 /**

--- a/packages/cli/tests/add-extended.test.ts
+++ b/packages/cli/tests/add-extended.test.ts
@@ -127,7 +127,7 @@ vi.mock('../src/registry/patterns.js', () => ({
 }));
 
 vi.mock('../src/utils/packages.js', () => ({
-	getMissingDependencies: vi.fn().mockResolvedValue([]),
+	getDependencyInstallPlan: vi.fn().mockResolvedValue({ missing: [], drift: [] }),
 	detectPackageManager: vi.fn().mockResolvedValue('pnpm'),
 	installDependencies: vi.fn(),
 }));
@@ -313,9 +313,10 @@ describe('Add Command Extended', () => {
 			const { getComponent } = await import('../src/registry/index.js');
 
 			(getComponent as any).mockReturnValue(MOCK_BUTTON_COMPONENT);
-			vi.mocked(packages.getMissingDependencies).mockResolvedValue([
-				{ name: 'foo', version: '1.0.0' },
-			]);
+			vi.mocked(packages.getDependencyInstallPlan).mockResolvedValue({
+				missing: [{ name: 'foo', version: '1.0.0' }],
+				drift: [],
+			});
 			vi.mocked(packages.installDependencies).mockRejectedValue(new Error('Install Error'));
 
 			const exitSpy = vi.spyOn(process, 'exit').mockImplementation((() => {
@@ -381,9 +382,10 @@ describe('Add Command Extended', () => {
 			const { getComponent } = await import('../src/registry/index.js');
 
 			(getComponent as any).mockReturnValue(MOCK_BUTTON_COMPONENT);
-			vi.mocked(packages.getMissingDependencies).mockResolvedValue([
-				{ name: 'foo', version: '1.0.0' },
-			]);
+			vi.mocked(packages.getDependencyInstallPlan).mockResolvedValue({
+				missing: [{ name: 'foo', version: '1.0.0' }],
+				drift: [],
+			});
 			vi.mocked(packages.installDependencies).mockResolvedValue(undefined);
 
 			await addAction(['button'], { cwd: '/' });
@@ -418,13 +420,13 @@ describe('Add Command Extended', () => {
 			// So even if our mock returns empty npmDependencies, addAction should add it.
 			// But we need to verify it.
 			// How? The resolution object is modified in place.
-			// We can spy on packages.getMissingDependencies call to see if it includes greater-components?
+			// We can spy on packages.getDependencyInstallPlan to see if it includes greater-components?
 			// Or check installDependencies?
 
 			// But wait, addAction modifies `resolution.npmDependencies`.
-			// Then `getMissingDependencies` is called with it.
+			// Then `getDependencyInstallPlan` is called with it.
 
-			expect(packages.getMissingDependencies).toHaveBeenCalledWith(
+			expect(packages.getDependencyInstallPlan).toHaveBeenCalledWith(
 				expect.arrayContaining([
 					expect.objectContaining({ name: '@equaltoai/greater-components' }),
 				]),

--- a/packages/cli/tests/add-extended.test.ts
+++ b/packages/cli/tests/add-extended.test.ts
@@ -348,7 +348,8 @@ describe('Add Command Extended', () => {
 			expect(files.writeComponentFilesWithTransform).toHaveBeenCalledWith(
 				[expect.objectContaining({ path: 'button.ts' })],
 				'/src/lib/foo',
-				expect.any(Object)
+				expect.any(Object),
+				'/'
 			);
 
 			const notes = vi.mocked(logger.note).mock.calls.map(([message]) => String(message));
@@ -370,7 +371,8 @@ describe('Add Command Extended', () => {
 			expect(files.writeComponentFilesWithTransform).toHaveBeenCalledWith(
 				[expect.objectContaining({ path: 'button.ts' })],
 				'/src/lib/primitives',
-				expect.any(Object)
+				expect.any(Object),
+				'/'
 			);
 
 			const notes = vi.mocked(logger.note).mock.calls.map(([message]) => String(message));

--- a/packages/cli/tests/commands.test.ts
+++ b/packages/cli/tests/commands.test.ts
@@ -52,7 +52,7 @@ const mockWriteComponentFiles = vi.fn().mockResolvedValue({
 });
 
 const mockFetchComponents = vi.fn();
-const mockGetMissingDependencies = vi.fn();
+const mockGetDependencyInstallPlan = vi.fn();
 const mockInstallDependencies = vi.fn();
 const mockDetectPackageManager = vi.fn();
 
@@ -141,7 +141,7 @@ vi.mock(srcPath('utils/fetch.js'), () => ({
 
 vi.mock(srcPath('utils/packages.js'), () => ({
 	installDependencies: mockInstallDependencies,
-	getMissingDependencies: mockGetMissingDependencies,
+	getDependencyInstallPlan: mockGetDependencyInstallPlan,
 	detectPackageManager: mockDetectPackageManager,
 }));
 
@@ -213,7 +213,7 @@ describe('cli commands', () => {
 				],
 			])
 		);
-		mockGetMissingDependencies.mockResolvedValue([]);
+		mockGetDependencyInstallPlan.mockResolvedValue({ missing: [], drift: [] });
 		mockDetectPackageManager.mockResolvedValue('pnpm');
 		mockWriteComponentFiles.mockResolvedValue({
 			writtenFiles: [],
@@ -382,7 +382,10 @@ describe('cli commands', () => {
 				],
 			])
 		);
-		mockGetMissingDependencies.mockResolvedValue([{ name: 'svelte', version: '^5.0.0' }]);
+		mockGetDependencyInstallPlan.mockResolvedValue({
+			missing: [{ name: 'svelte', version: '^5.0.0' }],
+			drift: [],
+		});
 		mockDetectPackageManager.mockResolvedValue('npm');
 		mockWriteComponentFiles.mockResolvedValue({
 			writtenFiles: [],
@@ -456,7 +459,7 @@ describe('cli commands', () => {
 				],
 			])
 		);
-		mockGetMissingDependencies.mockResolvedValue([]);
+		mockGetDependencyInstallPlan.mockResolvedValue({ missing: [], drift: [] });
 		mockDetectPackageManager.mockResolvedValue('pnpm');
 		mockWriteComponentFiles.mockRejectedValue(new Error('Write failed'));
 

--- a/packages/cli/tests/doctor.test.ts
+++ b/packages/cli/tests/doctor.test.ts
@@ -587,7 +587,7 @@ describe('checkNpmDependencies extended', () => {
 		expect(formatResult(skipped)).toContain('floor check skipped: viem declared as catalog:');
 	});
 
-	it('still fails when a semver declaration is below the security floor', async () => {
+	it('reports manifest-vs-floor drift without treating the declaration as missing', async () => {
 		const { checkNpmDependencies } = await import('../src/commands/doctor.js');
 		const { getComponent } = await import('../src/registry/index.js');
 		vi.mocked(getComponent).mockReturnValue({
@@ -605,13 +605,19 @@ describe('checkNpmDependencies extended', () => {
 			installed: [{ name: 'adapters' } as any],
 		});
 
-		expect(results).toHaveLength(1);
+		expect(results).toHaveLength(2);
 		expect(results[0]).toMatchObject({
 			name: 'NPM Dependencies',
-			passed: false,
-			severity: 'error',
+			passed: true,
+			message: 'All required dependencies are installed',
 		});
-		expect(results[0]?.details).toContain('viem@^2.55.10');
+		expect(results[1]).toMatchObject({
+			name: 'Manifest vs Required Floors',
+			passed: false,
+			severity: 'warning',
+			message: 'viem: manifest 2.51.3; Greater requires ^2.55.10',
+		});
+		expect(results[1]?.details).toContain('consumer-owned declaration was preserved');
 	});
 });
 

--- a/packages/cli/tests/doctor.test.ts
+++ b/packages/cli/tests/doctor.test.ts
@@ -548,7 +548,7 @@ describe('checkNpmDependencies extended', () => {
 		expect(registry.faces.blog.includes.shared).not.toContain('content');
 		expect(readingResults.find((result) => result.name === 'NPM Dependencies')).toMatchObject({
 			passed: true,
-			message: 'All required dependencies are installed',
+			message: 'All required dependencies are declared',
 		});
 		expect(
 			contentExpandedResults.find((result) => result.name === 'NPM Dependencies')
@@ -588,7 +588,7 @@ describe('checkNpmDependencies extended', () => {
 	});
 
 	it('reports manifest-vs-floor drift without treating the declaration as missing', async () => {
-		const { checkNpmDependencies } = await import('../src/commands/doctor.js');
+		const { checkNpmDependencies, formatResult } = await import('../src/commands/doctor.js');
 		const { getComponent } = await import('../src/registry/index.js');
 		vi.mocked(getComponent).mockReturnValue({
 			name: 'adapters',
@@ -609,7 +609,7 @@ describe('checkNpmDependencies extended', () => {
 		expect(results[0]).toMatchObject({
 			name: 'NPM Dependencies',
 			passed: true,
-			message: 'All required dependencies are installed',
+			message: 'All required dependencies are declared',
 		});
 		expect(results[1]).toMatchObject({
 			name: 'Manifest vs Required Floors',
@@ -618,6 +618,9 @@ describe('checkNpmDependencies extended', () => {
 			message: 'viem: manifest 2.51.3; Greater requires ^2.55.10',
 		});
 		expect(results[1]?.details).toContain('consumer-owned declaration was preserved');
+		expect(results.map(formatResult).join('\n')).not.toContain(
+			'All required dependencies are installed'
+		);
 	});
 });
 

--- a/packages/cli/tests/e2e/review-command-install.test.ts
+++ b/packages/cli/tests/e2e/review-command-install.test.ts
@@ -74,9 +74,8 @@ const REVIEW_TYPE_IMPORTERS = [
 ] as const;
 
 beforeAll(async () => {
-	if (!(await fs.pathExists(CLI_BIN))) {
-		await execa('pnpm', ['build'], { cwd: CLI_ROOT });
-	}
+	// This test executes dist/index.js, so always compile the source under test.
+	await execa('pnpm', ['build'], { cwd: CLI_ROOT });
 }, 300_000);
 
 /** Copies the fixture template, dropping the generated state `init` recreates. */
@@ -133,12 +132,23 @@ describe('greater add review (real command)', () => {
 				env: CLI_ENV,
 			});
 			expect(await fs.pathExists(path.join(root, 'components.json'))).toBe(true);
+			const packageJsonPath = path.join(root, 'package.json');
+			const manifestBeforeAdd = await fs.readFile(packageJsonPath, 'utf8');
+			expect(JSON.parse(manifestBeforeAdd).devDependencies.viem).toBe('^2.47.14');
 
 			// 2. The command under test. No `--all`: the closure below is what
 			//    `review`'s own registryDependencies must pull in on their own.
-			await execa('node', [CLI_BIN, 'add', '--yes', 'review', '--cwd', root], {
+			const addResult = await execa('node', [CLI_BIN, 'add', '--yes', 'review', '--cwd', root], {
 				env: CLI_ENV,
 			});
+
+			// Consumer-owned declarations are never package-manager rewrite targets.
+			// The adapters core requires viem ^2.55.10, while this fixture intentionally
+			// pins an older range. The complete manifest bytes must survive `add`.
+			expect(await fs.readFile(packageJsonPath, 'utf8')).toBe(manifestBeforeAdd);
+			expect(`${addResult.stdout}\n${addResult.stderr}`).toContain(
+				'viem: manifest ^2.47.14; Greater requires ^2.55.10'
+			);
 
 			// (a) Dependency closure: `blog-types` is not requested on the command
 			//     line, it is reached through `review`'s registryDependencies.

--- a/packages/cli/tests/e2e/review-command-install.test.ts
+++ b/packages/cli/tests/e2e/review-command-install.test.ts
@@ -195,9 +195,31 @@ function isExecutableScriptMatch(content: string, offset: number): boolean {
 	return state === 'normal';
 }
 
-function importSpecifiers(content: string): string[] {
+function maskSvelteMarkup(content: string): string {
+	const masked = Array.from({ length: content.length }, (_, index) => {
+		const char = content[index] ?? '';
+		return char === '\n' || char === '\r' ? char : ' ';
+	});
+	const executableTag = /<(script|style)\b[^>]*>[\s\S]*?<\/\1\s*>/gi;
+
+	let match: RegExpExecArray | null;
+	while ((match = executableTag.exec(content)) !== null) {
+		const openingEnd = match[0].indexOf('>') + 1;
+		const closingStart = match[0].lastIndexOf('</');
+		for (let offset = openingEnd; offset < closingStart; offset++) {
+			masked[match.index + offset] = match[0][offset] ?? '';
+		}
+	}
+
+	return masked.join('');
+}
+
+function importSpecifiers(content: string, filePath?: string): string[] {
 	const specifiers: string[] = [];
-	const executableContent = content.replace(/<!--[\s\S]*?-->/g, (comment) =>
+	// Svelte markup is not JavaScript: only script/style bodies may influence
+	// string and comment state for executable import matches.
+	const executableSource = filePath?.endsWith('.svelte') ? maskSvelteMarkup(content) : content;
+	const executableContent = executableSource.replace(/<!--[\s\S]*?-->/g, (comment) =>
 		comment.replace(/[^\n]/g, ' ')
 	);
 	for (const pattern of [
@@ -236,6 +258,17 @@ function resolvesOnDisk(fromFile: string, specifier: string): boolean {
 }
 
 describe('greater add review (real command)', () => {
+	it('keeps Svelte markup apostrophes from hiding script imports in the sweep', () => {
+		const source = [
+			"<p>Sam's post</p>",
+			'<script>',
+			"import 'bare-package';",
+			'</script>',
+		].join('\n');
+
+		expect(importSpecifiers(source, 'synthetic.svelte')).toEqual(['bare-package']);
+	});
+
 	it('preserves pins and installs a relative-import tree that type-checks and builds', async () => {
 		const root = await createScratchProject();
 
@@ -289,7 +322,7 @@ describe('greater add review (real command)', () => {
 			];
 			for (const file of await getFilesRecursively(libDir)) {
 				if (!/\.(?:svelte|[cm]?[jt]s|css)$/.test(file)) continue;
-				for (const specifier of importSpecifiers(await fs.readFile(file, 'utf8'))) {
+				for (const specifier of importSpecifiers(await fs.readFile(file, 'utf8'), file)) {
 					if (specifier.startsWith('.') && !resolvesOnDisk(file, specifier)) {
 						unresolved.push(`${path.relative(root, file)} → ${specifier}`);
 					}

--- a/packages/cli/tests/e2e/review-command-install.test.ts
+++ b/packages/cli/tests/e2e/review-command-install.test.ts
@@ -135,12 +135,71 @@ async function getFilesRecursively(dir: string): Promise<string[]> {
 	return files;
 }
 
+type StripState = 'normal' | 'line-comment' | 'block-comment' | 'single' | 'double' | 'template';
+
+function isExecutableScriptMatch(content: string, offset: number): boolean {
+	let state: StripState = 'normal';
+	let escaped = false;
+
+	for (let i = 0; i < offset; i++) {
+		const char = content[i] ?? '';
+		const next = content[i + 1] ?? '';
+
+		if (state === 'line-comment') {
+			if (char === '\n') state = 'normal';
+			continue;
+		}
+
+		if (state === 'block-comment') {
+			if (char === '*' && next === '/') {
+				state = 'normal';
+				i++;
+			}
+			continue;
+		}
+
+		if (state === 'single' || state === 'double' || state === 'template') {
+			if (escaped) {
+				escaped = false;
+				continue;
+			}
+			if (char === '\\') {
+				escaped = true;
+				continue;
+			}
+			if (
+				(state === 'single' && char === "'") ||
+				(state === 'double' && char === '"') ||
+				(state === 'template' && char === '`')
+			) {
+				state = 'normal';
+			}
+			continue;
+		}
+
+		if (char === '/' && next === '/') {
+			state = 'line-comment';
+			i++;
+			continue;
+		}
+		if (char === '/' && next === '*') {
+			state = 'block-comment';
+			i++;
+			continue;
+		}
+		if (char === "'") state = 'single';
+		else if (char === '"') state = 'double';
+		else if (char === '`') state = 'template';
+	}
+
+	return state === 'normal';
+}
+
 function importSpecifiers(content: string): string[] {
 	const specifiers: string[] = [];
-	const executableContent = content
-		.replace(/\/\*[\s\S]*?\*\//g, '')
-		.replace(/^\s*\/\/.*$/gm, '')
-		.replace(/<!--[\s\S]*?-->/g, '');
+	const executableContent = content.replace(/<!--[\s\S]*?-->/g, (comment) =>
+		comment.replace(/[^\n]/g, ' ')
+	);
 	for (const pattern of [
 		/(?:^|[;\n\r])\s*import\s+[^'"]+?from\s*(['"])([^'"]+)\1/g,
 		/(?:^|[;\n\r])\s*import\s*(['"])([^'"]+)\1/g,
@@ -150,7 +209,10 @@ function importSpecifiers(content: string): string[] {
 	]) {
 		let match: RegExpExecArray | null;
 		while ((match = pattern.exec(executableContent)) !== null) {
-			if (match[2]) specifiers.push(match[2]);
+			const statementOffset = match.index + match[0].search(/\b(?:import|export)\b|@import\b/);
+			if (match[2] && isExecutableScriptMatch(executableContent, statementOffset)) {
+				specifiers.push(match[2]);
+			}
 		}
 	}
 	return specifiers;
@@ -216,19 +278,37 @@ describe('greater add review (real command)', () => {
 			// added for Greater internals; the stock SvelteKit fixture stays untouched.
 			const unresolved: string[] = [];
 			const bareAliasTargets: string[] = [];
+			const bareGreaterPackageSpecifiers: string[] = [];
+			const bareAliasRoots = [
+				componentsJson.aliases.greater,
+				componentsJson.aliases.components,
+				componentsJson.aliases.utils,
+				componentsJson.aliases.hooks,
+				componentsJson.aliases.lib,
+				'$lib',
+			];
 			for (const file of await getFilesRecursively(libDir)) {
 				if (!/\.(?:svelte|[cm]?[jt]s|css)$/.test(file)) continue;
 				for (const specifier of importSpecifiers(await fs.readFile(file, 'utf8'))) {
 					if (specifier.startsWith('.') && !resolvesOnDisk(file, specifier)) {
 						unresolved.push(`${path.relative(root, file)} → ${specifier}`);
 					}
-					if (/^(?:src\/lib|\$lib)\/(?:greater|components)(?:\/|$)/.test(specifier)) {
+					if (
+						bareAliasRoots.some(
+							(aliasRoot: string) =>
+								specifier === aliasRoot || specifier.startsWith(`${aliasRoot}/`)
+						)
+					) {
 						bareAliasTargets.push(`${path.relative(root, file)} → ${specifier}`);
+					}
+					if (/^@equaltoai\/greater-components(?:-|\/|$)/.test(specifier)) {
+						bareGreaterPackageSpecifiers.push(`${path.relative(root, file)} → ${specifier}`);
 					}
 				}
 			}
 			expect(unresolved).toEqual([]);
 			expect(bareAliasTargets).toEqual([]);
+			expect(bareGreaterPackageSpecifiers).toEqual([]);
 
 			// Every file the catalog claims for `review` has to land, so a catalog
 			// entry that stops installing fails here rather than in a consumer.

--- a/packages/cli/tests/e2e/review-command-install.test.ts
+++ b/packages/cli/tests/e2e/review-command-install.test.ts
@@ -332,4 +332,37 @@ describe('greater add review (real command)', () => {
 			await fs.remove(root);
 		}
 	}, 300_000);
+
+	it('preserves a conflicting optional dependency pin byte-for-byte', async () => {
+		const root = await createScratchProject();
+
+		try {
+			const packageJsonPath = path.join(root, 'package.json');
+			const fixtureManifest = await fs.readJson(packageJsonPath);
+			const viemPin = fixtureManifest.devDependencies.viem;
+			delete fixtureManifest.devDependencies.viem;
+			fixtureManifest.optionalDependencies = {
+				...(fixtureManifest.optionalDependencies ?? {}),
+				viem: viemPin,
+			};
+			await fs.writeJson(packageJsonPath, fixtureManifest, { spaces: 2 });
+
+			await execa('node', [CLI_BIN, 'init', '--yes', '--face', 'blog', '--cwd', root], {
+				env: CLI_ENV,
+			});
+			const manifestBeforeAdd = await fs.readFile(packageJsonPath, 'utf8');
+			expect(JSON.parse(manifestBeforeAdd).optionalDependencies.viem).toBe('^2.47.14');
+
+			const addResult = await execa('node', [CLI_BIN, 'add', '--yes', 'review', '--cwd', root], {
+				env: CLI_ENV,
+			});
+
+			expect(await fs.readFile(packageJsonPath, 'utf8')).toBe(manifestBeforeAdd);
+			expect(`${addResult.stdout}\n${addResult.stderr}`).toContain(
+				'viem: manifest ^2.47.14; Greater requires ^2.55.10'
+			);
+		} finally {
+			await fs.remove(root);
+		}
+	}, 300_000);
 });

--- a/packages/cli/tests/e2e/review-command-install.test.ts
+++ b/packages/cli/tests/e2e/review-command-install.test.ts
@@ -39,6 +39,8 @@ const FIXTURE_TEMPLATE_ROOT = path.resolve(__dirname, '../fixtures/cli-fixture')
 const TMP_ROOT = path.resolve(__dirname, '../.tmp');
 const REPO_ROOT = path.resolve(CLI_ROOT, '../../');
 const TSC_BIN = path.join(REPO_ROOT, 'node_modules/.bin/tsc');
+const SVELTE_KIT_BIN = path.join(CLI_ROOT, 'node_modules/.bin/svelte-kit');
+const VITE_BIN = path.join(CLI_ROOT, 'node_modules/.bin/vite');
 
 /** Runs the CLI against this checkout instead of the network. */
 const CLI_ENV = { ...process.env, GREATER_CLI_LOCAL_REPO_ROOT: REPO_ROOT };
@@ -122,8 +124,57 @@ async function linkWorkspaceDependencies(root: string): Promise<void> {
 	}
 }
 
+async function getFilesRecursively(dir: string): Promise<string[]> {
+	const entries = await fs.readdir(dir, { withFileTypes: true });
+	const files: string[] = [];
+	for (const entry of entries) {
+		const fullPath = path.join(dir, entry.name);
+		if (entry.isDirectory()) files.push(...(await getFilesRecursively(fullPath)));
+		else files.push(fullPath);
+	}
+	return files;
+}
+
+function importSpecifiers(content: string): string[] {
+	const specifiers: string[] = [];
+	const executableContent = content
+		.replace(/\/\*[\s\S]*?\*\//g, '')
+		.replace(/^\s*\/\/.*$/gm, '')
+		.replace(/<!--[\s\S]*?-->/g, '');
+	for (const pattern of [
+		/(?:^|[;\n\r])\s*import\s+[^'"]+?from\s*(['"])([^'"]+)\1/g,
+		/(?:^|[;\n\r])\s*import\s*(['"])([^'"]+)\1/g,
+		/(?:^|[;\n\r])\s*export\s+[^'"]+?from\s*(['"])([^'"]+)\1/g,
+		/(?<![\w$])import\s*\(\s*(['"])([^'"]+)\1\s*\)/g,
+		/@import\s+(?:url\s*\(\s*)?(['"])([^'"]+)\1(?:\s*\))?/g,
+	]) {
+		let match: RegExpExecArray | null;
+		while ((match = pattern.exec(executableContent)) !== null) {
+			if (match[2]) specifiers.push(match[2]);
+		}
+	}
+	return specifiers;
+}
+
+function resolvesOnDisk(fromFile: string, specifier: string): boolean {
+	const cleanSpecifier = specifier.replace(/[?#].*$/, '');
+	const base = path.resolve(path.dirname(fromFile), cleanSpecifier);
+	const withoutExt = base.replace(/\.(?:[cm]?[jt]s|svelte|css)$/, '');
+	return [
+		base,
+		`${withoutExt}.ts`,
+		`${withoutExt}.js`,
+		`${withoutExt}.svelte`,
+		`${withoutExt}.svelte.ts`,
+		`${withoutExt}.css`,
+		path.join(base, 'index.ts'),
+		path.join(base, 'index.js'),
+		path.join(base, 'index.svelte'),
+	].some((candidate) => fs.existsSync(candidate));
+}
+
 describe('greater add review (real command)', () => {
-	it('installs the dependency closure, rewrites type imports, and type-checks', async () => {
+	it('preserves pins and installs a relative-import tree that type-checks and builds', async () => {
 		const root = await createScratchProject();
 
 		try {
@@ -160,6 +211,25 @@ describe('greater add review (real command)', () => {
 			const libDir = path.join(root, 'src/lib');
 			expect(await fs.pathExists(path.join(libDir, 'blog-types.ts'))).toBe(true);
 
+			// Every Greater-internal specifier emitted by the real add pipeline is
+			// relative and resolves in the installed tree. No tsconfig/vite alias is
+			// added for Greater internals; the stock SvelteKit fixture stays untouched.
+			const unresolved: string[] = [];
+			const bareAliasTargets: string[] = [];
+			for (const file of await getFilesRecursively(libDir)) {
+				if (!/\.(?:svelte|[cm]?[jt]s|css)$/.test(file)) continue;
+				for (const specifier of importSpecifiers(await fs.readFile(file, 'utf8'))) {
+					if (specifier.startsWith('.') && !resolvesOnDisk(file, specifier)) {
+						unresolved.push(`${path.relative(root, file)} → ${specifier}`);
+					}
+					if (/^(?:src\/lib|\$lib)\/(?:greater|components)(?:\/|$)/.test(specifier)) {
+						bareAliasTargets.push(`${path.relative(root, file)} → ${specifier}`);
+					}
+				}
+			}
+			expect(unresolved).toEqual([]);
+			expect(bareAliasTargets).toEqual([]);
+
 			// Every file the catalog claims for `review` has to land, so a catalog
 			// entry that stops installing fails here rather than in a consumer.
 			const reviewDir = path.join(libDir, 'components/Review');
@@ -187,6 +257,20 @@ describe('greater add review (real command)', () => {
 			//     Relative `.svelte` specifiers are covered by the directory
 			//     listing above and by `vendored-blog-install.test.ts`.
 			await linkWorkspaceDependencies(root);
+			await fs.writeFile(
+				path.join(root, 'src/routes/+page.svelte'),
+				[
+					'<script lang="ts">',
+					"\timport QueueCard from '$lib/components/Review/QueueCard.svelte';",
+					"\timport * as greaterUtils from '$lib/greater/utils';",
+					'\tconst installedComponent = QueueCard;',
+					"\tconst className = Object.keys(greaterUtils).length ? 'greater-resolution-proof' : '';",
+					'</script>',
+					'',
+					"<p class={className}>{installedComponent ? 'vendored imports resolve' : 'missing'}</p>",
+					'',
+				].join('\n')
+			);
 
 			await fs.writeFile(
 				path.join(libDir, 'review-shims.d.ts'),
@@ -236,6 +320,14 @@ describe('greater add review (real command)', () => {
 
 			expect(unresolvedRelative).toEqual([]);
 			expect(output, 'the installed Review tree failed to type-check').toBe('');
+
+			// Standard SvelteKit + Vite build, using only the configuration `init`
+			// scaffolded in the fresh fixture.
+			await execa(SVELTE_KIT_BIN, ['sync'], { cwd: root });
+			const build = await execa(VITE_BIN, ['build'], { cwd: root, reject: false });
+			expect(build.exitCode, `fresh consumer build failed:\n${build.stdout}\n${build.stderr}`).toBe(
+				0
+			);
 		} finally {
 			await fs.remove(root);
 		}

--- a/packages/cli/tests/e2e/review-command-install.test.ts
+++ b/packages/cli/tests/e2e/review-command-install.test.ts
@@ -259,12 +259,9 @@ function resolvesOnDisk(fromFile: string, specifier: string): boolean {
 
 describe('greater add review (real command)', () => {
 	it('keeps Svelte markup apostrophes from hiding script imports in the sweep', () => {
-		const source = [
-			"<p>Sam's post</p>",
-			'<script>',
-			"import 'bare-package';",
-			'</script>',
-		].join('\n');
+		const source = ["<p>Sam's post</p>", '<script>', "import 'bare-package';", '</script>'].join(
+			'\n'
+		);
 
 		expect(importSpecifiers(source, 'synthetic.svelte')).toEqual(['bare-package']);
 	});

--- a/packages/cli/tests/registry-generated-dependencies.test.ts
+++ b/packages/cli/tests/registry-generated-dependencies.test.ts
@@ -1,4 +1,5 @@
 import fs from 'node:fs';
+import { validRange } from 'semver';
 import { describe, expect, it } from 'vitest';
 
 interface RegistryDependency {
@@ -46,5 +47,23 @@ describe('generated Registry dependencies', () => {
 		expect(
 			allDependencies().filter((dependency) => dependency.name.slice(1).includes('@'))
 		).toEqual([]);
+	});
+
+	it('contains only parseable registry ranges and none of the historical fabricated versions', () => {
+		const dependencies = allDependencies();
+		const fabricated = new Set(['vite@^10.0.1', '@types/node@^3.1.0', 'typescript@^6.0.0']);
+
+		for (const dependency of dependencies) {
+			expect(
+				dependency.version === 'latest' || validRange(dependency.version),
+				`${dependency.name} has an invalid registry range: ${dependency.version}`
+			).toBeTruthy();
+			const specifier = `${dependency.name}@${dependency.version}`;
+			expect(fabricated.has(specifier), `registry retained fabricated ${specifier}`).toBe(false);
+		}
+
+		expect(dependencies.filter(({ name }) => name === 'vite')).toEqual([]);
+		expect(dependencies.filter(({ name }) => name === '@types/node')).toEqual([]);
+		expect(dependencies.filter(({ name }) => name === 'typescript')).toEqual([]);
 	});
 });

--- a/packages/cli/tests/registry-generated-dependencies.test.ts
+++ b/packages/cli/tests/registry-generated-dependencies.test.ts
@@ -116,6 +116,10 @@ describe('generated Registry dependencies', () => {
 		const dependencies = allDependencies();
 		const generatedRanges = generatedDependencyRanges();
 
+		expect(dependencies.filter(({ name }) => name === 'vite')).toEqual([]);
+		expect(dependencies.filter(({ name }) => name === '@types/node')).toEqual([]);
+		expect(dependencies.filter(({ name }) => name === 'typescript')).toEqual([]);
+
 		for (const dependency of dependencies) {
 			expect(
 				dependency.version === 'latest' || validRange(dependency.version),

--- a/packages/cli/tests/registry-generated-dependencies.test.ts
+++ b/packages/cli/tests/registry-generated-dependencies.test.ts
@@ -1,4 +1,6 @@
 import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
 import { validRange } from 'semver';
 import { describe, expect, it } from 'vitest';
 
@@ -18,6 +20,16 @@ interface RegistryIndex {
 	shared: Record<string, RegistryEntry>;
 }
 
+interface PackageManifest {
+	name: string;
+	version: string;
+	dependencies?: Record<string, string>;
+	devDependencies?: Record<string, string>;
+	peerDependencies?: Record<string, string>;
+}
+
+const PACKAGES_ROOT = fileURLToPath(new URL('../../', import.meta.url));
+
 const registry = JSON.parse(
 	fs.readFileSync(new URL('../../../registry/index.json', import.meta.url), 'utf8')
 ) as RegistryIndex;
@@ -28,6 +40,57 @@ function allDependencies(): RegistryDependency[] {
 		...Object.values(registry.faces),
 		...Object.values(registry.shared),
 	].flatMap((entry) => [...(entry.dependencies ?? []), ...(entry.peerDependencies ?? [])]);
+}
+
+function readPackageManifests(dir: string): PackageManifest[] {
+	const packageJsonPath = path.join(dir, 'package.json');
+	if (fs.existsSync(packageJsonPath)) {
+		return [JSON.parse(fs.readFileSync(packageJsonPath, 'utf8')) as PackageManifest];
+	}
+
+	return fs
+		.readdirSync(dir, { withFileTypes: true })
+		.filter(
+			(entry) => entry.isDirectory() && entry.name !== 'node_modules' && entry.name !== 'dist'
+		)
+		.flatMap((entry) => readPackageManifests(path.join(dir, entry.name)));
+}
+
+/**
+ * The generator resolves registry ranges from package manifests and workspace
+ * versions. Mirror that source of truth so this guard stays offline while
+ * rejecting any syntactically valid range that generation could not produce.
+ */
+function generatedDependencyRanges(): Map<string, Set<string>> {
+	const manifests = readPackageManifests(PACKAGES_ROOT);
+	const workspaceVersions = new Map(manifests.map(({ name, version }) => [name, version]));
+	const ranges = new Map<string, Set<string>>();
+	const add = (name: string, version: string): void => {
+		const versions = ranges.get(name) ?? new Set<string>();
+		versions.add(version);
+		ranges.set(name, versions);
+	};
+
+	for (const manifest of manifests) {
+		add(manifest.name, manifest.version);
+		const shortName = manifest.name.replace(/^@equaltoai\/greater-components-/, '');
+		if (shortName !== manifest.name) add(shortName, manifest.version);
+
+		for (const section of [
+			manifest.dependencies,
+			manifest.peerDependencies,
+			manifest.devDependencies,
+		]) {
+			for (const [name, declaredVersion] of Object.entries(section ?? {})) {
+				const version = declaredVersion.startsWith('workspace:')
+					? (workspaceVersions.get(name) ?? declaredVersion)
+					: declaredVersion;
+				add(name, version);
+			}
+		}
+	}
+
+	return ranges;
 }
 
 describe('generated Registry dependencies', () => {
@@ -49,21 +112,26 @@ describe('generated Registry dependencies', () => {
 		).toEqual([]);
 	});
 
-	it('contains only parseable registry ranges and none of the historical fabricated versions', () => {
+	it('contains only parseable ranges produced from offline package manifests', () => {
 		const dependencies = allDependencies();
-		const fabricated = new Set(['vite@^10.0.1', '@types/node@^3.1.0', 'typescript@^6.0.0']);
+		const generatedRanges = generatedDependencyRanges();
 
 		for (const dependency of dependencies) {
 			expect(
 				dependency.version === 'latest' || validRange(dependency.version),
 				`${dependency.name} has an invalid registry range: ${dependency.version}`
 			).toBeTruthy();
-			const specifier = `${dependency.name}@${dependency.version}`;
-			expect(fabricated.has(specifier), `registry retained fabricated ${specifier}`).toBe(false);
-		}
+			if (dependency.version === 'latest') continue;
 
-		expect(dependencies.filter(({ name }) => name === 'vite')).toEqual([]);
-		expect(dependencies.filter(({ name }) => name === '@types/node')).toEqual([]);
-		expect(dependencies.filter(({ name }) => name === 'typescript')).toEqual([]);
+			const allowed = generatedRanges.get(dependency.name);
+			expect(
+				allowed,
+				`${dependency.name}@${dependency.version} has no package-manifest source`
+			).toBeDefined();
+			expect(
+				[...(allowed ?? [])],
+				`${dependency.name}@${dependency.version} is not generated from its package-manifest ranges`
+			).toContain(dependency.version);
+		}
 	});
 });

--- a/packages/cli/tests/registry-generated-dependencies.test.ts
+++ b/packages/cli/tests/registry-generated-dependencies.test.ts
@@ -64,6 +64,8 @@ function readPackageManifests(dir: string): PackageManifest[] {
 function generatedDependencyRanges(): Map<string, Set<string>> {
 	const manifests = readPackageManifests(PACKAGES_ROOT);
 	const workspaceVersions = new Map(manifests.map(({ name, version }) => [name, version]));
+	// Deliberately pool the union of declared ranges by dependency name across
+	// every workspace manifest; package ownership is not encoded in Registry entries.
 	const ranges = new Map<string, Set<string>>();
 	const add = (name: string, version: string): void => {
 		const versions = ranges.get(name) ?? new Set<string>();

--- a/packages/cli/tests/transform.test.ts
+++ b/packages/cli/tests/transform.test.ts
@@ -457,6 +457,53 @@ describe('transformCssFileImports', () => {
 	});
 });
 
+describe('vendored relative import emission', () => {
+	const config = createTestConfig({
+		aliases: {
+			...createTestConfig().aliases,
+			components: 'src/lib/components',
+			utils: 'src/lib/utils',
+			ui: 'src/lib/components/ui',
+			lib: 'src/lib',
+			hooks: 'src/lib/primitives',
+			greater: 'src/lib/greater',
+		},
+	});
+
+	it('rewrites cross-directory core and shared imports relative to the installed file', () => {
+		const result = transformImports(
+			[
+				"import { cn } from '@equaltoai/greater-components-utils';",
+				"import { session } from '@equaltoai/greater-components/shared/auth';",
+			].join('\n'),
+			config,
+			'components/Article/Card.svelte.ts',
+			{
+				sourceFilePath: '/consumer/src/lib/components/Article/Card.svelte.ts',
+				consumerRoot: '/consumer',
+			}
+		);
+
+		expect(result.content).toContain("from '../../greater/utils'");
+		expect(result.content).toContain("from '../auth'");
+		expect(result.content).not.toContain('src/lib/');
+	});
+
+	it('rewrites CSS package imports relative to the installed stylesheet', () => {
+		const result = transformImports(
+			"@import '@equaltoai/greater-components-tokens/theme.css';",
+			config,
+			'primitives/style.css',
+			{
+				sourceFilePath: '/consumer/src/lib/greater/primitives/style.css',
+				consumerRoot: '/consumer',
+			}
+		);
+
+		expect(result.content).toBe("@import '../tokens/theme.css';");
+	});
+});
+
 describe('transformSvelteImports', () => {
 	const config = createTestConfig();
 

--- a/packages/cli/tests/utils.test.ts
+++ b/packages/cli/tests/utils.test.ts
@@ -198,15 +198,32 @@ describe('package utilities', () => {
 		expect(await isDependencyInstalled('viem', '/repo', '^2.55.10')).toBe(true);
 	});
 
-	it('marks an installed dependency below the registry floor for upgrade', async () => {
-		const { getMissingDependencies, isDependencyInstalled } =
+	it('separates a consumer pin below the registry floor from absent dependencies', async () => {
+		const { getDependencyInstallPlan, getMissingDependencies, isDependencyInstalled } =
 			await import('../src/utils/packages.js');
 		fsStore.set('/repo/package.json', JSON.stringify({ dependencies: { viem: '2.51.3' } }));
 
 		expect(await isDependencyInstalled('viem', '/repo', '^2.55.10')).toBe(false);
-		expect(await getMissingDependencies([{ name: 'viem', version: '^2.55.10' }], '/repo')).toEqual([
-			{ name: 'viem', version: '^2.55.10' },
-		]);
+		expect(await getMissingDependencies([{ name: 'viem', version: '^2.55.10' }], '/repo')).toEqual(
+			[]
+		);
+		expect(
+			await getDependencyInstallPlan(
+				[
+					{ name: 'viem', version: '^2.55.10' },
+					{ name: 'new-package', version: '^1.2.3' },
+				],
+				'/repo'
+			)
+		).toEqual({
+			missing: [{ name: 'new-package', version: '^1.2.3' }],
+			drift: [
+				{
+					dependency: { name: 'viem', version: '^2.55.10' },
+					declaration: '2.51.3',
+				},
+			],
+		});
 	});
 
 	it('treats non-semver declarations as present without installing', async () => {

--- a/packages/cli/tests/utils.test.ts
+++ b/packages/cli/tests/utils.test.ts
@@ -138,6 +138,28 @@ describe('file utilities', () => {
 		expect(await detectProjectType('/missing')).toBe('unknown');
 		expect(await getSvelteVersion('/missing')).toBeNull();
 	});
+
+	it('detects project tooling declared as optional dependencies', async () => {
+		const { detectProjectDetails, getSvelteVersion } = await import('../src/utils/files.js');
+		fsStore.set(
+			'/optional/package.json',
+			JSON.stringify({
+				optionalDependencies: {
+					'@sveltejs/kit': '^2.49.2',
+					svelte: '^5.55.7',
+					typescript: '^6.0.2',
+					vite: '^8.0.16',
+				},
+			})
+		);
+		fsStore.set('/optional/svelte.config.js', 'export default {}');
+
+		expect(await detectProjectDetails('/optional')).toMatchObject({
+			type: 'sveltekit',
+			hasTypeScript: true,
+		});
+		expect(await getSvelteVersion('/optional')).toBe(5);
+	});
 });
 
 describe('package utilities', () => {
@@ -198,33 +220,47 @@ describe('package utilities', () => {
 		expect(await isDependencyInstalled('viem', '/repo', '^2.55.10')).toBe(true);
 	});
 
-	it('separates a consumer pin below the registry floor from absent dependencies', async () => {
-		const { getDependencyInstallPlan, getMissingDependencies, isDependencyInstalled } =
-			await import('../src/utils/packages.js');
-		fsStore.set('/repo/package.json', JSON.stringify({ dependencies: { viem: '2.51.3' } }));
+	it.each(['dependencies', 'devDependencies', 'peerDependencies', 'optionalDependencies'] as const)(
+		'classifies a consumer pin in %s as declared drift without rewriting it',
+		async (section) => {
+			const {
+				getDependencyDeclarationStatus,
+				getDependencyInstallPlan,
+				getMissingDependencies,
+				isDependencyInstalled,
+			} = await import('../src/utils/packages.js');
+			const manifest = JSON.stringify({ [section]: { viem: '^2.47.14' } });
+			fsStore.set('/repo/package.json', manifest);
 
-		expect(await isDependencyInstalled('viem', '/repo', '^2.55.10')).toBe(false);
-		expect(await getMissingDependencies([{ name: 'viem', version: '^2.55.10' }], '/repo')).toEqual(
-			[]
-		);
-		expect(
-			await getDependencyInstallPlan(
-				[
-					{ name: 'viem', version: '^2.55.10' },
-					{ name: 'new-package', version: '^1.2.3' },
+			expect(await getDependencyDeclarationStatus('viem', '/repo', '^2.55.10')).toMatchObject({
+				present: true,
+				installed: false,
+				declaration: '^2.47.14',
+			});
+			expect(await isDependencyInstalled('viem', '/repo', '^2.55.10')).toBe(false);
+			expect(
+				await getMissingDependencies([{ name: 'viem', version: '^2.55.10' }], '/repo')
+			).toEqual([]);
+			expect(
+				await getDependencyInstallPlan(
+					[
+						{ name: 'viem', version: '^2.55.10' },
+						{ name: 'new-package', version: '^1.2.3' },
+					],
+					'/repo'
+				)
+			).toEqual({
+				missing: [{ name: 'new-package', version: '^1.2.3' }],
+				drift: [
+					{
+						dependency: { name: 'viem', version: '^2.55.10' },
+						declaration: '^2.47.14',
+					},
 				],
-				'/repo'
-			)
-		).toEqual({
-			missing: [{ name: 'new-package', version: '^1.2.3' }],
-			drift: [
-				{
-					dependency: { name: 'viem', version: '^2.55.10' },
-					declaration: '2.51.3',
-				},
-			],
-		});
-	});
+			});
+			expect(fsStore.get('/repo/package.json')).toBe(manifest);
+		}
+	);
 
 	it('treats non-semver declarations as present without installing', async () => {
 		const { getMissingDependencies, isDependencyInstalled } =

--- a/packages/greater-components/package.json
+++ b/packages/greater-components/package.json
@@ -472,7 +472,7 @@
     "shiki": "^4.0.2",
     "tabbable": "^6.4.0",
     "unified": "^11.0.5",
-    "viem": "^2.47.14",
+    "viem": "^2.55.10",
     "zod": "^4.3.6"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -929,8 +929,8 @@ importers:
         specifier: ^11.0.5
         version: 11.0.5
       viem:
-        specifier: ^2.47.14
-        version: 2.47.14(typescript@6.0.2)(zod@4.3.6)
+        specifier: ^2.55.10
+        version: 2.55.10(typescript@6.0.2)(zod@4.3.6)
       zod:
         specifier: ^4.3.6
         version: 4.3.6
@@ -5514,14 +5514,6 @@ packages:
     resolution: {integrity: sha512-qFOyK5PjiWZd+QQIh+1jhdb9LpxTF0qs7Pm8o5QHYZ0M3vKqSqzsZaEB6oWlxZ+q2sJBMI/Ktgd2N5ZwQoRHfg==}
     engines: {node: '>= 0.4'}
 
-  ox@0.14.15:
-    resolution: {integrity: sha512-3TubCmbKen/cuZQzX0qDbOS5lojjdSZ90lqKxWIDWd5siuJ0IJBaTXMYs8eMPLcraqnOwGZazz3apHPGiRCkGQ==}
-    peerDependencies:
-      typescript: '>=5.4.0'
-    peerDependenciesMeta:
-      typescript:
-        optional: true
-
   ox@0.14.33:
     resolution: {integrity: sha512-rooA/4o7bBof4Ge2VH/eovfNPb/AEEYyrNj03wggc55g5HZD8Pjs/OeWhttgjic3dDcqn0r29bDuvQEdTiUemQ==}
     peerDependencies:
@@ -6416,14 +6408,6 @@ packages:
 
   vfile@6.0.3:
     resolution: {integrity: sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q==}
-
-  viem@2.47.14:
-    resolution: {integrity: sha512-PHmJF1dfa9HEfrVshFXFkixzh/22Z3VFXN1omeFfjMoOFDGQkghsRdDW+KcE29gzM7KZ+MC04L+xpbm2G/kOkw==}
-    peerDependencies:
-      typescript: '>=5.0.4'
-    peerDependenciesMeta:
-      typescript:
-        optional: true
 
   viem@2.55.10:
     resolution: {integrity: sha512-Q9Ba+/ma81U2M5o5P2AQ7Ux8rTIwmCZvUcr8rKdQ22bV0IBFHllM2m5gWDP8hFaUN2nH2oW3QG44amRazflYNQ==}
@@ -11108,21 +11092,6 @@ snapshots:
       object-keys: 1.1.1
       safe-push-apply: 1.0.0
 
-  ox@0.14.15(typescript@6.0.2)(zod@4.3.6):
-    dependencies:
-      '@adraffy/ens-normalize': 1.11.1
-      '@noble/ciphers': 1.3.0
-      '@noble/curves': 1.9.1
-      '@noble/hashes': 1.8.0
-      '@scure/bip32': 1.7.0
-      '@scure/bip39': 1.6.0
-      abitype: 1.2.3(typescript@6.0.2)(zod@4.3.6)
-      eventemitter3: 5.0.1
-    optionalDependencies:
-      typescript: 6.0.2
-    transitivePeerDependencies:
-      - zod
-
   ox@0.14.33(typescript@6.0.2)(zod@4.3.6):
     dependencies:
       '@adraffy/ens-normalize': 1.11.1
@@ -12119,23 +12088,6 @@ snapshots:
     dependencies:
       '@types/unist': 3.0.3
       vfile-message: 4.0.3
-
-  viem@2.47.14(typescript@6.0.2)(zod@4.3.6):
-    dependencies:
-      '@noble/curves': 1.9.1
-      '@noble/hashes': 1.8.0
-      '@scure/bip32': 1.7.0
-      '@scure/bip39': 1.6.0
-      abitype: 1.2.3(typescript@6.0.2)(zod@4.3.6)
-      isows: 1.0.7(ws@8.21.1)
-      ox: 0.14.15(typescript@6.0.2)(zod@4.3.6)
-      ws: 8.21.1
-    optionalDependencies:
-      typescript: 6.0.2
-    transitivePeerDependencies:
-      - bufferutil
-      - utf-8-validate
-      - zod
 
   viem@2.55.10(typescript@6.0.2)(zod@4.3.6):
     dependencies:


### PR DESCRIPTION
Batch B of the greater v0.13.0 staging train: two `greater add` CLI defects surfaced by contentus M1 consumption evidence. Implemented by codex; adversarial review by claude follows in-thread.

Closes #918
Closes #919

## #918 — `greater add` rewrites consumer-owned package.json pins

Root cause: `packages/cli/src/utils/packages.ts` conflated an absent dependency with a present declaration below Greater's required floor; `add` passed both to `installDependencies`, letting the package manager rewrite the consumer's `package.json`.

Fix: explicit `present` status + install plan (`packages.ts:192-213`). Only entirely absent dependencies are installed; existing conflicting declarations are never rewritten. `greater add` now warns with name, consumer declaration, and required floor; `greater doctor` reports `Manifest vs Required Floors` drift (`doctor.ts:345-354`). Warn-only — no hard-fail case identified. The historical fabricated-version path (nonexistent ranges like `vite ^10.0.1`) is confirmed already closed by the registry range/freshness gates from #942, with new regression coverage rejecting those exact ranges.

Integration proof: the real `greater add review` fixture preserves the consumer `package.json` byte-for-byte (including `viem: ^2.47.14`) while warning that Greater requires `^2.55.10`. Fault injection: reverting the fix flips the pin and the test fails on `package.json bytes changed`.

## #919 — vendored imports emitted as bare, unresolvable specifiers

Root cause: `packages/cli/src/utils/transform.ts` returned configured alias targets directly without knowing the installed source-file location, so filesystem-style targets (`src/lib/greater/utils`) became bare specifiers no consumer setup resolves.

Fix (chosen approach: **relative imports** — no merge-sensitive vite/tsconfig scaffolding): installed-file transform context + relative-path calculation (`transform.ts:322-367`), covering static, side-effect, dynamic, re-export, Svelte, and CSS `@import` forms, threaded through add, update, and diff. A real fixture sweeps every emitted vendored specifier, verifies on-disk resolution, typechecks, and performs a standard SvelteKit/Vite production build with zero additional configuration. Fault injection: removing installed-file context emits 23 forbidden alias targets and the test fails.

## Verification

- CLI suite: 850 → 853 tests, 45/45 files passing.
- Root `pnpm build` exit 0; `pnpm format:check` clean (first and last).
- Both commits G-signed `72D6153132D52023`, DCO clean, `Refs #918`/`Refs #919`.

**Release impact (semver): patch** — bug fixes to CLI install/vendoring behavior, no API surface change.
