### PR TITLE
test: micro-PR — sentinel assertion cleanup, umbrella probe isolation, sweep comment ordering

### DIFF
--- a/packages/cli/tests/e2e/review-command-install.test.ts
+++ b/packages/cli/tests/e2e/review-command-install.test.ts
@@ -216,12 +216,14 @@ function maskSvelteMarkup(content: string): string {
 
 function importSpecifiers(content: string, filePath?: string): string[] {
 	const specifiers: string[] = [];
-	// Svelte markup is not JavaScript: only script/style bodies may influence
-	// string and comment state for executable import matches.
-	const executableSource = filePath?.endsWith('.svelte') ? maskSvelteMarkup(content) : content;
-	const executableContent = executableSource.replace(/<!--[\s\S]*?-->/g, (comment) =>
+	const commentStripped = content.replace(/<!--[\s\S]*?-->/g, (comment) =>
 		comment.replace(/[^\n]/g, ' ')
 	);
+	// Svelte markup is not JavaScript: only script/style bodies may influence
+	// string and comment state for executable import matches.
+	const executableContent = filePath?.endsWith('.svelte')
+		? maskSvelteMarkup(commentStripped)
+		: commentStripped;
 	for (const pattern of [
 		/(?:^|[;\n\r])\s*import\s+[^'"]+?from\s*(['"])([^'"]+)\1/g,
 		/(?:^|[;\n\r])\s*import\s*(['"])([^'"]+)\1/g,
@@ -264,6 +266,21 @@ describe('greater add review (real command)', () => {
 		);
 
 		expect(importSpecifiers(source, 'synthetic.svelte')).toEqual(['bare-package']);
+	});
+
+	it('ignores imports inside commented-out Svelte script blocks', () => {
+		const source = [
+			'<!--',
+			'<script>',
+			"import 'decoy';",
+			'</script>',
+			'-->',
+			'<script>',
+			"import 'pkg-real';",
+			'</script>',
+		].join('\n');
+
+		expect(importSpecifiers(source, 'synthetic.svelte')).toEqual(['pkg-real']);
 	});
 
 	it('preserves pins and installs a relative-import tree that type-checks and builds', async () => {

--- a/packages/faces/blog/scripts/assert-article-dependency-boundary.mjs
+++ b/packages/faces/blog/scripts/assert-article-dependency-boundary.mjs
@@ -6,53 +6,55 @@ import { fileURLToPath, pathToFileURL } from 'node:url';
 const packageDir = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
 const repoRoot = path.resolve(packageDir, '../../..');
 const umbrellaDir = path.join(repoRoot, 'packages', 'greater-components');
-const articleDir = path.join(packageDir, 'dist', 'components', 'Article');
-const editorRoot = path.join(packageDir, 'dist', 'components', 'Editor', 'Root.js');
-const articleModules = fs
-	.readdirSync(articleDir)
-	.filter((name) => name.endsWith('.js'))
-	.map((name) => ({ name, content: fs.readFileSync(path.join(articleDir, name), 'utf8') }));
-const articleGraph = articleModules.map(({ content }) => content).join('\n');
-const forbiddenReadingDependencies = [
-	'remark',
-	'remark-parse',
-	'shiki',
-	'mdast',
-	'html-to-markdown',
-];
+if (!process.argv.includes('--umbrella')) {
+	const articleDir = path.join(packageDir, 'dist', 'components', 'Article');
+	const editorRoot = path.join(packageDir, 'dist', 'components', 'Editor', 'Root.js');
+	const articleModules = fs
+		.readdirSync(articleDir)
+		.filter((name) => name.endsWith('.js'))
+		.map((name) => ({ name, content: fs.readFileSync(path.join(articleDir, name), 'utf8') }));
+	const articleGraph = articleModules.map(({ content }) => content).join('\n');
+	const forbiddenReadingDependencies = [
+		'remark',
+		'remark-parse',
+		'shiki',
+		'mdast',
+		'html-to-markdown',
+	];
 
-if (!articleGraph.includes('"@equaltoai/greater-components-utils/sanitizeHtml"')) {
-	console.error('Article reading output does not import the sanctioned sanitizeHtml subpath.');
-	process.exit(1);
+	if (!articleGraph.includes('"@equaltoai/greater-components-utils/sanitizeHtml"')) {
+		console.error('Article reading output does not import the sanctioned sanitizeHtml subpath.');
+		process.exit(1);
+	}
+
+	if (!articleGraph.includes('"@equaltoai/greater-components-utils/relativeTime"')) {
+		console.error('Article reading output does not import the sanctioned relativeTime subpath.');
+		process.exit(1);
+	}
+
+	if (/from "@equaltoai\/greater-components-utils"/.test(articleGraph)) {
+		console.error('Article reading output still resolves the utils barrel.');
+		process.exit(1);
+	}
+
+	const leaked = forbiddenReadingDependencies.filter((dependency) =>
+		articleGraph.includes(dependency)
+	);
+	if (leaked.length > 0) {
+		console.error(`Article reading output resolves editor-only dependencies: ${leaked.join(', ')}`);
+		process.exit(1);
+	}
+
+	const editorGraph = fs.readFileSync(editorRoot, 'utf8');
+	if (!editorGraph.includes('"@equaltoai/greater-components-content"')) {
+		console.error('Editor output no longer retains its content dependency.');
+		process.exit(1);
+	}
+
+	console.log(
+		`Article dependency boundary holds across ${articleModules.length} reading modules: no remark/shiki/mdast graph; editor content dependency retained.`
+	);
 }
-
-if (!articleGraph.includes('"@equaltoai/greater-components-utils/relativeTime"')) {
-	console.error('Article reading output does not import the sanctioned relativeTime subpath.');
-	process.exit(1);
-}
-
-if (/from "@equaltoai\/greater-components-utils"/.test(articleGraph)) {
-	console.error('Article reading output still resolves the utils barrel.');
-	process.exit(1);
-}
-
-const leaked = forbiddenReadingDependencies.filter((dependency) =>
-	articleGraph.includes(dependency)
-);
-if (leaked.length > 0) {
-	console.error(`Article reading output resolves editor-only dependencies: ${leaked.join(', ')}`);
-	process.exit(1);
-}
-
-const editorGraph = fs.readFileSync(editorRoot, 'utf8');
-if (!editorGraph.includes('"@equaltoai/greater-components-content"')) {
-	console.error('Editor output no longer retains its content dependency.');
-	process.exit(1);
-}
-
-console.log(
-	`Article dependency boundary holds across ${articleModules.length} reading modules: no remark/shiki/mdast graph; editor content dependency retained.`
-);
 
 if (process.argv.includes('--umbrella')) {
 	const cliTransformPath = path.join(repoRoot, 'packages', 'cli', 'dist', 'utils', 'transform.js');

--- a/packages/shared/messaging/tests/sanitize.test.ts
+++ b/packages/shared/messaging/tests/sanitize.test.ts
@@ -187,8 +187,6 @@ describe('messaging sanitization', () => {
 	it('pins the internal sentinel collision to the RFC 6761-reserved .invalid TLD', () => {
 		const sentinel = new URL('https://greater-sanitize.invalid/');
 
-		// Internal sentinel collisions are safe only while this host can never be delegated.
-		expect(sentinel.hostname).toMatch(/\.invalid$/u);
 		const anchor = expectOnlySafeAnchor(`<a href="${sentinel.href}">x</a>`);
 		expect(anchor.hasAttribute('rel')).toBe(false);
 	});

--- a/packages/utils/tests/sanitizeHtml.test.ts
+++ b/packages/utils/tests/sanitizeHtml.test.ts
@@ -175,8 +175,6 @@ describe('sanitizeHtml', () => {
 	it('pins the internal sentinel collision to the RFC 6761-reserved .invalid TLD', () => {
 		const sentinel = new URL('https://greater-sanitize.invalid/');
 
-		// Internal sentinel collisions are safe only while this host can never be delegated.
-		expect(sentinel.hostname).toMatch(/\.invalid$/u);
 		const anchor = expectOnlySafeAnchor(`<a href="${sentinel.href}">x</a>`);
 		expect(anchor.hasAttribute('rel')).toBe(false);
 		expect(anchor.hasAttribute('target')).toBe(false);


### PR DESCRIPTION
Test/probe-only micro-PR in the greater v0.13.0 staging train — three small review follow-ups, one commit each. Implemented by codex; adversarial review by claude follows in-thread.

Closes #961
Closes #957
Closes #960

## #961 — sanitizer sentinel test tautology

Dropped the tautological TLD assertions (they verified a test-local literal parses, not the engines' `SANITIZER_BASE_HOST`). The preferred export-and-assert approach was genuinely attempted and fault-injected — it works — but exporting touches registry-managed source (`packages/utils/src/sanitizeHtml.ts`) and the registry checksum gate rejects the stale checksum, which is out of scope here. Behavioral sentinel-collision tests preserved in both suites.

## #957 — `--umbrella` prologue build-order dependency

The blog-dist prologue in `assert-article-dependency-boundary.mjs` now runs only outside `--umbrella` mode, removing the undeclared blog→umbrella build-order coupling. Fault injection with `blog/dist` absent: umbrella mode exits 0 (post-transform resolution checks still run and pass), non-umbrella mode still exits 1 (ENOENT). Root `pnpm build` exit 0 with both modes exercised.

## #960 — sweep comment-ordering false positive

HTML comments are now stripped before Svelte markup masking in the vendored-import sweep, so a commented-out `<script>` no longer counts as executable. New regression case: commented-out `decoy` import + live `pkg-real` import → only the real one reported (fails pre-fix, passes post-fix).

## Verification

- CLI suite unfiltered: 859 → 860 (+1 regression case); sanitizer suites 254 + 248 pass.
- Root `pnpm build` exit 0; `tsc --noEmit` clean for all four touched packages; `pnpm format:check` clean first and last.
- 3/3 commits G-signed `72D6153132D52023`, DCO, `Refs #961/#957/#960`.

**Release impact (semver): none** — test/build-probe code only; no shipped surface changes.