### PR TITLE
fix(blog): replace phantom neutral token family

### DIFF
--- a/docs/faces/blog/review-workflow.md
+++ b/docs/faces/blog/review-workflow.md
@@ -176,10 +176,12 @@ New tokens are prefixed `--gr-blog-review-*`: card padding and radius, plus
 `approved` / `changes` / `pending` / `agent` background, foreground, and border
 triples, with light and dark values.
 
-Neutral steps are written as `var(--gr-color-neutral-N, var(--gr-color-gray-N))`
-because `--gr-color-neutral-*` is a bridge-level alias rather than a token the
-tokens package emits. Consumers that bridge their brand through
-`--gr-color-neutral-*` win; consumers that do not still render correctly.
+`neutral` is a selectable palette name, but `--gr-color-neutral-*` was never an
+emitted token family. This PR removes the never-functional, consumer-facing
+`var(--gr-color-neutral-N, var(--gr-color-gray-N))` bridge pattern. Consumers
+bridge neutral values through the emitted `--gr-color-gray-*` family or through
+their own component-level overrides. The repository guard rejects palette names
+used as custom-property paths so the removed pattern cannot return.
 
 ## Accessibility
 

--- a/packages/faces/artist/src/components/Artwork/AIDisclosure.svelte
+++ b/packages/faces/artist/src/components/Artwork/AIDisclosure.svelte
@@ -149,7 +149,7 @@ Consistent iconography.
 		align-items: center;
 		gap: var(--gr-spacing-scale-1);
 		padding: var(--gr-spacing-scale-1) var(--gr-spacing-scale-2);
-		background: var(--gr-artist-bg-elevated, var(--gr-color-gray-850));
+		background: var(--gr-artist-bg-elevated, var(--gr-color-gray-800));
 		border: 1px solid var(--gr-color-gray-700);
 		border-radius: var(--gr-radii-sm);
 		color: var(--gr-artist-adaptive-muted, var(--gr-color-gray-500));
@@ -199,7 +199,7 @@ Consistent iconography.
 		gap: var(--gr-spacing-scale-2);
 		margin-top: var(--gr-spacing-scale-2);
 		padding: var(--gr-spacing-scale-3);
-		background: var(--gr-artist-bg-elevated, var(--gr-color-gray-850));
+		background: var(--gr-artist-bg-elevated, var(--gr-color-gray-800));
 		border-radius: var(--gr-radii-sm);
 	}
 

--- a/packages/faces/artist/src/components/Artwork/Actions.svelte
+++ b/packages/faces/artist/src/components/Artwork/Actions.svelte
@@ -235,7 +235,7 @@ Event handlers from context.
 
 	.gr-artist-artwork-action:hover:not(:disabled) {
 		color: var(--gr-artist-adaptive-text, var(--gr-color-gray-100));
-		background: var(--gr-artist-bg-elevated, var(--gr-color-gray-850));
+		background: var(--gr-artist-bg-elevated, var(--gr-color-gray-800));
 	}
 
 	.gr-artist-artwork-action:focus-visible {

--- a/packages/faces/artist/src/components/Artwork/Attribution.svelte
+++ b/packages/faces/artist/src/components/Artwork/Attribution.svelte
@@ -139,7 +139,7 @@ REQ-PHIL-003: Prominent but doesn't compete with artwork.
 		border-radius: 50%;
 		overflow: hidden;
 		flex-shrink: 0;
-		background: var(--gr-artist-bg-elevated, var(--gr-color-gray-850));
+		background: var(--gr-artist-bg-elevated, var(--gr-color-gray-800));
 	}
 
 	.gr-artist-artwork-attribution-avatar img {

--- a/packages/faces/artist/src/components/Monetization/DirectPurchase.svelte
+++ b/packages/faces/artist/src/components/Monetization/DirectPurchase.svelte
@@ -632,7 +632,7 @@ Features:
 		justify-content: space-between;
 		align-items: center;
 		padding: var(--gr-spacing-scale-4);
-		background: var(--gr-color-gray-850);
+		background: var(--gr-color-gray-800);
 		border-radius: var(--gr-radii-md);
 	}
 
@@ -669,7 +669,7 @@ Features:
 		align-items: flex-start;
 		gap: var(--gr-spacing-scale-3);
 		padding: var(--gr-spacing-scale-4);
-		background: var(--gr-color-gray-850);
+		background: var(--gr-color-gray-800);
 		border: 2px solid var(--gr-color-gray-700);
 		border-radius: var(--gr-radii-md);
 		cursor: pointer;
@@ -781,7 +781,7 @@ Features:
 	.gr-monetization-purchase-quantity-input {
 		width: 50px;
 		padding: var(--gr-spacing-scale-2);
-		background: var(--gr-color-gray-850);
+		background: var(--gr-color-gray-800);
 		border: 1px solid var(--gr-color-gray-700);
 		border-radius: var(--gr-radii-md);
 		color: var(--gr-color-gray-100);
@@ -806,7 +806,7 @@ Features:
 		justify-content: space-between;
 		align-items: center;
 		padding: var(--gr-spacing-scale-4);
-		background: var(--gr-color-gray-850);
+		background: var(--gr-color-gray-800);
 		border-radius: var(--gr-radii-md);
 		margin-bottom: var(--gr-spacing-scale-4);
 	}
@@ -915,7 +915,7 @@ Features:
 	.gr-monetization-purchase-inquiry-input {
 		width: 100%;
 		padding: var(--gr-spacing-scale-3);
-		background: var(--gr-color-gray-850);
+		background: var(--gr-color-gray-800);
 		border: 1px solid var(--gr-color-gray-700);
 		border-radius: var(--gr-radii-md);
 		color: var(--gr-color-gray-100);

--- a/packages/faces/artist/src/components/Monetization/PremiumBadge.svelte
+++ b/packages/faces/artist/src/components/Monetization/PremiumBadge.svelte
@@ -247,7 +247,7 @@ Features:
 		left: 50%;
 		transform: translateX(-50%);
 		min-width: 200px;
-		background: var(--gr-color-gray-850);
+		background: var(--gr-color-gray-800);
 		border: 1px solid var(--gr-color-gray-700);
 		border-radius: var(--gr-radii-md);
 		padding: var(--gr-spacing-scale-3);

--- a/packages/faces/artist/src/components/Monetization/ProtectionTools.svelte
+++ b/packages/faces/artist/src/components/Monetization/ProtectionTools.svelte
@@ -593,7 +593,7 @@ Features:
 		align-items: center;
 		gap: var(--gr-spacing-scale-2);
 		padding: var(--gr-spacing-scale-4);
-		background: var(--gr-color-gray-850);
+		background: var(--gr-color-gray-800);
 		border: 1px solid var(--gr-color-gray-700);
 		border-radius: var(--gr-radii-md);
 		color: var(--gr-color-gray-300);
@@ -635,7 +635,7 @@ Features:
 		align-items: center;
 		justify-content: space-between;
 		padding: var(--gr-spacing-scale-3);
-		background: var(--gr-color-gray-850);
+		background: var(--gr-color-gray-800);
 		border-radius: var(--gr-radii-md);
 	}
 
@@ -728,7 +728,7 @@ Features:
 	.gr-monetization-protection-select {
 		width: 100%;
 		padding: var(--gr-spacing-scale-3);
-		background: var(--gr-color-gray-850);
+		background: var(--gr-color-gray-800);
 		border: 1px solid var(--gr-color-gray-700);
 		border-radius: var(--gr-radii-md);
 		color: var(--gr-color-gray-100);
@@ -760,7 +760,7 @@ Features:
 		align-items: flex-start;
 		gap: var(--gr-spacing-scale-3);
 		padding: var(--gr-spacing-scale-3);
-		background: var(--gr-color-gray-850);
+		background: var(--gr-color-gray-800);
 		border: 1px solid var(--gr-color-gray-700);
 		border-radius: var(--gr-radii-md);
 		cursor: pointer;
@@ -797,7 +797,7 @@ Features:
 	.gr-monetization-protection-toggle {
 		flex: 1;
 		padding: var(--gr-spacing-scale-3);
-		background: var(--gr-color-gray-850);
+		background: var(--gr-color-gray-800);
 		border: 1px solid var(--gr-color-gray-700);
 		border-radius: var(--gr-radii-md);
 		color: var(--gr-color-gray-400);

--- a/packages/faces/artist/src/components/Monetization/TipJar.svelte
+++ b/packages/faces/artist/src/components/Monetization/TipJar.svelte
@@ -450,7 +450,7 @@ Features:
 		align-items: center;
 		gap: var(--gr-spacing-scale-1);
 		padding: var(--gr-spacing-scale-4);
-		background: var(--gr-color-gray-850);
+		background: var(--gr-color-gray-800);
 		border: 2px solid var(--gr-color-gray-700);
 		border-radius: var(--gr-radii-md);
 		cursor: pointer;
@@ -511,7 +511,7 @@ Features:
 		width: 100%;
 		padding: var(--gr-spacing-scale-3) var(--gr-spacing-scale-3) var(--gr-spacing-scale-3)
 			var(--gr-spacing-scale-8);
-		background: var(--gr-color-gray-850);
+		background: var(--gr-color-gray-800);
 		border: 1px solid var(--gr-color-gray-700);
 		border-radius: var(--gr-radii-md);
 		color: var(--gr-color-gray-100);
@@ -546,7 +546,7 @@ Features:
 	.gr-monetization-tipjar-message-input {
 		width: 100%;
 		padding: var(--gr-spacing-scale-3);
-		background: var(--gr-color-gray-850);
+		background: var(--gr-color-gray-800);
 		border: 1px solid var(--gr-color-gray-700);
 		border-radius: var(--gr-radii-md);
 		color: var(--gr-color-gray-100);

--- a/packages/faces/artist/src/components/Transparency/AIDisclosure.svelte
+++ b/packages/faces/artist/src/components/Transparency/AIDisclosure.svelte
@@ -266,7 +266,7 @@ Supports three display variants:
 		align-items: center;
 		gap: var(--gr-spacing-scale-1);
 		padding: var(--gr-spacing-scale-1) var(--gr-spacing-scale-2);
-		background: var(--gr-color-gray-850);
+		background: var(--gr-color-gray-800);
 		border: 1px solid var(--gr-color-gray-700);
 		border-radius: var(--gr-radii-sm);
 		color: var(--gr-color-gray-400);

--- a/packages/faces/artist/src/components/Transparency/EthicalSourcingBadge.svelte
+++ b/packages/faces/artist/src/components/Transparency/EthicalSourcingBadge.svelte
@@ -345,7 +345,7 @@ Features:
 	}
 
 	.gr-transparency-ethical-badge--clickable .gr-transparency-ethical-badge-main:hover {
-		background: var(--gr-color-gray-750);
+		background: var(--gr-color-gray-700);
 		border-color: var(--gr-color-gray-600);
 	}
 
@@ -515,7 +515,7 @@ Features:
 	.gr-transparency-ethical-badge-details {
 		margin-top: var(--gr-spacing-scale-2);
 		padding: var(--gr-spacing-scale-4);
-		background: var(--gr-color-gray-850);
+		background: var(--gr-color-gray-800);
 		border: 1px solid var(--gr-color-gray-700);
 		border-radius: var(--gr-radii-md);
 	}

--- a/packages/faces/blog/src/theme.css
+++ b/packages/faces/blog/src/theme.css
@@ -180,6 +180,11 @@
 	color: var(--gr-blog-article-tag-text);
 }
 
+[data-theme='dark'] .gr-blog-tag-cloud .gr-blog-tag-cloud__tag {
+	background: var(--gr-color-gray-700);
+	color: var(--gr-color-gray-100);
+}
+
 [data-theme='dark'] .gr-blog-article__content code {
 	color: var(--gr-blog-code-text);
 }
@@ -1082,7 +1087,7 @@
 }
 
 .gr-blog-review-attribution__empty {
-	color: var(--gr-color-gray-500, var(--gr-color-gray-500));
+	color: var(--gr-color-gray-500);
 	font-style: italic;
 }
 

--- a/packages/faces/blog/src/theme.css
+++ b/packages/faces/blog/src/theme.css
@@ -36,12 +36,12 @@
 	/* Reading progress indicator */
 	--gr-blog-progress-height: 3px;
 	--gr-blog-progress-color: var(--gr-color-primary-500);
-	--gr-blog-progress-background: var(--gr-color-neutral-200);
+	--gr-blog-progress-background: var(--gr-color-gray-200);
 
 	/* Table of contents */
 	--gr-blog-toc-width: 240px;
 	--gr-blog-toc-active-color: var(--gr-color-primary-600);
-	--gr-blog-toc-link-color: var(--gr-color-neutral-600);
+	--gr-blog-toc-link-color: var(--gr-color-gray-600);
 
 	/* Author card */
 	--gr-blog-author-avatar-size: 64px;
@@ -52,13 +52,13 @@
 	--gr-blog-featured-image-radius: var(--gr-radii-lg);
 
 	/* Code blocks */
-	--gr-blog-code-background: var(--gr-color-neutral-50);
-	--gr-blog-code-border: var(--gr-color-neutral-200);
+	--gr-blog-code-background: var(--gr-color-gray-50);
+	--gr-blog-code-border: var(--gr-color-gray-200);
 	--gr-blog-code-radius: var(--gr-radii-md);
 	--gr-blog-code-text: var(--gr-color-gray-800, #1f2937);
 
 	/* Reading surface colors */
-	--gr-blog-article-background: var(--gr-color-neutral-0, var(--gr-color-base-white, #ffffff));
+	--gr-blog-article-background: var(--gr-color-base-white, #ffffff);
 	--gr-blog-article-text: var(--gr-color-gray-800, #1f2937);
 	--gr-blog-article-heading: var(--gr-color-gray-900, #111827);
 	--gr-blog-article-muted: var(--gr-color-gray-600, #4b5563);
@@ -69,7 +69,7 @@
 	/* Blockquotes */
 	--gr-blog-blockquote-border-width: 4px;
 	--gr-blog-blockquote-border-color: var(--gr-color-primary-400);
-	--gr-blog-blockquote-background: var(--gr-color-neutral-50);
+	--gr-blog-blockquote-background: var(--gr-color-gray-50);
 
 	/* Newsletter signup */
 	--gr-blog-newsletter-background: var(--gr-color-primary-50);
@@ -79,7 +79,7 @@
 /* Dark theme overrides */
 [data-theme='dark'] {
 	--gr-blog-code-background: var(--gr-color-gray-800, #1f2937);
-	--gr-blog-code-border: var(--gr-color-neutral-700);
+	--gr-blog-code-border: var(--gr-color-gray-700);
 	--gr-blog-code-text: var(--gr-color-gray-100, #f3f4f6);
 	--gr-blog-article-background: var(--gr-color-gray-900, #111827);
 	--gr-blog-article-text: var(--gr-color-gray-200, #e5e7eb);
@@ -88,34 +88,55 @@
 	--gr-blog-article-link: var(--gr-color-primary-400, #60a5fa);
 	--gr-blog-article-tag-background: var(--gr-color-gray-800, #1f2937);
 	--gr-blog-article-tag-text: var(--gr-color-gray-200, #e5e7eb);
-	--gr-blog-blockquote-background: var(--gr-color-neutral-800);
-	--gr-blog-newsletter-background: var(--gr-color-neutral-800);
-	--gr-blog-newsletter-border: var(--gr-color-neutral-700);
-	--gr-blog-toc-link-color: var(--gr-color-neutral-400);
-	--gr-blog-progress-background: var(--gr-color-neutral-700);
+	--gr-blog-blockquote-background: var(--gr-color-gray-800);
+	--gr-blog-newsletter-background: var(--gr-color-gray-800);
+	--gr-blog-newsletter-border: var(--gr-color-gray-700);
+	--gr-blog-toc-link-color: var(--gr-color-gray-400);
+	--gr-blog-progress-background: var(--gr-color-gray-700);
 }
 
 [data-theme='dark'] .gr-blog-article-card {
-	background: var(--gr-color-neutral-900);
-	border-color: var(--gr-color-neutral-700);
+	background: var(--gr-color-gray-900);
+	border-color: var(--gr-color-gray-700);
 }
 
 [data-theme='dark'] .gr-blog-article-card__meta {
-	color: var(--gr-color-neutral-400);
+	color: var(--gr-color-gray-400);
 }
 
 [data-theme='dark'] .gr-blog-article-card__title {
-	color: var(--gr-color-neutral-100);
+	color: var(--gr-color-gray-100);
 }
 
 [data-theme='dark'] .gr-blog-article-card__subtitle,
 [data-theme='dark'] .gr-blog-article-card__excerpt {
-	color: var(--gr-color-neutral-300);
+	color: var(--gr-color-gray-300);
 }
 
 [data-theme='dark'] .gr-blog-article-card__tag {
-	background: var(--gr-color-neutral-800);
-	color: var(--gr-color-neutral-200);
+	background: var(--gr-color-gray-800);
+	color: var(--gr-color-gray-200);
+}
+
+[data-theme='dark'] .gr-blog-toc__title,
+[data-theme='dark'] .gr-blog-archive__month-title,
+[data-theme='dark'] .gr-blog-editor__meta {
+	color: var(--gr-color-gray-300);
+}
+
+[data-theme='dark'] .gr-blog-newsletter__title,
+[data-theme='dark'] .gr-blog-archive__year {
+	color: var(--gr-color-gray-100);
+}
+
+[data-theme='dark'] .gr-blog-newsletter__description {
+	color: var(--gr-color-gray-300);
+}
+
+[data-theme='dark'] .gr-blog-editor__preview {
+	background: var(--gr-color-gray-900);
+	border-color: var(--gr-color-gray-700);
+	color: var(--gr-color-gray-100);
 }
 
 [data-theme='dark'] .gr-blog-article {
@@ -185,7 +206,7 @@
 	font-family: var(--gr-blog-font-family-body);
 	font-size: var(--gr-typography-fontSize-lg);
 	line-height: var(--gr-blog-line-height-body);
-	color: var(--gr-color-neutral-800);
+	color: var(--gr-color-gray-800);
 }
 
 .gr-blog-article__content p {
@@ -200,7 +221,7 @@
 	line-height: var(--gr-blog-line-height-heading);
 	margin-top: var(--gr-blog-heading-spacing-top);
 	margin-bottom: var(--gr-blog-heading-spacing-bottom);
-	color: var(--gr-color-neutral-900);
+	color: var(--gr-color-gray-900);
 }
 
 .gr-blog-article__content h1 {
@@ -236,8 +257,8 @@
  * ============================================================================ */
 
 .gr-blog-article-card {
-	background: var(--gr-color-surface, var(--gr-color-neutral-0, #ffffff));
-	border: 1px solid var(--gr-color-border, var(--gr-color-neutral-200));
+	background: var(--gr-color-surface, var(--gr-color-base-white, #ffffff));
+	border: 1px solid var(--gr-color-border, var(--gr-color-gray-200));
 	border-radius: var(--gr-radii-lg);
 	overflow: hidden;
 	transition:
@@ -283,11 +304,11 @@
 	margin: 0 0 var(--gr-spacing-scale-3);
 	font-family: var(--gr-blog-font-family-heading);
 	font-size: var(--gr-typography-fontSize-sm);
-	color: var(--gr-color-neutral-600);
+	color: var(--gr-color-gray-600);
 }
 
 .gr-blog-article-card__separator {
-	color: var(--gr-color-neutral-400);
+	color: var(--gr-color-gray-400);
 }
 
 .gr-blog-article-card__title {
@@ -295,13 +316,13 @@
 	font-family: var(--gr-blog-font-family-heading);
 	font-size: var(--gr-typography-fontSize-2xl);
 	line-height: var(--gr-blog-line-height-heading);
-	color: var(--gr-color-neutral-900);
+	color: var(--gr-color-gray-900);
 }
 
 .gr-blog-article-card__subtitle,
 .gr-blog-article-card__excerpt {
 	margin: 0 0 var(--gr-spacing-scale-3);
-	color: var(--gr-color-neutral-700);
+	color: var(--gr-color-gray-700);
 	line-height: 1.6;
 }
 
@@ -322,8 +343,8 @@
 	display: inline-flex;
 	align-items: center;
 	border-radius: var(--gr-radii-full);
-	background: var(--gr-color-neutral-100);
-	color: var(--gr-color-neutral-700);
+	background: var(--gr-color-gray-100);
+	color: var(--gr-color-gray-700);
 	padding: var(--gr-spacing-scale-1) var(--gr-spacing-scale-3);
 	font-size: var(--gr-typography-fontSize-sm);
 	font-family: var(--gr-blog-font-family-heading);
@@ -372,7 +393,7 @@
 	font-weight: var(--gr-typography-fontWeight-semibold);
 	text-transform: uppercase;
 	letter-spacing: 0.05em;
-	color: var(--gr-color-neutral-500);
+	color: var(--gr-color-gray-500);
 	margin-bottom: var(--gr-spacing-scale-3);
 }
 
@@ -425,7 +446,7 @@
 	display: flex;
 	gap: var(--gr-spacing-scale-4);
 	padding: var(--gr-spacing-scale-6);
-	background: var(--gr-color-neutral-50);
+	background: var(--gr-color-gray-50);
 	border-radius: var(--gr-radii-lg);
 }
 
@@ -445,13 +466,13 @@
 	font-family: var(--gr-blog-font-family-heading);
 	font-size: var(--gr-typography-fontSize-lg);
 	font-weight: var(--gr-typography-fontWeight-semibold);
-	color: var(--gr-color-neutral-900);
+	color: var(--gr-color-gray-900);
 	margin-bottom: var(--gr-spacing-scale-1);
 }
 
 .gr-blog-author-card__bio {
 	font-size: var(--gr-typography-fontSize-sm);
-	color: var(--gr-color-neutral-600);
+	color: var(--gr-color-gray-600);
 	line-height: var(--gr-blog-line-height-body);
 }
 
@@ -481,8 +502,8 @@
 	align-items: center;
 	justify-content: space-between;
 	padding: var(--gr-spacing-scale-4) var(--gr-spacing-scale-6);
-	background: var(--gr-color-neutral-900);
-	color: var(--gr-color-neutral-100);
+	background: var(--gr-color-gray-900);
+	color: var(--gr-color-gray-100);
 }
 
 .gr-blog-publication-banner__logo {
@@ -512,13 +533,13 @@
 	font-family: var(--gr-blog-font-family-heading);
 	font-size: var(--gr-typography-fontSize-2xl);
 	font-weight: var(--gr-typography-fontWeight-bold);
-	color: var(--gr-color-neutral-900);
+	color: var(--gr-color-gray-900);
 	margin-bottom: var(--gr-spacing-scale-2);
 }
 
 .gr-blog-newsletter__description {
 	font-size: var(--gr-typography-fontSize-base);
-	color: var(--gr-color-neutral-600);
+	color: var(--gr-color-gray-600);
 	margin-bottom: var(--gr-spacing-scale-6);
 }
 
@@ -541,10 +562,10 @@
 	font-family: var(--gr-blog-font-family-heading);
 	font-size: var(--gr-typography-fontSize-2xl);
 	font-weight: var(--gr-typography-fontWeight-bold);
-	color: var(--gr-color-neutral-900);
+	color: var(--gr-color-gray-900);
 	margin-bottom: var(--gr-spacing-scale-4);
 	padding-bottom: var(--gr-spacing-scale-2);
-	border-bottom: 2px solid var(--gr-color-neutral-200);
+	border-bottom: 2px solid var(--gr-color-gray-200);
 }
 
 .gr-blog-archive__month {
@@ -555,7 +576,7 @@
 	font-family: var(--gr-blog-font-family-heading);
 	font-size: var(--gr-typography-fontSize-lg);
 	font-weight: var(--gr-typography-fontWeight-semibold);
-	color: var(--gr-color-neutral-700);
+	color: var(--gr-color-gray-700);
 	margin-bottom: var(--gr-spacing-scale-3);
 }
 
@@ -573,10 +594,10 @@
 	display: inline-flex;
 	align-items: center;
 	padding: var(--gr-spacing-scale-1) var(--gr-spacing-scale-3);
-	background: var(--gr-color-neutral-100);
+	background: var(--gr-color-gray-100);
 	border-radius: var(--gr-radii-full);
 	font-size: var(--gr-typography-fontSize-sm);
-	color: var(--gr-color-neutral-700);
+	color: var(--gr-color-gray-700);
 	text-decoration: none;
 	transition:
 		background 150ms ease,
@@ -607,15 +628,15 @@
 	align-items: center;
 	gap: var(--gr-spacing-scale-1);
 	padding: var(--gr-spacing-scale-2) var(--gr-spacing-scale-3);
-	background: var(--gr-color-neutral-50);
-	border: 1px solid var(--gr-color-neutral-200);
+	background: var(--gr-color-gray-50);
+	border: 1px solid var(--gr-color-gray-200);
 	border-radius: var(--gr-radii-md);
 }
 
 .gr-blog-editor-toolbar__divider {
 	width: 1px;
 	height: 24px;
-	background: var(--gr-color-neutral-300);
+	background: var(--gr-color-gray-300);
 	margin: 0 var(--gr-spacing-scale-2);
 }
 
@@ -628,7 +649,7 @@
 	border: none;
 	background: transparent;
 	border-radius: var(--gr-radii-sm);
-	color: var(--gr-color-neutral-600);
+	color: var(--gr-color-gray-600);
 	cursor: pointer;
 	transition:
 		background 150ms ease,
@@ -636,8 +657,8 @@
 }
 
 .gr-blog-editor-toolbar__button:hover {
-	background: var(--gr-color-neutral-200);
-	color: var(--gr-color-neutral-900);
+	background: var(--gr-color-gray-200);
+	color: var(--gr-color-gray-900);
 }
 
 .gr-blog-editor-toolbar__button--active {
@@ -660,7 +681,7 @@
 	width: 100%;
 	min-height: 240px;
 	padding: var(--gr-spacing-scale-4);
-	border: 1px solid var(--gr-color-neutral-200);
+	border: 1px solid var(--gr-color-gray-200);
 	border-radius: var(--gr-radii-md);
 	font-family: var(--gr-blog-font-family-body);
 	font-size: var(--gr-typography-fontSize-base);
@@ -669,9 +690,9 @@
 
 .gr-blog-editor__preview {
 	padding: var(--gr-spacing-scale-4);
-	border: 1px solid var(--gr-color-neutral-200);
+	border: 1px solid var(--gr-color-gray-200);
 	border-radius: var(--gr-radii-md);
-	background: var(--gr-color-neutral-50);
+	background: var(--gr-color-gray-50);
 	max-height: 60vh;
 	overflow: auto;
 }
@@ -683,19 +704,19 @@
 	gap: var(--gr-spacing-scale-3);
 	margin-top: var(--gr-spacing-scale-3);
 	font-size: var(--gr-typography-fontSize-sm);
-	color: var(--gr-color-neutral-600);
+	color: var(--gr-color-gray-600);
 }
 
 .gr-blog-editor__meta button {
 	padding: var(--gr-spacing-scale-1) var(--gr-spacing-scale-3);
-	border: 1px solid var(--gr-color-neutral-200);
-	background: var(--gr-color-neutral-50);
+	border: 1px solid var(--gr-color-gray-200);
+	background: var(--gr-color-gray-50);
 	border-radius: var(--gr-radii-md);
 	cursor: pointer;
 }
 
 .gr-blog-editor__meta button:hover {
-	background: var(--gr-color-neutral-100);
+	background: var(--gr-color-gray-100);
 }
 
 @media (min-width: 900px) {
@@ -773,7 +794,7 @@
 	right: 0;
 	padding: var(--gr-spacing-scale-3) var(--gr-spacing-scale-4);
 	background: linear-gradient(transparent, rgba(0, 0, 0, 0.7));
-	color: var(--gr-color-neutral-100);
+	color: var(--gr-color-gray-100);
 	font-size: var(--gr-typography-fontSize-sm);
 }
 
@@ -811,9 +832,8 @@
  * review workflow.
  *
  * All colour comes from `--gr-*` custom properties so a consumer can rebrand by
- * bridging tokens alone. Neutral steps carry a `--gr-color-gray-*` fallback
- * because `--gr-color-neutral-*` is a bridge-level alias rather than a token
- * the tokens package emits directly.
+ * bridging tokens alone. Neutral steps use the emitted `--gr-color-gray-*` token
+ * path; selectable palette names change those values and are not token paths.
  *
  * State is never communicated by colour alone: every state badge renders its
  * label as text.
@@ -832,9 +852,9 @@
 	--gr-blog-review-changes-fg: var(--gr-color-warning-900);
 	--gr-blog-review-changes-border: var(--gr-color-warning-300);
 
-	--gr-blog-review-pending-bg: var(--gr-color-neutral-100, var(--gr-color-gray-100));
-	--gr-blog-review-pending-fg: var(--gr-color-neutral-800, var(--gr-color-gray-800));
-	--gr-blog-review-pending-border: var(--gr-color-neutral-300, var(--gr-color-gray-300));
+	--gr-blog-review-pending-bg: var(--gr-color-gray-100);
+	--gr-blog-review-pending-fg: var(--gr-color-gray-800);
+	--gr-blog-review-pending-border: var(--gr-color-gray-300);
 
 	--gr-blog-review-agent-bg: var(--gr-color-primary-100);
 	--gr-blog-review-agent-fg: var(--gr-color-primary-900, var(--gr-color-primary-700));
@@ -850,9 +870,9 @@
 	--gr-blog-review-changes-fg: var(--gr-color-warning-100);
 	--gr-blog-review-changes-border: var(--gr-color-warning-700);
 
-	--gr-blog-review-pending-bg: var(--gr-color-neutral-800, var(--gr-color-gray-800));
-	--gr-blog-review-pending-fg: var(--gr-color-neutral-100, var(--gr-color-gray-100));
-	--gr-blog-review-pending-border: var(--gr-color-neutral-600, var(--gr-color-gray-600));
+	--gr-blog-review-pending-bg: var(--gr-color-gray-800);
+	--gr-blog-review-pending-fg: var(--gr-color-gray-100);
+	--gr-blog-review-pending-border: var(--gr-color-gray-600);
 
 	--gr-blog-review-agent-bg: var(--gr-color-primary-900);
 	--gr-blog-review-agent-fg: var(--gr-color-primary-100);
@@ -868,15 +888,15 @@
 	flex-direction: column;
 	gap: var(--gr-blog-review-gap);
 	padding: var(--gr-blog-review-card-padding);
-	background: var(--gr-color-surface, var(--gr-color-neutral-0, #ffffff));
-	border: 1px solid var(--gr-color-border, var(--gr-color-neutral-200, var(--gr-color-gray-200)));
+	background: var(--gr-color-surface, var(--gr-color-base-white, #ffffff));
+	border: 1px solid var(--gr-color-border, var(--gr-color-gray-200));
 	border-radius: var(--gr-blog-review-radius);
 	font-family: var(--gr-blog-font-family-heading);
 }
 
 [data-theme='dark'] .gr-blog-review-card {
-	background: var(--gr-color-neutral-900, var(--gr-color-gray-900));
-	border-color: var(--gr-color-neutral-700, var(--gr-color-gray-700));
+	background: var(--gr-color-gray-900);
+	border-color: var(--gr-color-gray-700);
 }
 
 .gr-blog-review-card__header {
@@ -898,11 +918,11 @@
 	margin: 0;
 	font-size: 1.125rem;
 	line-height: var(--gr-blog-line-height-heading);
-	color: var(--gr-color-neutral-900, var(--gr-color-gray-900));
+	color: var(--gr-color-gray-900);
 }
 
 [data-theme='dark'] .gr-blog-review-card__title {
-	color: var(--gr-color-neutral-100, var(--gr-color-gray-100));
+	color: var(--gr-color-gray-100);
 }
 
 .gr-blog-review-card__link {
@@ -920,12 +940,12 @@
 	margin: 0;
 	font-size: 0.9375rem;
 	line-height: 1.5;
-	color: var(--gr-color-neutral-600, var(--gr-color-gray-600));
+	color: var(--gr-color-gray-600);
 }
 
 [data-theme='dark'] .gr-blog-review-card__subtitle,
 [data-theme='dark'] .gr-blog-review-card__excerpt {
-	color: var(--gr-color-neutral-300, var(--gr-color-gray-300));
+	color: var(--gr-color-gray-300);
 }
 
 .gr-blog-review-card__meta {
@@ -935,11 +955,11 @@
 	gap: var(--gr-spacing-scale-2);
 	margin: 0;
 	font-size: 0.8125rem;
-	color: var(--gr-color-neutral-600, var(--gr-color-gray-600));
+	color: var(--gr-color-gray-600);
 }
 
 [data-theme='dark'] .gr-blog-review-card__meta {
-	color: var(--gr-color-neutral-400, var(--gr-color-gray-400));
+	color: var(--gr-color-gray-400);
 }
 
 .gr-blog-review-card__author {
@@ -953,7 +973,7 @@
 }
 
 .gr-blog-review-card__separator {
-	color: var(--gr-color-neutral-400, var(--gr-color-gray-400));
+	color: var(--gr-color-gray-400);
 }
 
 .gr-blog-review-card__state-group {
@@ -981,11 +1001,11 @@
 .gr-blog-review-card__state-note {
 	font-size: 0.6875rem;
 	text-align: right;
-	color: var(--gr-color-neutral-600, var(--gr-color-gray-600));
+	color: var(--gr-color-gray-600);
 }
 
 [data-theme='dark'] .gr-blog-review-card__state-note {
-	color: var(--gr-color-neutral-400, var(--gr-color-gray-400));
+	color: var(--gr-color-gray-400);
 }
 
 .gr-blog-review-card__state--approved {
@@ -1024,13 +1044,12 @@
 .gr-blog-review-card__attribution,
 .gr-blog-review-card__actions {
 	padding-top: var(--gr-spacing-scale-3);
-	border-top: 1px solid
-		var(--gr-color-border, var(--gr-color-neutral-200, var(--gr-color-gray-200)));
+	border-top: 1px solid var(--gr-color-border, var(--gr-color-gray-200));
 }
 
 [data-theme='dark'] .gr-blog-review-card__attribution,
 [data-theme='dark'] .gr-blog-review-card__actions {
-	border-top-color: var(--gr-color-neutral-700, var(--gr-color-gray-700));
+	border-top-color: var(--gr-color-gray-700);
 }
 
 /* --------------------------------------------------------------------------
@@ -1039,11 +1058,11 @@
 
 .gr-blog-review-attribution {
 	font-size: 0.8125rem;
-	color: var(--gr-color-neutral-700, var(--gr-color-gray-700));
+	color: var(--gr-color-gray-700);
 }
 
 [data-theme='dark'] .gr-blog-review-attribution {
-	color: var(--gr-color-neutral-300, var(--gr-color-gray-300));
+	color: var(--gr-color-gray-300);
 }
 
 .gr-blog-review-attribution__actor-name {
@@ -1053,17 +1072,17 @@
 .gr-blog-review-attribution__actor-handle,
 .gr-blog-review-attribution__granted-at,
 .gr-blog-review-attribution__state-source {
-	color: var(--gr-color-neutral-600, var(--gr-color-gray-600));
+	color: var(--gr-color-gray-600);
 }
 
 [data-theme='dark'] .gr-blog-review-attribution__actor-handle,
 [data-theme='dark'] .gr-blog-review-attribution__granted-at,
 [data-theme='dark'] .gr-blog-review-attribution__state-source {
-	color: var(--gr-color-neutral-400, var(--gr-color-gray-400));
+	color: var(--gr-color-gray-400);
 }
 
 .gr-blog-review-attribution__empty {
-	color: var(--gr-color-neutral-500, var(--gr-color-gray-500));
+	color: var(--gr-color-gray-500, var(--gr-color-gray-500));
 	font-style: italic;
 }
 
@@ -1100,7 +1119,7 @@
 }
 
 .gr-blog-review-attribution__revocable {
-	color: var(--gr-color-neutral-600, var(--gr-color-gray-600));
+	color: var(--gr-color-gray-600);
 }
 
 /* --------------------------------------------------------------------------
@@ -1117,11 +1136,11 @@
 	margin: 0 0 var(--gr-spacing-scale-4);
 	font-size: 0.9375rem;
 	line-height: 1.5;
-	color: var(--gr-color-neutral-700, var(--gr-color-gray-700));
+	color: var(--gr-color-gray-700);
 }
 
 [data-theme='dark'] .gr-blog-review-verdict__prompt {
-	color: var(--gr-color-neutral-300, var(--gr-color-gray-300));
+	color: var(--gr-color-gray-300);
 }
 
 /* The notes field is the TextArea primitive — label, error text, and ARIA

--- a/packages/faces/blog/tests/theme.test.ts
+++ b/packages/faces/blog/tests/theme.test.ts
@@ -10,6 +10,7 @@ const tokenCss = fs.readFileSync(
 
 function declarations(css: string, selector: string): string {
 	let offset = 0;
+	const blocks: string[] = [];
 	while (offset < css.length) {
 		const open = css.indexOf('{', offset);
 		if (open < 0) break;
@@ -19,9 +20,10 @@ function declarations(css: string, selector: string): string {
 			.replace(/\/\*[\s\S]*?\*\//g, '')
 			.trim();
 		const close = css.indexOf('}', open);
-		if (candidate === selector && close >= 0) return css.slice(open + 1, close);
+		if (candidate === selector && close >= 0) blocks.push(css.slice(open + 1, close));
 		offset = open + 1;
 	}
+	if (blocks.length > 0) return blocks.join('\n');
 	throw new Error(`Missing CSS block for ${selector}`);
 }
 
@@ -60,9 +62,13 @@ function themeProperties(theme: 'light' | 'dark'): Map<string, string> {
 		...readCustomProperties(declarations(tokenCss, ':root')),
 		...readCustomProperties(declarations(blogCss, ':root')),
 	]);
+	for (const [name, value] of readCustomProperties(
+		declarations(tokenCss, `[data-theme="${theme}"]`)
+	)) {
+		properties.set(name, value);
+	}
 	if (theme === 'dark') {
 		for (const [name, value] of [
-			...readCustomProperties(declarations(tokenCss, '[data-theme="dark"]')),
 			...readCustomProperties(declarations(blogCss, "[data-theme='dark']")),
 		]) {
 			properties.set(name, value);
@@ -94,6 +100,21 @@ function contrast(foreground: string, background: string): number {
 }
 
 describe('blog reading-surface theme', () => {
+	it('references selectable palettes only through emitted token paths', () => {
+		const emittedTokens = new Set(
+			Array.from(tokenCss.matchAll(/(--gr-[\w-]+)\s*:/g), (match) => match[1])
+		);
+		const paletteReferences = Array.from(
+			blogCss.matchAll(/var\(\s*(--gr-color-(?:gray|neutral|slate|stone|zinc)-[\w-]+)/g),
+			(match) => match[1]
+		);
+
+		expect(
+			paletteReferences.filter((token) => !emittedTokens.has(token)),
+			'palette names select --gr-color-gray-* values and are not token paths'
+		).toEqual([]);
+	});
+
 	it.each(['light', 'dark'] as const)('resolves all new public reading tokens in %s', (theme) => {
 		const properties = themeProperties(theme);
 		for (const token of [
@@ -150,17 +171,83 @@ describe('blog reading-surface theme', () => {
 		);
 	});
 
+	it.each(['light', 'dark'] as const)(
+		'holds contrast for every neutral-mapping text cell in %s',
+		(theme) => {
+			const properties = themeProperties(theme);
+			const pageBackground = '--gr-semantic-background-primary';
+			const cells =
+				theme === 'light'
+					? [
+							['article prose', '--gr-color-gray-800', '--gr-color-base-white'],
+							['article heading', '--gr-color-gray-900', '--gr-color-base-white'],
+							['card meta', '--gr-color-gray-600', '--gr-color-base-white'],
+							['card subtitle', '--gr-color-gray-700', '--gr-color-base-white'],
+							['card tag', '--gr-color-gray-700', '--gr-color-gray-100'],
+							['toc title', '--gr-color-gray-500', pageBackground],
+							['toc link', '--gr-color-gray-600', pageBackground],
+							['author name', '--gr-color-gray-900', '--gr-color-gray-50'],
+							['author bio', '--gr-color-gray-600', '--gr-color-gray-50'],
+							['publication', '--gr-color-gray-100', '--gr-color-gray-900'],
+							['newsletter title', '--gr-color-gray-900', '--gr-color-primary-50'],
+							['newsletter description', '--gr-color-gray-600', '--gr-color-primary-50'],
+							['archive year', '--gr-color-gray-900', pageBackground],
+							['archive month', '--gr-color-gray-700', pageBackground],
+							['tag cloud', '--gr-color-gray-700', '--gr-color-gray-100'],
+							['toolbar button', '--gr-color-gray-600', '--gr-color-gray-50'],
+							['toolbar button hover', '--gr-color-gray-900', '--gr-color-gray-200'],
+							['editor meta', '--gr-color-gray-600', pageBackground],
+							['caption gradient', '--gr-color-gray-100', '#4d4d4d'],
+						]
+					: [
+							['article prose', '--gr-color-gray-200', '--gr-color-gray-900'],
+							['article heading', '--gr-color-gray-100', '--gr-color-gray-900'],
+							['article meta', '--gr-color-gray-300', '--gr-color-gray-900'],
+							['article link', '--gr-color-primary-400', '--gr-color-gray-900'],
+							['article tag', '--gr-color-gray-200', '--gr-color-gray-800'],
+							['code', '--gr-color-gray-100', '--gr-color-gray-800'],
+							['card meta', '--gr-color-gray-400', '--gr-color-gray-900'],
+							['card title', '--gr-color-gray-100', '--gr-color-gray-900'],
+							['card subtitle', '--gr-color-gray-300', '--gr-color-gray-900'],
+							['card tag', '--gr-color-gray-200', '--gr-color-gray-800'],
+							['toc title', '--gr-color-gray-300', pageBackground],
+							['toc link', '--gr-color-gray-400', pageBackground],
+							['author name', '--gr-color-gray-900', '--gr-color-gray-50'],
+							['author bio', '--gr-color-gray-600', '--gr-color-gray-50'],
+							['publication', '--gr-color-gray-100', '--gr-color-gray-900'],
+							['newsletter title', '--gr-color-gray-100', '--gr-color-gray-800'],
+							['newsletter description', '--gr-color-gray-300', '--gr-color-gray-800'],
+							['archive year', '--gr-color-gray-100', pageBackground],
+							['archive month', '--gr-color-gray-300', pageBackground],
+							['tag cloud', '--gr-color-gray-700', '--gr-color-gray-100'],
+							['toolbar button', '--gr-color-gray-600', '--gr-color-gray-50'],
+							['toolbar button hover', '--gr-color-gray-900', '--gr-color-gray-200'],
+							['editor preview', '--gr-color-gray-100', '--gr-color-gray-900'],
+							['editor meta', '--gr-color-gray-300', pageBackground],
+							['caption gradient', '--gr-color-gray-100', '#4d4d4d'],
+						];
+
+			for (const [name, foregroundToken, backgroundToken] of cells) {
+				const foreground = resolveValue(`var(${foregroundToken})`, properties);
+				const background = backgroundToken.startsWith('#')
+					? backgroundToken
+					: resolveValue(`var(${backgroundToken})`, properties);
+				expect(contrast(foreground, background), name).toBeGreaterThanOrEqual(4.5);
+			}
+		}
+	);
+
 	it('leaves the light reading surface on its pre-theme cascade', () => {
 		expect(declarations(blogCss, '.gr-blog-article')).not.toMatch(/\b(?:background|color)\s*:/);
 		expect(declarations(blogCss, '.gr-blog-article__content')).toContain(
-			'color: var(--gr-color-neutral-800)'
+			'color: var(--gr-color-gray-800)'
 		);
 		expect(
 			declarations(
 				blogCss,
 				'.gr-blog-article__content h1,\n.gr-blog-article__content h2,\n.gr-blog-article__content h3,\n.gr-blog-article__content h4'
 			)
-		).toContain('color: var(--gr-color-neutral-900)');
+		).toContain('color: var(--gr-color-gray-900)');
 		expect(() => declarations(blogCss, '.gr-blog-article__content a')).toThrow();
 		expect(declarations(blogCss, '.gr-blog-article__content code')).not.toMatch(/\bcolor\s*:/);
 	});

--- a/packages/faces/blog/tests/theme.test.ts
+++ b/packages/faces/blog/tests/theme.test.ts
@@ -36,6 +36,15 @@ function readCustomProperties(block: string): Map<string, string> {
 	);
 }
 
+function declarationValue(css: string, selector: string, property: string): string {
+	const matches = Array.from(
+		declarations(css, selector).matchAll(new RegExp(`(?:^|;)\\s*${property}\\s*:\\s*([^;]+)`, 'g'))
+	);
+	const value = matches.at(-1)?.[1]?.trim();
+	if (!value) throw new Error(`Missing ${property} declaration for ${selector}`);
+	return value;
+}
+
 function resolveValue(
 	value: string,
 	properties: Map<string, string>,
@@ -101,11 +110,12 @@ function contrast(foreground: string, background: string): number {
 
 describe('blog reading-surface theme', () => {
 	it('references selectable palettes only through emitted token paths', () => {
+		const uncommentedBlogCss = blogCss.replace(/\/\*[\s\S]*?\*\//g, '');
 		const emittedTokens = new Set(
 			Array.from(tokenCss.matchAll(/(--gr-[\w-]+)\s*:/g), (match) => match[1])
 		);
 		const paletteReferences = Array.from(
-			blogCss.matchAll(/var\(\s*(--gr-color-(?:gray|neutral|slate|stone|zinc)-[\w-]+)/g),
+			uncommentedBlogCss.matchAll(/var\(\s*(--gr-color-(?:gray|neutral|slate|stone|zinc)-[\w-]+)/g),
 			(match) => match[1]
 		);
 
@@ -175,64 +185,269 @@ describe('blog reading-surface theme', () => {
 		'holds contrast for every neutral-mapping text cell in %s',
 		(theme) => {
 			const properties = themeProperties(theme);
-			const pageBackground = '--gr-semantic-background-primary';
-			const cells =
+			const pageBackground = { value: 'var(--gr-semantic-background-primary)' };
+			const articleHeadings =
+				'.gr-blog-article__content h1,\n.gr-blog-article__content h2,\n.gr-blog-article__content h3,\n.gr-blog-article__content h4';
+			const darkArticleHeadings =
+				"[data-theme='dark'] .gr-blog-article__content h1,\n[data-theme='dark'] .gr-blog-article__content h2,\n[data-theme='dark'] .gr-blog-article__content h3,\n[data-theme='dark'] .gr-blog-article__content h4,\n[data-theme='dark'] .gr-blog-article__content h5,\n[data-theme='dark'] .gr-blog-article__content h6,\n[data-theme='dark'] .gr-blog-article__title";
+			const darkCardSubtitle =
+				"[data-theme='dark'] .gr-blog-article-card__subtitle,\n[data-theme='dark'] .gr-blog-article-card__excerpt";
+			const darkTocArchiveMeta =
+				"[data-theme='dark'] .gr-blog-toc__title,\n[data-theme='dark'] .gr-blog-archive__month-title,\n[data-theme='dark'] .gr-blog-editor__meta";
+			const darkNewsletterArchive =
+				"[data-theme='dark'] .gr-blog-newsletter__title,\n[data-theme='dark'] .gr-blog-archive__year";
+			const cells: Array<{
+				name: string;
+				foreground: { selector: string; property: string };
+				background: { selector?: string; property?: string; value?: string };
+			}> =
 				theme === 'light'
 					? [
-							['article prose', '--gr-color-gray-800', '--gr-color-base-white'],
-							['article heading', '--gr-color-gray-900', '--gr-color-base-white'],
-							['card meta', '--gr-color-gray-600', '--gr-color-base-white'],
-							['card subtitle', '--gr-color-gray-700', '--gr-color-base-white'],
-							['card tag', '--gr-color-gray-700', '--gr-color-gray-100'],
-							['toc title', '--gr-color-gray-500', pageBackground],
-							['toc link', '--gr-color-gray-600', pageBackground],
-							['author name', '--gr-color-gray-900', '--gr-color-gray-50'],
-							['author bio', '--gr-color-gray-600', '--gr-color-gray-50'],
-							['publication', '--gr-color-gray-100', '--gr-color-gray-900'],
-							['newsletter title', '--gr-color-gray-900', '--gr-color-primary-50'],
-							['newsletter description', '--gr-color-gray-600', '--gr-color-primary-50'],
-							['archive year', '--gr-color-gray-900', pageBackground],
-							['archive month', '--gr-color-gray-700', pageBackground],
-							['tag cloud', '--gr-color-gray-700', '--gr-color-gray-100'],
-							['toolbar button', '--gr-color-gray-600', '--gr-color-gray-50'],
-							['toolbar button hover', '--gr-color-gray-900', '--gr-color-gray-200'],
-							['editor meta', '--gr-color-gray-600', pageBackground],
-							['caption gradient', '--gr-color-gray-100', '#4d4d4d'],
+							{
+								name: 'article prose',
+								foreground: { selector: '.gr-blog-article__content', property: 'color' },
+								background: pageBackground,
+							},
+							{
+								name: 'article heading',
+								foreground: { selector: articleHeadings, property: 'color' },
+								background: pageBackground,
+							},
+							...[
+								['card meta', '.gr-blog-article-card__meta'],
+								[
+									'card subtitle',
+									'.gr-blog-article-card__subtitle,\n.gr-blog-article-card__excerpt',
+								],
+							].map(([name, selector]) => ({
+								name,
+								foreground: { selector, property: 'color' },
+								background: { selector: '.gr-blog-article-card', property: 'background' },
+							})),
+							{
+								name: 'card tag',
+								foreground: { selector: '.gr-blog-article-card__tag', property: 'color' },
+								background: { selector: '.gr-blog-article-card__tag', property: 'background' },
+							},
+							...[
+								['toc title', '.gr-blog-toc__title'],
+								['toc link', '.gr-blog-toc__link'],
+								['archive year', '.gr-blog-archive__year'],
+								['archive month', '.gr-blog-archive__month-title'],
+								['editor meta', '.gr-blog-editor__meta'],
+							].map(([name, selector]) => ({
+								name,
+								foreground: { selector, property: 'color' },
+								background: pageBackground,
+							})),
+							...[
+								['author name', '.gr-blog-author-card__name'],
+								['author bio', '.gr-blog-author-card__bio'],
+							].map(([name, selector]) => ({
+								name,
+								foreground: { selector, property: 'color' },
+								background: { selector: '.gr-blog-author-card', property: 'background' },
+							})),
+							{
+								name: 'publication',
+								foreground: { selector: '.gr-blog-publication-banner', property: 'color' },
+								background: { selector: '.gr-blog-publication-banner', property: 'background' },
+							},
+							...[
+								['newsletter title', '.gr-blog-newsletter__title'],
+								['newsletter description', '.gr-blog-newsletter__description'],
+							].map(([name, selector]) => ({
+								name,
+								foreground: { selector, property: 'color' },
+								background: { selector: '.gr-blog-newsletter', property: 'background' },
+							})),
+							{
+								name: 'tag cloud',
+								foreground: { selector: '.gr-blog-tag-cloud__tag', property: 'color' },
+								background: { selector: '.gr-blog-tag-cloud__tag', property: 'background' },
+							},
+							{
+								name: 'toolbar button',
+								foreground: { selector: '.gr-blog-editor-toolbar__button', property: 'color' },
+								background: { selector: '.gr-blog-editor-toolbar', property: 'background' },
+							},
+							{
+								name: 'toolbar button hover',
+								foreground: {
+									selector: '.gr-blog-editor-toolbar__button:hover',
+									property: 'color',
+								},
+								background: {
+									selector: '.gr-blog-editor-toolbar__button:hover',
+									property: 'background',
+								},
+							},
+							{
+								name: 'caption gradient',
+								foreground: { selector: '.gr-blog-featured-image__caption', property: 'color' },
+								background: { value: '#4d4d4d' },
+							},
 						]
 					: [
-							['article prose', '--gr-color-gray-200', '--gr-color-gray-900'],
-							['article heading', '--gr-color-gray-100', '--gr-color-gray-900'],
-							['article meta', '--gr-color-gray-300', '--gr-color-gray-900'],
-							['article link', '--gr-color-primary-400', '--gr-color-gray-900'],
-							['article tag', '--gr-color-gray-200', '--gr-color-gray-800'],
-							['code', '--gr-color-gray-100', '--gr-color-gray-800'],
-							['card meta', '--gr-color-gray-400', '--gr-color-gray-900'],
-							['card title', '--gr-color-gray-100', '--gr-color-gray-900'],
-							['card subtitle', '--gr-color-gray-300', '--gr-color-gray-900'],
-							['card tag', '--gr-color-gray-200', '--gr-color-gray-800'],
-							['toc title', '--gr-color-gray-300', pageBackground],
-							['toc link', '--gr-color-gray-400', pageBackground],
-							['author name', '--gr-color-gray-900', '--gr-color-gray-50'],
-							['author bio', '--gr-color-gray-600', '--gr-color-gray-50'],
-							['publication', '--gr-color-gray-100', '--gr-color-gray-900'],
-							['newsletter title', '--gr-color-gray-100', '--gr-color-gray-800'],
-							['newsletter description', '--gr-color-gray-300', '--gr-color-gray-800'],
-							['archive year', '--gr-color-gray-100', pageBackground],
-							['archive month', '--gr-color-gray-300', pageBackground],
-							['tag cloud', '--gr-color-gray-700', '--gr-color-gray-100'],
-							['toolbar button', '--gr-color-gray-600', '--gr-color-gray-50'],
-							['toolbar button hover', '--gr-color-gray-900', '--gr-color-gray-200'],
-							['editor preview', '--gr-color-gray-100', '--gr-color-gray-900'],
-							['editor meta', '--gr-color-gray-300', pageBackground],
-							['caption gradient', '--gr-color-gray-100', '#4d4d4d'],
+							{
+								name: 'article prose',
+								foreground: {
+									selector: "[data-theme='dark'] .gr-blog-article__content",
+									property: 'color',
+								},
+								background: {
+									selector: "[data-theme='dark'] .gr-blog-article",
+									property: 'background',
+								},
+							},
+							{
+								name: 'article heading',
+								foreground: { selector: darkArticleHeadings, property: 'color' },
+								background: {
+									selector: "[data-theme='dark'] .gr-blog-article",
+									property: 'background',
+								},
+							},
+							...[
+								[
+									'article meta',
+									"[data-theme='dark'] .gr-blog-article__subtitle,\n[data-theme='dark'] .gr-blog-article__meta",
+								],
+								['article link', "[data-theme='dark'] .gr-blog-article__content a"],
+							].map(([name, selector]) => ({
+								name,
+								foreground: { selector, property: 'color' },
+								background: {
+									selector: "[data-theme='dark'] .gr-blog-article",
+									property: 'background',
+								},
+							})),
+							...[
+								[
+									'article tag',
+									"[data-theme='dark'] .gr-blog-article__tags .gr-blog-tag-cloud__tag",
+								],
+								['code', "[data-theme='dark'] .gr-blog-article__content code"],
+							].map(([name, selector]) => ({
+								name,
+								foreground: { selector, property: 'color' },
+								background: {
+									selector:
+										name === 'code' ? '.gr-blog-article__content :not(pre) > code' : selector,
+									property: 'background',
+								},
+							})),
+							...[
+								['card meta', "[data-theme='dark'] .gr-blog-article-card__meta"],
+								['card title', "[data-theme='dark'] .gr-blog-article-card__title"],
+								['card subtitle', darkCardSubtitle],
+							].map(([name, selector]) => ({
+								name,
+								foreground: { selector, property: 'color' },
+								background: {
+									selector: "[data-theme='dark'] .gr-blog-article-card",
+									property: 'background',
+								},
+							})),
+							{
+								name: 'card tag',
+								foreground: {
+									selector: "[data-theme='dark'] .gr-blog-article-card__tag",
+									property: 'color',
+								},
+								background: {
+									selector: "[data-theme='dark'] .gr-blog-article-card__tag",
+									property: 'background',
+								},
+							},
+							...[
+								['toc title', darkTocArchiveMeta],
+								['toc link', '.gr-blog-toc__link'],
+								['archive year', darkNewsletterArchive],
+								['archive month', darkTocArchiveMeta],
+								['editor meta', darkTocArchiveMeta],
+							].map(([name, selector]) => ({
+								name,
+								foreground: { selector, property: 'color' },
+								background: pageBackground,
+							})),
+							...[
+								['author name', '.gr-blog-author-card__name'],
+								['author bio', '.gr-blog-author-card__bio'],
+							].map(([name, selector]) => ({
+								name,
+								foreground: { selector, property: 'color' },
+								background: { selector: '.gr-blog-author-card', property: 'background' },
+							})),
+							{
+								name: 'publication',
+								foreground: { selector: '.gr-blog-publication-banner', property: 'color' },
+								background: { selector: '.gr-blog-publication-banner', property: 'background' },
+							},
+							...[
+								['newsletter title', darkNewsletterArchive],
+								['newsletter description', "[data-theme='dark'] .gr-blog-newsletter__description"],
+							].map(([name, selector]) => ({
+								name,
+								foreground: { selector, property: 'color' },
+								background: { selector: '.gr-blog-newsletter', property: 'background' },
+							})),
+							{
+								name: 'tag cloud',
+								foreground: {
+									selector: "[data-theme='dark'] .gr-blog-tag-cloud .gr-blog-tag-cloud__tag",
+									property: 'color',
+								},
+								background: {
+									selector: "[data-theme='dark'] .gr-blog-tag-cloud .gr-blog-tag-cloud__tag",
+									property: 'background',
+								},
+							},
+							{
+								name: 'toolbar button',
+								foreground: { selector: '.gr-blog-editor-toolbar__button', property: 'color' },
+								background: { selector: '.gr-blog-editor-toolbar', property: 'background' },
+							},
+							{
+								name: 'toolbar button hover',
+								foreground: {
+									selector: '.gr-blog-editor-toolbar__button:hover',
+									property: 'color',
+								},
+								background: {
+									selector: '.gr-blog-editor-toolbar__button:hover',
+									property: 'background',
+								},
+							},
+							{
+								name: 'editor preview',
+								foreground: {
+									selector: "[data-theme='dark'] .gr-blog-editor__preview",
+									property: 'color',
+								},
+								background: {
+									selector: "[data-theme='dark'] .gr-blog-editor__preview",
+									property: 'background',
+								},
+							},
+							{
+								name: 'caption gradient',
+								foreground: { selector: '.gr-blog-featured-image__caption', property: 'color' },
+								background: { value: '#4d4d4d' },
+							},
 						];
 
-			for (const [name, foregroundToken, backgroundToken] of cells) {
-				const foreground = resolveValue(`var(${foregroundToken})`, properties);
-				const background = backgroundToken.startsWith('#')
-					? backgroundToken
-					: resolveValue(`var(${backgroundToken})`, properties);
-				expect(contrast(foreground, background), name).toBeGreaterThanOrEqual(4.5);
+			for (const { name, foreground, background } of cells) {
+				const foregroundValue = resolveValue(
+					declarationValue(blogCss, foreground.selector, foreground.property),
+					properties
+				);
+				const backgroundValue = resolveValue(
+					background.value ??
+						declarationValue(blogCss, background.selector as string, background.property as string),
+					properties
+				);
+				expect(contrast(foregroundValue, backgroundValue), name).toBeGreaterThanOrEqual(4.5);
 			}
 		}
 	);

--- a/packages/faces/community/src/theme.css
+++ b/packages/faces/community/src/theme.css
@@ -90,6 +90,19 @@
 	background: var(--gr-color-gray-900);
 }
 
+[data-theme='dark'] .gr-community-header__banner--placeholder {
+	background: linear-gradient(
+		135deg,
+		var(--gr-color-gray-800),
+		var(--gr-color-gray-700),
+		var(--gr-color-gray-800)
+	);
+}
+
+[data-theme='dark'] .gr-community-header__icon {
+	background: var(--gr-color-gray-700);
+}
+
 /* ============================================================================
  * Post Card Layout
  * ============================================================================ */

--- a/packages/faces/community/src/theme.css
+++ b/packages/faces/community/src/theme.css
@@ -23,7 +23,7 @@
 	--gr-community-vote-button-size: 24px;
 	--gr-community-vote-upvote-color: var(--gr-color-success-500);
 	--gr-community-vote-downvote-color: var(--gr-color-error-500);
-	--gr-community-vote-neutral-color: var(--gr-color-neutral-400);
+	--gr-community-vote-neutral-color: var(--gr-color-gray-500);
 	--gr-community-vote-score-font: var(--gr-typography-fontFamily-mono);
 
 	/* Comment threading */
@@ -68,11 +68,26 @@
 
 /* Dark theme overrides */
 [data-theme='dark'] {
-	--gr-community-card-background: var(--gr-color-neutral-900);
-	--gr-community-card-border: var(--gr-color-neutral-700);
+	--gr-community-card-background: var(--gr-color-gray-900);
+	--gr-community-card-border: var(--gr-color-gray-700);
+	--gr-community-vote-neutral-color: var(--gr-color-gray-400);
 	--gr-community-comment-op-highlight: var(--gr-color-primary-900);
 	--gr-community-comment-mod-highlight: var(--gr-color-success-900);
 	--gr-community-removed-background: var(--gr-color-error-900);
+}
+
+[data-theme='dark'] .gr-community-vote__button:hover,
+[data-theme='dark'] .gr-community-flair--post,
+[data-theme='dark'] .gr-community-sort__option:hover,
+[data-theme='dark'] .gr-community-mod-panel__refresh:hover,
+[data-theme='dark'] .gr-community-mod-queue-item__actions button:hover,
+[data-theme='dark'] .gr-community-header__subscribe:hover,
+[data-theme='dark'] .gr-community-wiki__action:hover {
+	background: var(--gr-color-gray-800);
+}
+
+[data-theme='dark'] .gr-community-mod-queue-item__preview {
+	background: var(--gr-color-gray-900);
 }
 
 /* ============================================================================
@@ -195,7 +210,7 @@
 }
 
 .gr-community-vote__button:hover {
-	background: var(--gr-color-neutral-100);
+	background: var(--gr-color-gray-100);
 }
 
 .gr-community-vote__button--upvote.gr-community-vote__button--active {
@@ -345,7 +360,7 @@
 }
 
 .gr-community-flair--post {
-	background: var(--gr-color-neutral-100);
+	background: var(--gr-color-gray-100);
 	color: var(--gr-color-text-primary);
 }
 
@@ -385,7 +400,7 @@
 }
 
 .gr-community-sort__option:hover {
-	background: var(--gr-color-neutral-100);
+	background: var(--gr-color-gray-100);
 	color: var(--gr-color-text-primary);
 }
 
@@ -530,7 +545,7 @@
 }
 
 .gr-community-mod-panel__refresh:hover {
-	background: var(--gr-color-neutral-100);
+	background: var(--gr-color-gray-100);
 }
 
 .gr-community-mod-panel__refresh:disabled {
@@ -594,7 +609,7 @@
 	margin-top: var(--gr-spacing-scale-2);
 	padding: var(--gr-spacing-scale-2);
 	border-radius: var(--gr-radii-md);
-	background: var(--gr-color-neutral-50);
+	background: var(--gr-color-gray-50);
 	border: 1px solid var(--gr-color-border-secondary);
 }
 
@@ -616,7 +631,7 @@
 }
 
 .gr-community-mod-queue-item__actions button:hover {
-	background: var(--gr-color-neutral-100);
+	background: var(--gr-color-gray-100);
 }
 
 .gr-community-mod-log {
@@ -674,9 +689,9 @@
 .gr-community-header__banner--placeholder {
 	background: linear-gradient(
 		135deg,
-		var(--gr-color-neutral-100),
-		var(--gr-color-neutral-200),
-		var(--gr-color-neutral-100)
+		var(--gr-color-gray-100),
+		var(--gr-color-gray-200),
+		var(--gr-color-gray-100)
 	);
 }
 
@@ -697,7 +712,7 @@
 	border-radius: var(--gr-radii-full);
 	border: 4px solid var(--gr-community-card-background);
 	margin-top: -40px;
-	background: var(--gr-color-neutral-200);
+	background: var(--gr-color-gray-200);
 }
 
 .gr-community-header__details {
@@ -745,7 +760,7 @@
 }
 
 .gr-community-header__subscribe:hover {
-	background: var(--gr-color-neutral-100);
+	background: var(--gr-color-gray-100);
 }
 
 /* ============================================================================
@@ -807,7 +822,7 @@
 }
 
 .gr-community-wiki__action:hover {
-	background: var(--gr-color-neutral-100);
+	background: var(--gr-color-gray-100);
 }
 
 .gr-community-wiki__action:disabled {

--- a/packages/faces/community/tests/a11y/contrast.test.ts
+++ b/packages/faces/community/tests/a11y/contrast.test.ts
@@ -5,17 +5,79 @@ import path from 'node:path';
 import { Flair } from '../../src/components/Flair/index.js';
 import { Voting } from '../../src/components/Voting/index.js';
 
+const communityCss = fs.readFileSync(path.resolve(process.cwd(), 'src/theme.css'), 'utf8');
 const tokenCss = fs.readFileSync(
 	path.resolve(process.cwd(), '../../tokens/dist/theme.css'),
 	'utf8'
 );
 
-function tokenColor(name: string): string {
-	const match = tokenCss.match(
-		new RegExp(`${name.replaceAll('-', '\\-')}\\s*:\\s*(#[\\da-f]{6})`, 'i')
+function declarations(css: string, selector: string): string {
+	let offset = 0;
+	const blocks: string[] = [];
+	while (offset < css.length) {
+		const open = css.indexOf('{', offset);
+		if (open < 0) break;
+		const start = Math.max(css.lastIndexOf('}', open - 1), css.lastIndexOf('{', open - 1)) + 1;
+		const candidate = css
+			.slice(start, open)
+			.replace(/\/\*[\s\S]*?\*\//g, '')
+			.trim();
+		const close = css.indexOf('}', open);
+		if (candidate === selector && close >= 0) blocks.push(css.slice(open + 1, close));
+		offset = open + 1;
+	}
+	if (blocks.length > 0) return blocks.join('\n');
+	throw new Error(`Missing CSS block for ${selector}`);
+}
+
+function readCustomProperties(block: string): Map<string, string> {
+	return new Map(
+		Array.from(block.matchAll(/(--[\w-]+)\s*:\s*([^;]+);/g), (match) => [
+			match[1] as string,
+			match[2]?.trim() as string,
+		])
 	);
-	if (!match?.[1]) throw new Error(`Missing emitted token: ${name}`);
-	return match[1];
+}
+
+function resolveValue(
+	value: string,
+	properties: Map<string, string>,
+	seen = new Set<string>()
+): string {
+	const trimmed = value.trim();
+	if (/^#[\da-f]{6}$/i.test(trimmed)) return trimmed.toLowerCase();
+
+	const variable = trimmed.match(/^var\(\s*(--[\w-]+)\s*(?:,\s*(.+))?\)$/s);
+	if (!variable?.[1]) throw new Error(`Unresolved CSS value: ${value}`);
+
+	const name = variable[1];
+	if (seen.has(name)) throw new Error(`Circular CSS variable: ${name}`);
+
+	const nextSeen = new Set(seen).add(name);
+	const declared = properties.get(name);
+	if (declared) return resolveValue(declared, properties, nextSeen);
+	if (variable[2]) return resolveValue(variable[2], properties, nextSeen);
+	throw new Error(`Missing emitted token: ${name}`);
+}
+
+function themeProperties(theme: 'light' | 'dark'): Map<string, string> {
+	const properties = new Map([
+		...readCustomProperties(declarations(tokenCss, ':root')),
+		...readCustomProperties(declarations(communityCss, ':root')),
+	]);
+	for (const [name, value] of readCustomProperties(
+		declarations(tokenCss, `[data-theme="${theme}"]`)
+	)) {
+		properties.set(name, value);
+	}
+	if (theme === 'dark') {
+		for (const [name, value] of readCustomProperties(
+			declarations(communityCss, "[data-theme='dark']")
+		)) {
+			properties.set(name, value);
+		}
+	}
+	return properties;
 }
 
 function luminance(hex: string): number {
@@ -40,16 +102,32 @@ function contrast(foreground: string, background: string): number {
 }
 
 describe('A11y: Contrast & Visuals', () => {
-	it.each([
-		['light neutral vote icon', '--gr-color-gray-500', '--gr-color-base-white', 3],
-		['dark neutral vote icon', '--gr-color-gray-400', '--gr-color-gray-900', 3],
-		['light neutral surface text', '--gr-color-gray-900', '--gr-color-gray-100', 4.5],
-		['dark neutral surface text', '--gr-color-gray-50', '--gr-color-gray-800', 4.5],
-		['dark moderation preview text', '--gr-color-gray-50', '--gr-color-gray-900', 4.5],
-	] as const)('holds %s contrast', (_name, foregroundToken, backgroundToken, floor) => {
-		expect(
-			contrast(tokenColor(foregroundToken), tokenColor(backgroundToken))
-		).toBeGreaterThanOrEqual(floor);
+	it.each(['light', 'dark'] as const)(
+		'holds neutral vote icon contrast from the %s face declaration',
+		(theme) => {
+			const properties = themeProperties(theme);
+			const foreground = resolveValue('var(--gr-community-vote-neutral-color)', properties);
+			const background = resolveValue(
+				theme === 'light'
+					? 'var(--gr-semantic-background-primary)'
+					: 'var(--gr-community-card-background)',
+				properties
+			);
+
+			expect(contrast(foreground, background)).toBeGreaterThanOrEqual(3);
+		}
+	);
+
+	it('keeps header placeholders on dark emitted surfaces', () => {
+		const banner = declarations(
+			communityCss,
+			"[data-theme='dark'] .gr-community-header__banner--placeholder"
+		);
+		const icon = declarations(communityCss, "[data-theme='dark'] .gr-community-header__icon");
+
+		expect(banner).toContain('var(--gr-color-gray-800)');
+		expect(banner).toContain('var(--gr-color-gray-700)');
+		expect(icon).toContain('background: var(--gr-color-gray-700)');
 	});
 
 	describe('Flair Badge', () => {

--- a/packages/faces/community/tests/a11y/contrast.test.ts
+++ b/packages/faces/community/tests/a11y/contrast.test.ts
@@ -1,9 +1,57 @@
 import { render } from '@testing-library/svelte';
 import { describe, it, expect } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
 import { Flair } from '../../src/components/Flair/index.js';
 import { Voting } from '../../src/components/Voting/index.js';
 
+const tokenCss = fs.readFileSync(
+	path.resolve(process.cwd(), '../../tokens/dist/theme.css'),
+	'utf8'
+);
+
+function tokenColor(name: string): string {
+	const match = tokenCss.match(
+		new RegExp(`${name.replaceAll('-', '\\-')}\\s*:\\s*(#[\\da-f]{6})`, 'i')
+	);
+	if (!match?.[1]) throw new Error(`Missing emitted token: ${name}`);
+	return match[1];
+}
+
+function luminance(hex: string): number {
+	const channels = hex
+		.slice(1)
+		.match(/.{2}/g)
+		?.map((value) => Number.parseInt(value, 16) / 255);
+	if (!channels || channels.length !== 3) throw new Error(`Invalid color: ${hex}`);
+	const [red, green, blue] = channels.map((value) =>
+		value <= 0.04045 ? value / 12.92 : ((value + 0.055) / 1.055) ** 2.4
+	);
+	if (red === undefined || green === undefined || blue === undefined) {
+		throw new Error(`Invalid color: ${hex}`);
+	}
+	return red * 0.2126 + green * 0.7152 + blue * 0.0722;
+}
+
+function contrast(foreground: string, background: string): number {
+	const [lighter, darker] = [luminance(foreground), luminance(background)].sort((a, b) => b - a);
+	if (lighter === undefined || darker === undefined) throw new Error('Missing luminance');
+	return (lighter + 0.05) / (darker + 0.05);
+}
+
 describe('A11y: Contrast & Visuals', () => {
+	it.each([
+		['light neutral vote icon', '--gr-color-gray-500', '--gr-color-base-white', 3],
+		['dark neutral vote icon', '--gr-color-gray-400', '--gr-color-gray-900', 3],
+		['light neutral surface text', '--gr-color-gray-900', '--gr-color-gray-100', 4.5],
+		['dark neutral surface text', '--gr-color-gray-50', '--gr-color-gray-800', 4.5],
+		['dark moderation preview text', '--gr-color-gray-50', '--gr-color-gray-900', 4.5],
+	] as const)('holds %s contrast', (_name, foregroundToken, backgroundToken, floor) => {
+		expect(
+			contrast(tokenColor(foregroundToken), tokenColor(backgroundToken))
+		).toBeGreaterThanOrEqual(floor);
+	});
+
 	describe('Flair Badge', () => {
 		it('renders a CSP-safe indicator for user-defined colors', () => {
 			const flair = {

--- a/packages/shared/chat/src/ChatMessages.svelte
+++ b/packages/shared/chat/src/ChatMessages.svelte
@@ -378,18 +378,18 @@
 	}
 
 	.chat-messages::-webkit-scrollbar-thumb {
-		background: var(--gr-color-neutral-300, #d1d5db);
+		background: var(--gr-color-gray-300, #d1d5db);
 		border-radius: var(--gr-radii-full, 9999px);
 	}
 
 	.chat-messages::-webkit-scrollbar-thumb:hover {
-		background: var(--gr-color-neutral-400, #9ca3af);
+		background: var(--gr-color-gray-400, #9ca3af);
 	}
 
 	/* Firefox scrollbar */
 	.chat-messages {
 		scrollbar-width: thin;
-		scrollbar-color: var(--gr-color-neutral-300, #d1d5db)
+		scrollbar-color: var(--gr-color-gray-300, #d1d5db)
 			var(--gr-semantic-background-secondary, #f3f4f6);
 	}
 
@@ -428,7 +428,7 @@
 		width: 2rem;
 		height: 2rem;
 		border-radius: var(--gr-radii-full, 9999px);
-		background: var(--gr-color-neutral-200, #e5e7eb);
+		background: var(--gr-color-gray-200, #e5e7eb);
 		flex-shrink: 0;
 	}
 
@@ -442,7 +442,7 @@
 	.chat-messages__skeleton-line {
 		height: 1rem;
 		border-radius: var(--gr-radii-md, 0.375rem);
-		background: var(--gr-color-neutral-200, #e5e7eb);
+		background: var(--gr-color-gray-200, #e5e7eb);
 	}
 
 	.chat-messages__skeleton-line--short {
@@ -482,7 +482,7 @@
 		width: 4rem;
 		height: 4rem;
 		margin-bottom: var(--gr-spacing-scale-4, 1rem);
-		color: var(--gr-color-neutral-400, #9ca3af);
+		color: var(--gr-color-gray-400, #9ca3af);
 	}
 
 	.chat-messages__empty-icon svg {

--- a/registry/index.json
+++ b/registry/index.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://equalto.ai/schemas/registry-index.schema.json",
   "schemaVersion": "1.0.0",
-  "generatedAt": "2026-08-02T19:10:09.454Z",
+  "generatedAt": "2026-08-02T23:07:31.569Z",
   "ref": "greater-v0.11.9",
   "version": "0.11.9",
   "checksums": {
@@ -1106,7 +1106,7 @@
     "packages/faces/blog/src/index.ts": "sha256-GnJM/z+KouLcZ7pk992s7hwhuI52RC0dLOFlAPo3X1o=",
     "packages/faces/blog/src/patterns/index.ts": "sha256-meoG+gNvG1Os36voxE5lVckTjWYsOZA+Tdff8i7HsDY=",
     "packages/faces/blog/src/share.ts": "sha256-zh34kdwk9EtN/we6XkorjmvX8eXNRaQQBC1YKwVOSCo=",
-    "packages/faces/blog/src/theme.css": "sha256-bOUgmqu39QtNYETX6XKA4Oubhx9b3kt8vYiKLmb59kQ=",
+    "packages/faces/blog/src/theme.css": "sha256-Ozm8V8VwCsCwGz00W8M6U464d7ByEV37YRzL9Q5iSFo=",
     "packages/faces/blog/src/types.ts": "sha256-nfVa2XmlruYKSE432+1kVae4efSDuv9ENZHJHXWfO/4=",
     "packages/faces/community/src/components/Community/context.ts": "sha256-o7hAokh6NA8qRTQSPQx4gZSwM2yKGGWlgI9xWCCQTY8=",
     "packages/faces/community/src/components/Community/Header.svelte": "sha256-Cgg2NDuydM3itR8WioXBTqcdGuRWBeMnvmi/yfg7yCc=",
@@ -1141,7 +1141,7 @@
     "packages/faces/community/src/components/Wiki/Root.svelte": "sha256-AD0jxr5r3cej0cAltug3RyPMvvsUTUu+M3TPzlWIw0M=",
     "packages/faces/community/src/index.ts": "sha256-D/NdPVN+HVexdqKLIPLgwPXti4yYZFgztf/9StwAGkY=",
     "packages/faces/community/src/patterns/index.ts": "sha256-kRP0ROU/+0oDWOAxAu8NXWhR47fPnxjpXQHgKsL6Vhw=",
-    "packages/faces/community/src/theme.css": "sha256-r80CiFwFk/4wJ5n01HKoCImBtUVtvVB7nQvx7m//+68=",
+    "packages/faces/community/src/theme.css": "sha256-NraH13ApTCKfOpCbPBzJbXHIN+AttgdgIyMilxhOBms=",
     "packages/faces/community/src/types.ts": "sha256-wEwXOHVZlULqUqn/FKSLoXzZlJSwTxYExJHQm7+U79I=",
     "packages/faces/artist/src/adapters/artistAdapter.ts": "sha256-LXukzcPVqCu3rH5f4+pw4kZMi54SZ2x3mfrrb0EEQYE=",
     "packages/faces/artist/src/components/ArtistBadge.svelte": "sha256-qG53BPZJRYIWTDXeoeExOf/zQF7t3qjKb/VpQbYx0Nc=",
@@ -1410,7 +1410,7 @@
     "packages/shared/chat/src/ChatInput.svelte": "sha256-lU6LPsynBURd6Mb4hNJ4SiRIQ5EtrFVChV4KbrvWGOo=",
     "packages/shared/chat/src/ChatMessage.svelte": "sha256-PpUf+DIw5R0FvGV4g9b4qHU8hrZQceQ9al/ha3R1y20=",
     "packages/shared/chat/src/ChatMessageAction.svelte": "sha256-pEcRybpKjXTvpfBEUzEK5ZsqQFY7Mequc8wdLyCBHso=",
-    "packages/shared/chat/src/ChatMessages.svelte": "sha256-QB0ljSSirBW556RPlFF3AksCrw21dxW8tjoFq4XYz84=",
+    "packages/shared/chat/src/ChatMessages.svelte": "sha256-M68I+kyLEwfkbYYm2aUzlyCZn8BuR86fA7TNOO0iYLU=",
     "packages/shared/chat/src/ChatSettings.svelte": "sha256-3KK1ivBHd/qrP6ODHkeWCSs7//0cKmMxzfvBipA9PzE=",
     "packages/shared/chat/src/ChatSuggestions.svelte": "sha256-xJJBHn5k57LVPEZMJJw4QY754aK1w3DDSl+u1RC4DMI=",
     "packages/shared/chat/src/ChatThreadView.svelte": "sha256-znXq/fPkCGPHD/HWkIGWK7JFFXC47q3yhqHN1O5YfcY=",
@@ -7354,8 +7354,8 @@
         },
         {
           "path": "src/theme.css",
-          "checksum": "sha256-bOUgmqu39QtNYETX6XKA4Oubhx9b3kt8vYiKLmb59kQ=",
-          "size": 33377
+          "checksum": "sha256-Ozm8V8VwCsCwGz00W8M6U464d7ByEV37YRzL9Q5iSFo=",
+          "size": 32929
         },
         {
           "path": "src/types.ts",
@@ -7642,8 +7642,8 @@
         },
         {
           "path": "src/theme.css",
-          "checksum": "sha256-r80CiFwFk/4wJ5n01HKoCImBtUVtvVB7nQvx7m//+68=",
-          "size": 24498
+          "checksum": "sha256-NraH13ApTCKfOpCbPBzJbXHIN+AttgdgIyMilxhOBms=",
+          "size": 25060
         },
         {
           "path": "src/types.ts",
@@ -9521,8 +9521,8 @@
         },
         {
           "path": "src/ChatMessages.svelte",
-          "checksum": "sha256-QB0ljSSirBW556RPlFF3AksCrw21dxW8tjoFq4XYz84=",
-          "size": 13565
+          "checksum": "sha256-M68I+kyLEwfkbYYm2aUzlyCZn8BuR86fA7TNOO0iYLU=",
+          "size": 13547
         },
         {
           "path": "src/ChatSettings.svelte",

--- a/registry/index.json
+++ b/registry/index.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://equalto.ai/schemas/registry-index.schema.json",
   "schemaVersion": "1.0.0",
-  "generatedAt": "2026-08-02T23:07:31.569Z",
+  "generatedAt": "2026-08-02T23:58:25.765Z",
   "ref": "greater-v0.11.9",
   "version": "0.11.9",
   "checksums": {
@@ -1106,7 +1106,7 @@
     "packages/faces/blog/src/index.ts": "sha256-GnJM/z+KouLcZ7pk992s7hwhuI52RC0dLOFlAPo3X1o=",
     "packages/faces/blog/src/patterns/index.ts": "sha256-meoG+gNvG1Os36voxE5lVckTjWYsOZA+Tdff8i7HsDY=",
     "packages/faces/blog/src/share.ts": "sha256-zh34kdwk9EtN/we6XkorjmvX8eXNRaQQBC1YKwVOSCo=",
-    "packages/faces/blog/src/theme.css": "sha256-Ozm8V8VwCsCwGz00W8M6U464d7ByEV37YRzL9Q5iSFo=",
+    "packages/faces/blog/src/theme.css": "sha256-rMIJJY8KvUAkAXhRIbP7fmSQvFWfUgsse2Gy/gLGllo=",
     "packages/faces/blog/src/types.ts": "sha256-nfVa2XmlruYKSE432+1kVae4efSDuv9ENZHJHXWfO/4=",
     "packages/faces/community/src/components/Community/context.ts": "sha256-o7hAokh6NA8qRTQSPQx4gZSwM2yKGGWlgI9xWCCQTY8=",
     "packages/faces/community/src/components/Community/Header.svelte": "sha256-Cgg2NDuydM3itR8WioXBTqcdGuRWBeMnvmi/yfg7yCc=",
@@ -1141,7 +1141,7 @@
     "packages/faces/community/src/components/Wiki/Root.svelte": "sha256-AD0jxr5r3cej0cAltug3RyPMvvsUTUu+M3TPzlWIw0M=",
     "packages/faces/community/src/index.ts": "sha256-D/NdPVN+HVexdqKLIPLgwPXti4yYZFgztf/9StwAGkY=",
     "packages/faces/community/src/patterns/index.ts": "sha256-kRP0ROU/+0oDWOAxAu8NXWhR47fPnxjpXQHgKsL6Vhw=",
-    "packages/faces/community/src/theme.css": "sha256-NraH13ApTCKfOpCbPBzJbXHIN+AttgdgIyMilxhOBms=",
+    "packages/faces/community/src/theme.css": "sha256-Bv7l1bpwxdZebcGw4Ft7VbIXuUegPiU1kZ58UPU0Es0=",
     "packages/faces/community/src/types.ts": "sha256-wEwXOHVZlULqUqn/FKSLoXzZlJSwTxYExJHQm7+U79I=",
     "packages/faces/artist/src/adapters/artistAdapter.ts": "sha256-LXukzcPVqCu3rH5f4+pw4kZMi54SZ2x3mfrrb0EEQYE=",
     "packages/faces/artist/src/components/ArtistBadge.svelte": "sha256-qG53BPZJRYIWTDXeoeExOf/zQF7t3qjKb/VpQbYx0Nc=",
@@ -1160,9 +1160,9 @@
     "packages/faces/artist/src/components/ArtistProfile/Timeline.svelte": "sha256-pYTXPUJ+ObxLhvbKiAFqwRvXbbSx8nOd6Jiy+OETlME=",
     "packages/faces/artist/src/components/ArtistTimeline/index.ts": "sha256-DKtEBn2hsKq9aQQC3Se3sAH4Qyv9bcq9qftg00h6FZg=",
     "packages/faces/artist/src/components/ArtistTimeline.svelte": "sha256-B/A9t/xM8UdSV5+UaDVkYrU3KAKSH3CsPzhSeMs5HAM=",
-    "packages/faces/artist/src/components/Artwork/Actions.svelte": "sha256-6NHpKElejn6kEoBexel/w0ylSnQh/1fEIaOEW6/eg/8=",
-    "packages/faces/artist/src/components/Artwork/AIDisclosure.svelte": "sha256-EiOQG1Z1mH8tUt9VkO7kwAusrd6+6UMXytlzbZ90+rE=",
-    "packages/faces/artist/src/components/Artwork/Attribution.svelte": "sha256-i0Z0EtdJJuHakz4+QEn20xhbJkxOF8+Yz1dnRvVuO+8=",
+    "packages/faces/artist/src/components/Artwork/Actions.svelte": "sha256-GXBihIIw90V8/1CHiBRmKHbnpg4tWXcPFEHXoG0l9E0=",
+    "packages/faces/artist/src/components/Artwork/AIDisclosure.svelte": "sha256-mKG4lYa/h2wVkzcdN45ERgJqOPvnlNBp1EwRaf0gWtc=",
+    "packages/faces/artist/src/components/Artwork/Attribution.svelte": "sha256-iy9ZVZP3pHxfJFbF9n1OiVxQszetpSlYfRJ6f2xj91s=",
     "packages/faces/artist/src/components/Artwork/context.ts": "sha256-wTQwllHHORte9qG/MNa8phOYDn1yZX0b1ApKyy26Uf8=",
     "packages/faces/artist/src/components/Artwork/Image.svelte": "sha256-16FmETvACjAjLAjV1NY0XDP50bafUmrj1IZ8nK/b63Y=",
     "packages/faces/artist/src/components/Artwork/index.ts": "sha256-Qoc+aLbbdwGiCI/sjnGqayeThQ1Wati1s9CHCQkVOmE=",
@@ -1240,16 +1240,16 @@
     "packages/faces/artist/src/components/MediaViewer/Navigation.svelte": "sha256-d+xVTVNoM896cPJWitkBcvQ6MBrn7KHx/j/jvPlTGEc=",
     "packages/faces/artist/src/components/MediaViewer/Root.svelte": "sha256-xj7dC00b9R6i0IAzTRQXWUFXO5FDGlEs26IKnwy7PPI=",
     "packages/faces/artist/src/components/MediaViewer/ZoomControls.svelte": "sha256-wby9XJ+JRj327wE2bBhEjdn6NWzOjYEQTMgm5RtnYUw=",
-    "packages/faces/artist/src/components/Monetization/DirectPurchase.svelte": "sha256-3BpwuXm3ovquQpFs8kDAdUcL9JxFG8Bndx4pdgGpPMw=",
+    "packages/faces/artist/src/components/Monetization/DirectPurchase.svelte": "sha256-BoIKe2Z8CxaCviFanCTaXEZ54Xuuv/Um4KmSk7TZe/4=",
     "packages/faces/artist/src/components/Monetization/index.ts": "sha256-rMMEbtBMXVx3TTbc2PDVol0M9qPQFSzVvwbBxSCKMPE=",
     "packages/faces/artist/src/components/Monetization/InstitutionalTools.svelte": "sha256-NCTPifwVDooZIZlsymYLmErufgWVbwy/ACiOCovDKJE=",
-    "packages/faces/artist/src/components/Monetization/PremiumBadge.svelte": "sha256-OlD5NK8Cn60BxvjGKFum5K6t0IHMGMwUfHnVFcGap6U=",
-    "packages/faces/artist/src/components/Monetization/ProtectionTools.svelte": "sha256-rysyZIi+oqMl1fi2bNHBXK5RwhlmNU2N9/e4sq7W30E=",
-    "packages/faces/artist/src/components/Monetization/TipJar.svelte": "sha256-bznNJglJA73ucUNwsoGiZVwhrc+Bcl3DjnJJIevAhkI=",
+    "packages/faces/artist/src/components/Monetization/PremiumBadge.svelte": "sha256-5qymZj5uHo1ZKg0lNelFRSgjpSTJMDHTrHLeiXY3QQI=",
+    "packages/faces/artist/src/components/Monetization/ProtectionTools.svelte": "sha256-4973UNFdO7rOKulh7Efjj6OWkoAhqwjU47O3yi26gQk=",
+    "packages/faces/artist/src/components/Monetization/TipJar.svelte": "sha256-YsUF/EWswwFsZ9yXif180YvnT/YCVcqBI2blqtRVDzI=",
     "packages/faces/artist/src/components/PortfolioSection.svelte": "sha256-2gQ8aAOEGOFh5zmos3E3nPHlzIQ684yQspSAW1aYrpg=",
-    "packages/faces/artist/src/components/Transparency/AIDisclosure.svelte": "sha256-XVkIqnZTTR72FHOcaD+sbdHVNz2z1MGOA0YCsaEIi/c=",
+    "packages/faces/artist/src/components/Transparency/AIDisclosure.svelte": "sha256-sVjsl5dRPU1Yaa9+jYjq8A9gShPtocIbxvqOTi3pRHg=",
     "packages/faces/artist/src/components/Transparency/AIOptOutControls.svelte": "sha256-HgTv5l3PeM3z3IlS1+6yGUAepSKljHQiVRIqj1bAat0=",
-    "packages/faces/artist/src/components/Transparency/EthicalSourcingBadge.svelte": "sha256-nsyVlNo4GVsbJcJSqwgaeAYgxZTpgOP3TWPiWK1A3Ok=",
+    "packages/faces/artist/src/components/Transparency/EthicalSourcingBadge.svelte": "sha256-Kwf+BMQ7SvFsIOkE2CKJNlHXPT5DDZAa9Z8PoeJv6lk=",
     "packages/faces/artist/src/components/Transparency/index.ts": "sha256-8ZrN45E4iiVNIYHPwZ7QIe+MbkF5KnPJUwhRt+jmr84=",
     "packages/faces/artist/src/components/Transparency/ProcessDocumentation.svelte": "sha256-wdmeVWpN9Bz4uM0RQmYPcNU9pmB0bCZToXmEnBlrZQE=",
     "packages/faces/artist/src/index.ts": "sha256-/0ZhuioYTEf7cIFGwhXmQVYnxyxbu9dn7IEDgF93/uE=",
@@ -7354,8 +7354,8 @@
         },
         {
           "path": "src/theme.css",
-          "checksum": "sha256-Ozm8V8VwCsCwGz00W8M6U464d7ByEV37YRzL9Q5iSFo=",
-          "size": 32929
+          "checksum": "sha256-rMIJJY8KvUAkAXhRIbP7fmSQvFWfUgsse2Gy/gLGllo=",
+          "size": 33044
         },
         {
           "path": "src/types.ts",
@@ -7642,8 +7642,8 @@
         },
         {
           "path": "src/theme.css",
-          "checksum": "sha256-NraH13ApTCKfOpCbPBzJbXHIN+AttgdgIyMilxhOBms=",
-          "size": 25060
+          "checksum": "sha256-Bv7l1bpwxdZebcGw4Ft7VbIXuUegPiU1kZ58UPU0Es0=",
+          "size": 25345
         },
         {
           "path": "src/types.ts",
@@ -7857,17 +7857,17 @@
         },
         {
           "path": "src/components/Artwork/Actions.svelte",
-          "checksum": "sha256-6NHpKElejn6kEoBexel/w0ylSnQh/1fEIaOEW6/eg/8=",
+          "checksum": "sha256-GXBihIIw90V8/1CHiBRmKHbnpg4tWXcPFEHXoG0l9E0=",
           "size": 6406
         },
         {
           "path": "src/components/Artwork/AIDisclosure.svelte",
-          "checksum": "sha256-EiOQG1Z1mH8tUt9VkO7kwAusrd6+6UMXytlzbZ90+rE=",
+          "checksum": "sha256-mKG4lYa/h2wVkzcdN45ERgJqOPvnlNBp1EwRaf0gWtc=",
           "size": 5726
         },
         {
           "path": "src/components/Artwork/Attribution.svelte",
-          "checksum": "sha256-i0Z0EtdJJuHakz4+QEn20xhbJkxOF8+Yz1dnRvVuO+8=",
+          "checksum": "sha256-iy9ZVZP3pHxfJFbF9n1OiVxQszetpSlYfRJ6f2xj91s=",
           "size": 4869
         },
         {
@@ -8257,7 +8257,7 @@
         },
         {
           "path": "src/components/Monetization/DirectPurchase.svelte",
-          "checksum": "sha256-3BpwuXm3ovquQpFs8kDAdUcL9JxFG8Bndx4pdgGpPMw=",
+          "checksum": "sha256-BoIKe2Z8CxaCviFanCTaXEZ54Xuuv/Um4KmSk7TZe/4=",
           "size": 25916
         },
         {
@@ -8272,17 +8272,17 @@
         },
         {
           "path": "src/components/Monetization/PremiumBadge.svelte",
-          "checksum": "sha256-OlD5NK8Cn60BxvjGKFum5K6t0IHMGMwUfHnVFcGap6U=",
+          "checksum": "sha256-5qymZj5uHo1ZKg0lNelFRSgjpSTJMDHTrHLeiXY3QQI=",
           "size": 8094
         },
         {
           "path": "src/components/Monetization/ProtectionTools.svelte",
-          "checksum": "sha256-rysyZIi+oqMl1fi2bNHBXK5RwhlmNU2N9/e4sq7W30E=",
+          "checksum": "sha256-4973UNFdO7rOKulh7Efjj6OWkoAhqwjU47O3yi26gQk=",
           "size": 24859
         },
         {
           "path": "src/components/Monetization/TipJar.svelte",
-          "checksum": "sha256-bznNJglJA73ucUNwsoGiZVwhrc+Bcl3DjnJJIevAhkI=",
+          "checksum": "sha256-YsUF/EWswwFsZ9yXif180YvnT/YCVcqBI2blqtRVDzI=",
           "size": 19924
         },
         {
@@ -8292,7 +8292,7 @@
         },
         {
           "path": "src/components/Transparency/AIDisclosure.svelte",
-          "checksum": "sha256-XVkIqnZTTR72FHOcaD+sbdHVNz2z1MGOA0YCsaEIi/c=",
+          "checksum": "sha256-sVjsl5dRPU1Yaa9+jYjq8A9gShPtocIbxvqOTi3pRHg=",
           "size": 12403
         },
         {
@@ -8302,7 +8302,7 @@
         },
         {
           "path": "src/components/Transparency/EthicalSourcingBadge.svelte",
-          "checksum": "sha256-nsyVlNo4GVsbJcJSqwgaeAYgxZTpgOP3TWPiWK1A3Ok=",
+          "checksum": "sha256-Kwf+BMQ7SvFsIOkE2CKJNlHXPT5DDZAa9Z8PoeJv6lk=",
           "size": 16074
         },
         {

--- a/scripts/audit-tokens-placeholders.mjs
+++ b/scripts/audit-tokens-placeholders.mjs
@@ -3,7 +3,8 @@
  * Audit Tokens Placeholders Script
  *
  * Fails if token reference placeholders like `{color.base.white}` are found in
- * emitted CSS/SCSS output for the tokens package.
+ * emitted CSS/SCSS output for the tokens package, or if package source treats a
+ * selectable gray palette name as an emitted custom-property family.
  */
 
 import fs from 'node:fs';
@@ -42,9 +43,57 @@ function listFilesRecursive(dir) {
 	return results;
 }
 
+function lineNumberAt(content, offset) {
+	return content.slice(0, offset).split('\n').length;
+}
+
+function auditSelectablePaletteReferences() {
+	const emittedThemePath = path.join(rootDir, 'packages', 'tokens', 'dist', 'theme.css');
+	const palettesPath = path.join(rootDir, 'packages', 'tokens', 'src', 'palettes.json');
+	const packagesDir = path.join(rootDir, 'packages');
+
+	const emittedTheme = fs.readFileSync(emittedThemePath, 'utf8');
+	const emittedProperties = new Set(
+		Array.from(emittedTheme.matchAll(/(--gr-[\w-]+)\s*:/g), (match) => match[1])
+	);
+	const paletteNames = Object.keys(JSON.parse(fs.readFileSync(palettesPath, 'utf8'))).filter(
+		(name) => name !== 'gray'
+	);
+	const paletteReference = new RegExp(
+		`var\\(\\s*(--gr-color-(?:${paletteNames.join('|')})-[\\w-]+)`,
+		'g'
+	);
+	const sourceFiles = listFilesRecursive(packagesDir).filter((file) => {
+		const relative = path.relative(packagesDir, file);
+		if (
+			relative.split(path.sep).some((part) => ['coverage', 'dist', 'node_modules'].includes(part))
+		) {
+			return false;
+		}
+		return file.endsWith('.css') || file.endsWith('.scss') || file.endsWith('.svelte');
+	});
+	const errors = [];
+
+	for (const file of sourceFiles) {
+		const content = fs.readFileSync(file, 'utf8');
+		for (const match of content.matchAll(paletteReference)) {
+			const property = match[1];
+			if (property && !emittedProperties.has(property)) {
+				errors.push({
+					file: path.relative(rootDir, file),
+					line: lineNumberAt(content, match.index ?? 0),
+					property,
+				});
+			}
+		}
+	}
+
+	return { errors, sourceFileCount: sourceFiles.length };
+}
+
 function main() {
 	log('\n' + '='.repeat(60), colors.bold);
-	log('🪙 Audit Tokens Placeholders', colors.bold);
+	log('🪙 Audit Tokens Output & References', colors.bold);
 	log('='.repeat(60) + '\n');
 
 	const distDir = path.join(rootDir, 'packages', 'tokens', 'dist');
@@ -75,17 +124,38 @@ function main() {
 		}
 	}
 
+	const paletteAudit = auditSelectablePaletteReferences();
+
 	log('\n' + '='.repeat(60));
-	if (errors.length > 0) {
-		log(`❌ Tokens placeholders audit FAILED (${errors.length} files)`, colors.red);
-		errors.forEach((error) => {
-			log(`   - ${error.file}`, colors.red);
-			log(`     ${error.matches.join(', ')}`, colors.red);
-		});
+	if (errors.length > 0 || paletteAudit.errors.length > 0) {
+		if (errors.length > 0) {
+			log(`❌ Tokens placeholders audit FAILED (${errors.length} files)`, colors.red);
+			errors.forEach((error) => {
+				log(`   - ${error.file}`, colors.red);
+				log(`     ${error.matches.join(', ')}`, colors.red);
+			});
+		}
+		if (paletteAudit.errors.length > 0) {
+			log(
+				`❌ Token reference existence audit FAILED (${paletteAudit.errors.length} references)`,
+				colors.red
+			);
+			paletteAudit.errors.forEach((error) => {
+				log(`   - ${error.file}:${error.line} ${error.property}`, colors.red);
+			});
+			log(
+				'   Palette names select the values emitted under --gr-color-gray-*; they are not token paths.',
+				colors.yellow
+			);
+		}
 		process.exit(1);
 	}
 
 	log(`✅ Tokens placeholders audit PASSED (${files.length} files checked)`, colors.green);
+	log(
+		`✅ Token reference existence audit PASSED (${paletteAudit.sourceFileCount} source files checked)`,
+		colors.green
+	);
 	process.exit(0);
 }
 

--- a/scripts/audit-tokens-placeholders.mjs
+++ b/scripts/audit-tokens-placeholders.mjs
@@ -3,8 +3,8 @@
  * Audit Tokens Placeholders Script
  *
  * Fails if token reference placeholders like `{color.base.white}` are found in
- * emitted CSS/SCSS output for the tokens package, or if package source treats a
- * selectable gray palette name as an emitted custom-property family.
+ * emitted CSS/SCSS output for the tokens package, or if package source references
+ * a selectable palette token that is absent from the emitted theme sheet.
  */
 
 import fs from 'node:fs';
@@ -47,7 +47,11 @@ function lineNumberAt(content, offset) {
 	return content.slice(0, offset).split('\n').length;
 }
 
-function auditSelectablePaletteReferences() {
+function stripBlockComments(content) {
+	return content.replace(/\/\*[\s\S]*?\*\//g, (comment) => comment.replace(/[^\n]/g, ' '));
+}
+
+function auditTokenReferences() {
 	const emittedThemePath = path.join(rootDir, 'packages', 'tokens', 'dist', 'theme.css');
 	const palettesPath = path.join(rootDir, 'packages', 'tokens', 'src', 'palettes.json');
 	const packagesDir = path.join(rootDir, 'packages');
@@ -56,9 +60,7 @@ function auditSelectablePaletteReferences() {
 	const emittedProperties = new Set(
 		Array.from(emittedTheme.matchAll(/(--gr-[\w-]+)\s*:/g), (match) => match[1])
 	);
-	const paletteNames = Object.keys(JSON.parse(fs.readFileSync(palettesPath, 'utf8'))).filter(
-		(name) => name !== 'gray'
-	);
+	const paletteNames = Object.keys(JSON.parse(fs.readFileSync(palettesPath, 'utf8')));
 	const paletteReference = new RegExp(
 		`var\\(\\s*(--gr-color-(?:${paletteNames.join('|')})-[\\w-]+)`,
 		'g'
@@ -76,7 +78,8 @@ function auditSelectablePaletteReferences() {
 
 	for (const file of sourceFiles) {
 		const content = fs.readFileSync(file, 'utf8');
-		for (const match of content.matchAll(paletteReference)) {
+		const uncommented = stripBlockComments(content);
+		for (const match of uncommented.matchAll(paletteReference)) {
 			const property = match[1];
 			if (property && !emittedProperties.has(property)) {
 				errors.push({
@@ -124,10 +127,10 @@ function main() {
 		}
 	}
 
-	const paletteAudit = auditSelectablePaletteReferences();
+	const tokenReferenceAudit = auditTokenReferences();
 
 	log('\n' + '='.repeat(60));
-	if (errors.length > 0 || paletteAudit.errors.length > 0) {
+	if (errors.length > 0 || tokenReferenceAudit.errors.length > 0) {
 		if (errors.length > 0) {
 			log(`❌ Tokens placeholders audit FAILED (${errors.length} files)`, colors.red);
 			errors.forEach((error) => {
@@ -135,16 +138,16 @@ function main() {
 				log(`     ${error.matches.join(', ')}`, colors.red);
 			});
 		}
-		if (paletteAudit.errors.length > 0) {
+		if (tokenReferenceAudit.errors.length > 0) {
 			log(
-				`❌ Token reference existence audit FAILED (${paletteAudit.errors.length} references)`,
+				`❌ Token reference existence audit FAILED (${tokenReferenceAudit.errors.length} references)`,
 				colors.red
 			);
-			paletteAudit.errors.forEach((error) => {
+			tokenReferenceAudit.errors.forEach((error) => {
 				log(`   - ${error.file}:${error.line} ${error.property}`, colors.red);
 			});
 			log(
-				'   Palette names select the values emitted under --gr-color-gray-*; they are not token paths.',
+				'   Selectable palette references must use properties present in the emitted token sheet.',
 				colors.yellow
 			);
 		}
@@ -153,7 +156,7 @@ function main() {
 
 	log(`✅ Tokens placeholders audit PASSED (${files.length} files checked)`, colors.green);
 	log(
-		`✅ Token reference existence audit PASSED (${paletteAudit.sourceFileCount} source files checked)`,
+		`✅ Token reference existence audit PASSED (${tokenReferenceAudit.sourceFileCount} source files checked)`,
 		colors.green
 	);
 	process.exit(0);


### PR DESCRIPTION
## Summary

- Maps every `--gr-color-neutral-*` reference — a selectable palette name used as a custom-property path, defined **nowhere** in the repo or the emitted token sheet — to the emitted `--gr-color-gray-*` family. Tracked source/test hits: blog 88 (86 theme.css + 2 test expectations), community 15, shared/chat 6. Previously dead declarations now render with their intended values; `grep` sweep of `packages/` goes 545 line hits → 0 (dist regenerated, not hand-edited).
- Non-mechanical decisions, all flagged in the delegate report: `neutral-0` → `base-white` (no `gray-0` exists); community neutral vote split per theme (light `gray-500`, dark `gray-400`) to hold the 3:1 non-text floor; explicit dark-theme overrides for muted text, editor preview, hover surfaces, and moderation preview; a false "neutral alias" comment removed.
- Computed-style probe (Chromium `getComputedStyle`, staging CSS vs HEAD, emitted token sheet): **37 changed light rows, 40 changed dark rows**, each listed with justification in the codex report; unchanged-but-adjacent rows called out (review-workflow rows, chat cells, #955 dark values all stable).
- Contrast re-measured: all blog text cells ≥ **4.5:1** WCAG AA both themes; community UI icons ≥ **3:1** non-text.
- **Recurrence guard:** `pnpm validate:tokens` now runs a token-reference existence audit over 1,247 source files and rejects palette names (`neutral`, `slate`, `stone`, `zinc`) used as token paths; wired through `pnpm validate:package` in the `test.yml` CI path. Injection (`var(--gr-color-neutral-777)`) fails the audit; byte-exact restore + clean pass demonstrated.

## Evidence

- codex delegate report (session `20260802T224921Z-greater-components-3330897`): unfiltered suites — blog 244 passed / 4 skipped (248), community 171/171, chat 232/232, theme file 7/7; `pnpm build`, `lint` (0 errors), `typecheck`, `validate:tokens`, `validate:package`, registry validation (1,453 checksums), governance rubric (28 pass), DCO, GPG all pass. Single commit `8c5bf56b3` appended on staging `72dd3cf9e`.
- Factory pre-push verification: append-only chain confirmed, GPG signature good (key 72D6153132D52023), DCO final paragraph present, Prettier clean on all 7 changed files, `git grep` shows no tracked phantom refs outside guard/tests, `validate-registry-index.js` PASSED, `validate:tokens` PASSED.

## Release impact

**patch** — previously dead theme declarations now render with their intended emitted token values. No adapters, pinned snapshots, public token names, or component APIs changed.

Closes #956